### PR TITLE
Feedback Bug #19689 Managed attribute list page fails when a descript…

### DIFF
--- a/packages/dina-ui/pages/object-store/managedAttributesView/listView.tsx
+++ b/packages/dina-ui/pages/object-store/managedAttributesView/listView.tsx
@@ -17,9 +17,9 @@ const ATTRIBUTES_LIST_COLUMNS: Array<ColumnDefinition<ManagedAttribute>> = [
   "createdDate",
   {
     Cell: ({ original: { description } }) =>
-      (description.en || description.fr) && (
+      (description?.en || description?.fr) && (
         <div>
-          en : {description.en} | fr : {description.fr}
+          en : {description?.en} | fr : {description?.fr}
         </div>
       ),
 


### PR DESCRIPTION
…ion in the list is null

https://redmine.biodiversity.agr.gc.ca/issues/19689

Added optional chaininng operator to description field to avoid typeErrors if description is null.