### PR TITLE
Feedback Support #19812 Align table header text to left

### DIFF
--- a/packages/common-ui/lib/formik-connected/GroupedCheckBoxFields.tsx
+++ b/packages/common-ui/lib/formik-connected/GroupedCheckBoxFields.tsx
@@ -100,7 +100,7 @@ export function useGroupedCheckBoxes<TData extends KitsuResource>({
       .length;
 
     return (
-      <div className="grouped-checkbox-header">
+      <div className="grouped-checkbox-header text-center">
         Select <CheckAllCheckBox />
         <img
           src="/static/images/iconInformation.gif"

--- a/packages/common-ui/lib/table/QueryTable.tsx
+++ b/packages/common-ui/lib/table/QueryTable.tsx
@@ -68,6 +68,11 @@ const queryTableStyle = `
     white-space: unset !important;
   }
 
+  /* Align the header titles to the left to match the cell text alignment. */ 
+  .ReactTable .rt-thead .rt-tr {
+    text-align: left;
+  }
+
   /*
    * Hides the page-jump input's spin button, which on this component would not
    * otherwise trigger a page jump.


### PR DESCRIPTION
https://redmine.biodiversity.agr.gc.ca/issues/19812

-Aligned header text to the left.
-Centered the checkbox header text to match the checkbox cells.