### PR TITLE
Support #19181 Ensure UI is ready for derivedFrom

### DIFF
--- a/packages/common-ui/lib/list-page-layout/ListPageLayout.tsx
+++ b/packages/common-ui/lib/list-page-layout/ListPageLayout.tsx
@@ -6,6 +6,7 @@ import { rsql } from "../filter-builder/rsql";
 import { FilterForm } from "./FilterForm";
 
 interface ListPageLayoutProps<TData extends KitsuResource> {
+  additionalFilters?: FilterParam;
   filterAttributes: string[];
   id: string;
   queryTableProps: QueryTableProps<TData>;
@@ -17,6 +18,7 @@ interface ListPageLayoutProps<TData extends KitsuResource> {
  * The filter form state is hydrated from localstorage, and is saved in localstorage on form submit.
  */
 export function ListPageLayout<TData extends KitsuResource>({
+  additionalFilters,
   filterAttributes,
   id,
   queryTableProps,
@@ -39,9 +41,18 @@ export function ListPageLayout<TData extends KitsuResource>({
     tablePageSizeKey
   );
 
+  const filterBuilderRsql = rsql(filterForm.filterBuilderModel);
+
+  // Combine the inner rsql with the passed additionalFilters?.rsql filter if they are set:
+  const combinedRsql = [
+    ...(filterBuilderRsql ? [filterBuilderRsql] : []),
+    ...(additionalFilters?.rsql ? [additionalFilters?.rsql] : [])
+  ].join(" and ");
+
   // Build the JSONAPI filter param to be sent to the back-end.
   const filterParam: FilterParam = {
-    rsql: rsql(filterForm.filterBuilderModel)
+    ...additionalFilters,
+    rsql: combinedRsql
   };
 
   return (

--- a/packages/common-ui/lib/list-page-layout/__tests__/ListPageLayout.test.tsx
+++ b/packages/common-ui/lib/list-page-layout/__tests__/ListPageLayout.test.tsx
@@ -82,4 +82,27 @@ describe("ListPageLayout component", () => {
     expect(wrapper.find(QueryTable).prop("defaultSort")).toEqual(testSort);
     expect(wrapper.find(QueryTable).prop("defaultPageSize")).toEqual(5);
   });
+
+  it("Allows a passed additionalFilters prop.", async () => {
+    const wrapper = mountWithAppContext(
+      <ListPageLayout
+        id="test-layout"
+        additionalFilters={{
+          attr1: "a",
+          rsql: "attr2==b"
+        }}
+        filterAttributes={["name"]}
+        queryTableProps={{
+          columns: ["name", "type"],
+          path: "pcrPrimer"
+        }}
+      />,
+      { apiContext: mockApiCtx }
+    );
+
+    expect(wrapper.find(QueryTable).prop("filter")).toEqual({
+      attr1: "a",
+      rsql: "attr2==b"
+    });
+  });
 });

--- a/packages/objectstore-ui/pages/object/list.tsx
+++ b/packages/objectstore-ui/pages/object/list.tsx
@@ -123,6 +123,8 @@ export default function MetadataListPage() {
           <div className={`table-section col-${tableSectionWidth}`}>
             <SplitPagePanel>
               <ListPageLayout<Metadata>
+                // Filter out the derived objects e.g. thumbnails:
+                additionalFilters={{ rsql: "acSubTypeId==null" }}
                 filterAttributes={METADATA_FILTER_ATTRIBUTES}
                 id="metadata-list"
                 queryTableProps={{


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/19181

-Added filter to object list page to only return where object subtype id is null.