### PR TITLE
20896

### DIFF
--- a/packages/common-ui/lib/list-page-layout/ListPageLayout.tsx
+++ b/packages/common-ui/lib/list-page-layout/ListPageLayout.tsx
@@ -9,6 +9,7 @@ import { FilterForm } from "./FilterForm";
 
 interface ListPageLayoutProps<TData extends KitsuResource> {
   additionalFilters?: FilterParam | ((filterForm: any) => FilterParam);
+  defaultSort?: SortingRule[];
   filterAttributes?: FilterAttribute[];
   filterFormchildren?: (formik: FormikProps<any>) => React.ReactElement;
   id: string;
@@ -22,6 +23,7 @@ interface ListPageLayoutProps<TData extends KitsuResource> {
  */
 export function ListPageLayout<TData extends KitsuResource>({
   additionalFilters: additionalFiltersProp,
+  defaultSort: defaultSortProp,
   filterAttributes,
   filterFormchildren,
   id,
@@ -38,9 +40,11 @@ export function ListPageLayout<TData extends KitsuResource>({
 
   // Default sort and page-size from the QueryTable. These are only used on the initial
   // QueryTable render, and are saved in localStorage when the table's sort or page-size is changed.
-  const [defaultSort, setDefaultSort] = useLocalStorage<SortingRule[]>(
-    tableSortKey
-  );
+  const [storedDefaultSort, setStoredDefaultSort] = useLocalStorage<
+    SortingRule[]
+  >(tableSortKey);
+  const defaultSort = storedDefaultSort ?? defaultSortProp;
+
   const [defaultPageSize, setDefaultPageSize] = useLocalStorage<number>(
     tablePageSizeKey
   );
@@ -76,10 +80,8 @@ export function ListPageLayout<TData extends KitsuResource>({
           defaultPageSize={defaultPageSize ?? undefined}
           defaultSort={defaultSort ?? undefined}
           filter={filterParam}
-          reactTableProps={{
-            onPageSizeChange: newSize => setDefaultPageSize(newSize),
-            onSortedChange: newSort => setDefaultSort(newSort)
-          }}
+          onPageSizeChange={newSize => setDefaultPageSize(newSize)}
+          onSortedChange={newSort => setStoredDefaultSort(newSort)}
           {...queryTableProps}
         />
       </WrapTable>

--- a/packages/common-ui/lib/table/QueryTable.tsx
+++ b/packages/common-ui/lib/table/QueryTable.tsx
@@ -53,6 +53,10 @@ export interface QueryTableProps<TData extends KitsuResource> {
   /** Query success callback. */
   onSuccess?: (response: KitsuResponse<TData[], MetaWithTotal>) => void;
 
+  onPageSizeChange?: (newSize: number) => void;
+
+  onSortedChange?: (newSort: SortingRule[]) => void;
+
   /**
    * Override internal react-table props.
    * Pass in either the props or a function that provides the props.
@@ -102,6 +106,8 @@ export function QueryTable<TData extends KitsuResource>({
   joinSpecs,
   loading: loadingProp,
   onSuccess,
+  onPageSizeChange,
+  onSortedChange,
   path,
   reactTableProps
 }: QueryTableProps<TData>) {
@@ -242,6 +248,8 @@ export function QueryTable<TData extends KitsuResource>({
         showPaginationTop={true}
         noDataText={<CommonMessage id="noRowsFound" />}
         ofText={<CommonMessage id="of" />}
+        onPageSizeChange={onPageSizeChange}
+        onSortedChange={onSortedChange}
         rowsText={formatMessage({ id: "rows" })}
         previousText={<CommonMessage id="previous" />}
         nextText={<CommonMessage id="next" />}

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -174,6 +174,12 @@ export default function MetadataListPage() {
                   ...(filterForm.group && { bucket: filterForm.group }),
                   rsql: "acSubTypeId==null"
                 })}
+                defaultSort={[
+                  {
+                    desc: true,
+                    id: "xmpMetadataDate"
+                  }
+                ]}
                 filterAttributes={METADATA_FILTER_ATTRIBUTES}
                 filterFormchildren={({ submitForm }) => (
                   <div className="form-group">


### PR DESCRIPTION
-Fixed ListPageLayout and QueryTable so defaultSort can be set and local storage can be used.
-Set the defaultSort in the Object list page.