### PR TITLE
Support_19955_Managed_Attributes_view_improvements

### DIFF
--- a/packages/common-ui/lib/formik-connected/DateField.tsx
+++ b/packages/common-ui/lib/formik-connected/DateField.tsx
@@ -32,7 +32,7 @@ export function DateField(props: LabelWrapperParams & DateFieldProps) {
               <DatePicker
                 className="form-control"
                 dateFormat={showTime ? "Pp" : "yyyy-MM-dd"}
-                isClearable={true}
+                isClearable={!disabled}
                 onChange={onChange}
                 selected={
                   value

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -34,7 +34,8 @@ export const DINAUI_MESSAGES_ENGLISH = {
   field_dcRights: "Rights Statement",
   field_dcType: "Stored Object Type",
   field_managedAttributeAcceptedValue: "Accepted Value",
-  field_managedAttributeCreateDate: "Create Date",
+  field_managedAttributeCreatedOn: "Created On",
+  field_managedAttributeCreatedBy: "Created By",
   field_managedAttributeDescEn: "English Description",
   field_managedAttributeDescFr: "French Description",
   field_managedAttributeMandatoryFieldsError:

--- a/packages/dina-ui/pages/object-store/managedAttributesView/detailsView.tsx
+++ b/packages/dina-ui/pages/object-store/managedAttributesView/detailsView.tsx
@@ -10,7 +10,8 @@ import {
   Query,
   SelectField,
   SubmitButton,
-  TextField
+  TextField,
+  DateField
 } from "common-ui";
 import { Field, FieldProps, Form, Formik, FormikContextType } from "formik";
 import { WithRouterProps } from "next/dist/client/with-router";
@@ -151,13 +152,13 @@ function ManagedAttributeForm({ profile, router }: ManagedAttributeFormProps) {
           </h4>
           <TextField name="name" hideLabel={true} />
         </div>
-        <div style={{ width: "300px" }}>
+        <div style={{ width: "70%" }}>
           <h4>
             <DinaMessage id="field_managedAttributeDescEn" />
           </h4>
           <TextField name="description.en" hideLabel={true} />
         </div>
-        <div style={{ width: "300px" }}>
+        <div style={{ width: "70%" }}>
           <h4>
             <DinaMessage id="field_managedAttributeDescFr" />
           </h4>
@@ -184,6 +185,27 @@ function ManagedAttributeForm({ profile, router }: ManagedAttributeFormProps) {
               initialValues={profile ? profile.acceptedValues : undefined}
               hideLabel={true}
             />
+          </div>
+        )}
+        {id && (
+          <div style={{ width: "300px" }}>
+            <h4>
+              <DinaMessage id="field_managedAttributeCreatedOn" />
+            </h4>
+            <DateField
+              showTime={true}
+              name="createdOn"
+              disabled={true}
+              hideLabel={true}
+            />
+          </div>
+        )}
+        {id && (
+          <div style={{ width: "300px" }}>
+            <h4>
+              <DinaMessage id="field_managedAttributeCreatedBy" />
+            </h4>
+            <TextField name="createdBy" hideLabel={true} readOnly={true} />
           </div>
         )}
       </Form>

--- a/packages/dina-ui/pages/object-store/managedAttributesView/listView.tsx
+++ b/packages/dina-ui/pages/object-store/managedAttributesView/listView.tsx
@@ -14,14 +14,18 @@ const ATTRIBUTES_LIST_COLUMNS: ColumnDefinition<ManagedAttribute>[] = [
     Header: "Name",
     accessor: "name"
   },
-  "createdDate",
+  "createdBy",
   {
     Cell: ({ original: { description } }) =>
-      description?.en || description?.fr ? (
-        <div>
+      description?.en && description?.fr ? (
+        <>
           en : {description?.en} | fr : {description?.fr}
-        </div>
-      ) : null,
+        </>
+      ) : description?.en ? (
+        description.en
+      ) : (
+        description.fr
+      ),
     accessor: "description"
   },
   "managedAttributeType",

--- a/packages/dina-ui/types/objectstore-api/resources/ManagedAttribute.ts
+++ b/packages/dina-ui/types/objectstore-api/resources/ManagedAttribute.ts
@@ -5,7 +5,8 @@ export interface ManagedAttributeAttributes {
   name: string;
   managedAttributeType: string;
   acceptedValues?: string[];
-  createdDate?: string;
+  createdBy?: string;
+  createdOn?: string;
   description?: Map<string, string>;
 }
 export enum ManagedAttributeType {


### PR DESCRIPTION
List view:
- Remove CreatedDate and add CreatedBy
- Description renders only the content if there is only one language
Details view
- Expand description fields
- Display CreatedOn and CreatedBy
- Made date field not clearable in readonly mode.