### PR TITLE
Feedback Support #19348 Improve collapser arrows in Objectstore UI

### DIFF
--- a/packages/common-ui/lib/collapser/__tests__/useCollapser.test.tsx
+++ b/packages/common-ui/lib/collapser/__tests__/useCollapser.test.tsx
@@ -17,22 +17,22 @@ function TestComponent() {
 }
 
 describe("Collapser", () => {
-  it("Renders initially as collapsed.", () => {
+  it("Renders initially as open.", () => {
     const wrapper = mount(<TestComponent />);
-    expect(wrapper.find(".collapsible-content").exists()).toEqual(false);
+    expect(wrapper.find(".collapsible-content").exists()).toEqual(true);
   });
 
   it("Provides a button to change collapsed state.", () => {
     const wrapper = mount(<TestComponent />);
 
-    // Un-collapse the content:
-    wrapper.find("button.collapser-button").simulate("click");
-    wrapper.update();
-    expect(wrapper.find(".collapsible-content").exists()).toEqual(true);
-
     // Collapse the content:
     wrapper.find("button.collapser-button").simulate("click");
     wrapper.update();
     expect(wrapper.find(".collapsible-content").exists()).toEqual(false);
+
+    // Un-collapse the content:
+    wrapper.find("button.collapser-button").simulate("click");
+    wrapper.update();
+    expect(wrapper.find(".collapsible-content").exists()).toEqual(true);
   });
 });

--- a/packages/common-ui/lib/collapser/useCollapser.tsx
+++ b/packages/common-ui/lib/collapser/useCollapser.tsx
@@ -8,7 +8,7 @@ type CollapserState = "COLLAPSED" | "OPEN";
 export function useCollapser(id: string) {
   const STORAGE_KEY = `collapser-${id}-collapsed`;
   const [state, setState] = useLocalStorage<CollapserState>(STORAGE_KEY);
-  const collapsed = state !== "OPEN";
+  const collapsed = state === "COLLAPSED";
 
   function Collapser() {
     return (

--- a/packages/objectstore-ui/components/metadata/MetadataDetails.tsx
+++ b/packages/objectstore-ui/components/metadata/MetadataDetails.tsx
@@ -183,7 +183,7 @@ function MetadataTags({ tags }: MetadataTagsProps) {
               <span
                 key={i}
                 style={{
-                  background: "yellow",
+                  background: "#AEB404",
                   borderRadius: "25px",
                   margin: "0.5rem",
                   padding: "0.5rem"

--- a/packages/objectstore-ui/components/metadata/MetadataDetails.tsx
+++ b/packages/objectstore-ui/components/metadata/MetadataDetails.tsx
@@ -183,7 +183,7 @@ function MetadataTags({ tags }: MetadataTagsProps) {
               <span
                 key={i}
                 style={{
-                  background: "#AEB404",
+                  background: "yellow",
                   borderRadius: "25px",
                   margin: "0.5rem",
                   padding: "0.5rem"

--- a/packages/objectstore-ui/components/metadata/MetadataDetails.tsx
+++ b/packages/objectstore-ui/components/metadata/MetadataDetails.tsx
@@ -93,8 +93,8 @@ function MetadataAttributeGroup({
   return (
     <div className="form-group">
       <h4>
-        {title}
         <Collapser />
+        {title}
       </h4>
       {!collapsed && (
         <ReactTable
@@ -141,8 +141,8 @@ function MetadataManagedAttributes({
   return (
     <div className="form-group">
       <h4>
-        <ObjectStoreMessage id="metadataManagedAttributesLabel" />
         <Collapser />
+        <ObjectStoreMessage id="metadataManagedAttributesLabel" />
       </h4>
       {!collapsed && (
         <ReactTable


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/19348

-Made the collapser open by default.
-Aligned the collapser to the left of the text.