### PR TITLE
Feedback Support #19671 Add support for Keycloak roles per group

### DIFF
--- a/packages/common-ui/lib/account/__tests__/AccountProvider.test.tsx
+++ b/packages/common-ui/lib/account/__tests__/AccountProvider.test.tsx
@@ -1,0 +1,20 @@
+import { keycloakGroupNamesToBareGroupNames } from "../AccountProvider";
+
+describe("AccountProvider", () => {
+  it("Converts Keycloak's group names to bare group names.", () => {
+    const keycloakGroups = [
+      "/cnc/admin",
+      "/cnc/staff",
+      "/aafc/staff",
+      "/othergroup",
+      "no-leading-slash"
+    ];
+    const bareGroupNames = keycloakGroupNamesToBareGroupNames(keycloakGroups);
+    expect(bareGroupNames).toEqual([
+      "cnc",
+      "aafc",
+      "othergroup",
+      "no-leading-slash"
+    ]);
+  });
+});

--- a/packages/dina-ui/page-tests/object-store/upload.test.tsx
+++ b/packages/dina-ui/page-tests/object-store/upload.test.tsx
@@ -17,7 +17,7 @@ jest.mock("next/router", () => ({
 const MOCK_ACCOUNT_CONTEXT: AccountContextI = {
   agentId: "6ee06232-e801-4cd5-8fc5-127aa14c3ace",
   authenticated: true,
-  groups: ["/group-with-slash", "group-without-slash"],
+  groupNames: ["example-group"],
   initialized: true,
   login: noop,
   logout: noop,
@@ -114,9 +114,9 @@ describe("Upload page", () => {
     );
     await flushPromises(ui, container);
 
-    // The prefixed slash should be removed:
+    // The group name should be in the URL:
     expect(mockPost).lastCalledWith(
-      "/objectstore-api/file/group-with-slash",
+      "/objectstore-api/file/example-group",
       // Form data with the file would go here:
       expect.anything(),
       // Passes in the custom error handler:
@@ -128,7 +128,7 @@ describe("Upload page", () => {
         {
           resource: {
             acMetadataCreator: "6ee06232-e801-4cd5-8fc5-127aa14c3ace",
-            bucket: "group-with-slash",
+            bucket: "example-group",
             fileIdentifier: "c0f78fce-1825-4c4e-89c7-92fe0ed9dc73",
             type: "metadata"
           },
@@ -137,7 +137,7 @@ describe("Upload page", () => {
         {
           resource: {
             acMetadataCreator: "6ee06232-e801-4cd5-8fc5-127aa14c3ace",
-            bucket: "group-with-slash",
+            bucket: "example-group",
             fileIdentifier: "c0f78fce-1825-4c4e-89c7-92fe0ed9dc73",
             type: "metadata"
           },
@@ -146,7 +146,7 @@ describe("Upload page", () => {
         {
           resource: {
             acMetadataCreator: "6ee06232-e801-4cd5-8fc5-127aa14c3ace",
-            bucket: "group-with-slash",
+            bucket: "example-group",
             fileIdentifier: "c0f78fce-1825-4c4e-89c7-92fe0ed9dc73",
             type: "metadata"
           },
@@ -182,7 +182,7 @@ describe("Upload page", () => {
   it("Only renders if the user belongs a group", () => {
     const ui = (
       <MockAppContextProvider
-        accountContext={{ ...MOCK_ACCOUNT_CONTEXT, groups: [] }}
+        accountContext={{ ...MOCK_ACCOUNT_CONTEXT, groupNames: [] }}
       >
         <UploadPage />
       </MockAppContextProvider>

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -35,7 +35,7 @@ export interface MetadataListFormValues {
 
 export default function MetadataListPage() {
   const { formatMessage } = useDinaIntl();
-  const { groups } = useAccount();
+  const { groupNames } = useAccount();
 
   const {
     CheckBoxField,
@@ -97,14 +97,10 @@ export default function MetadataListPage() {
 
   const groupSelectOptions = [
     { label: "<any>", value: undefined },
-    ...(groups ?? []).map(group => {
-      // Remove keycloak's prefixed slash from the start of the group name:
-      const unprefixedGroup = group.replace(/\/(.*)/, "$1");
-      return {
-        label: unprefixedGroup,
-        value: unprefixedGroup
-      };
-    })
+    ...(groupNames ?? []).map(group => ({
+      label: group,
+      value: group
+    }))
   ];
 
   // Workaround to make sure react-table doesn't unmount TBodyComponent

--- a/packages/dina-ui/pages/object-store/upload.tsx
+++ b/packages/dina-ui/pages/object-store/upload.tsx
@@ -60,7 +60,7 @@ export default function UploadPage() {
   const router = useRouter();
   const { formatMessage } = useDinaIntl();
   const { apiClient, save } = useContext(ApiClientContext);
-  const { agentId, groups, initialized: accountInitialized } = useAccount();
+  const { agentId, groupNames, initialized: accountInitialized } = useAccount();
 
   const {
     getRootProps,
@@ -128,21 +128,17 @@ export default function UploadPage() {
     });
   }
 
-  const groupSelectOptions = (groups ?? []).map(group => {
-    // Remove keycloak's prefixed slash from the start of the group name:
-    const unprefixedGroup = group.replace(/\/(.*)/, "$1");
-    return {
-      label: unprefixedGroup,
-      value: unprefixedGroup
-    };
-  });
+  const groupSelectOptions = (groupNames ?? []).map(group => ({
+    label: group,
+    value: group
+  }));
 
   return (
     <div>
       <Head title={formatMessage("uploadPageTitle")} />
       <Nav />
       <div className="container">
-        {!accountInitialized || !groups?.length ? (
+        {!accountInitialized || !groupNames?.length ? (
           <div className="alert alert-warning no-group-alert">
             <DinaMessage id="userMustBelongToGroup" />
           </div>

--- a/packages/dina-ui/test-util/mock-app-context.tsx
+++ b/packages/dina-ui/test-util/mock-app-context.tsx
@@ -58,7 +58,7 @@ export function mountWithAppContext(
 
 const DEFAULT_MOCK_ACCOUNT_CONTEXT: AccountContextI = {
   authenticated: true,
-  groups: ["/aafc", "cnc"],
+  groupNames: ["/aafc", "cnc"],
   initialized: true,
   login: noop,
   logout: noop,


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/19671

-Added conversion from keycloak's group name format to bare group names, with only unique values in the dropdowns.