### PR TITLE
Feedback Support #19581 Allow Caddy port to be configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ./ ./
 # dina-ui step:
 RUN yarn --cwd=/dina-ui/packages/dina-ui build
 
-FROM caddy/caddy:2.0.0-rc.3
+FROM caddy/caddy:2.0.0-alpine
 COPY --from=builder /dina-ui/packages/dina-ui/prod.Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /dina-ui/packages/dina-ui/out /www/html
-EXPOSE 80
+EXPOSE 8080

--- a/packages/dina-ui/Dockerfile
+++ b/packages/dina-ui/Dockerfile
@@ -1,4 +1,0 @@
-FROM caddy/caddy:2.0.0-rc.3
-COPY ./prod.Caddyfile /etc/caddy/Caddyfile
-COPY ./out /www/html
-EXPOSE 80

--- a/packages/dina-ui/dev.Caddyfile
+++ b/packages/dina-ui/dev.Caddyfile
@@ -1,4 +1,4 @@
-http://:80
+http://:8080
 
 # Proxy to the front-end:
 reverse_proxy / {$UI_DEV_SERVER_ADDRESS}

--- a/packages/dina-ui/prod.Caddyfile
+++ b/packages/dina-ui/prod.Caddyfile
@@ -1,6 +1,6 @@
 # Configures Caddy (reverse proxy) to serve the app as static files and proxy
 # API urls to the API service.
-http://:80
+http://:8080
 
 # Serve the production app as static HTML files:
 root * /www/html

--- a/packages/seqdb-ui/dev.Caddyfile
+++ b/packages/seqdb-ui/dev.Caddyfile
@@ -1,0 +1,14 @@
+http://:8080
+
+# Proxy to the front-end:
+reverse_proxy / {$UI_DEV_SERVER_ADDRESS}
+reverse_proxy /favicon.ico {$UI_DEV_SERVER_ADDRESS}
+reverse_proxy /_next/* {$UI_DEV_SERVER_ADDRESS}
+reverse_proxy /* {$UI_DEV_SERVER_ADDRESS}
+
+# Proxy to the back-end SeqDB API:
+route /api/* {
+  # For demo purposes, automatically authenticate against the REST API as Admin:Admin
+  request_header Authorization "Basic QWRtaW46QWRtaW4="
+	reverse_proxy {$API_ADDRESS}
+}

--- a/packages/seqdb-ui/prod.Caddyfile
+++ b/packages/seqdb-ui/prod.Caddyfile
@@ -1,6 +1,6 @@
 # Configures Caddy (reverse proxy) to serve the app as static files and proxy
 # API urls to the API service.
-http://:80
+http://:8080
 
 # Serve the production app as static HTML files:
 root * /www/html

--- a/seqdb-ui.Dockerfile
+++ b/seqdb-ui.Dockerfile
@@ -13,7 +13,7 @@ COPY ./ ./
 # seqdb-ui step:
 RUN yarn --cwd=/dina-ui/packages/seqdb-ui build
 
-FROM caddy/caddy:2.0.0-rc.3
+FROM caddy/caddy:2.0.0-alpine
 COPY --from=builder /dina-ui/packages/seqdb-ui/prod.Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /dina-ui/packages/seqdb-ui/out /www/html
-EXPOSE 80
+EXPOSE 8080


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/19581

-Changed Caddy configs port to 8080 so it can run on openshift without the permission error.
-Added missing dev.Caddyfile for seqdb.
-Updated Caddy images to 2.0.0-alpine.