### PR TITLE
Support 21228 ISB EIS WCAG2 1.1.1 Non-text content(Level A)

### DIFF
--- a/packages/common-ui/lib/formik-connected/GroupedCheckBoxFields.tsx
+++ b/packages/common-ui/lib/formik-connected/GroupedCheckBoxFields.tsx
@@ -101,7 +101,7 @@ export function useGroupedCheckBoxes<TData extends KitsuResource>({
       <div className="grouped-checkbox-header text-center">
         <CommonMessage id="select" /> <CheckAllCheckBox />
         <Tooltip id="checkAllTooltipMessage" />
-        <div>
+        <div aria-describedby="checkAllTooltipMessage">
           ({totalChecked} <CommonMessage id="selected" />)
         </div>
       </div>

--- a/packages/common-ui/lib/table/QueryTable.tsx
+++ b/packages/common-ui/lib/table/QueryTable.tsx
@@ -204,7 +204,7 @@ export function QueryTable<TData extends KitsuResource>({
         <Tooltip
           id="queryTableMultiSortExplanation"
           visibleElement={
-            <a href="#">
+            <a href="#" aria-describedby="queryTableMultiSortExplanation">
               <CommonMessage id="queryTableMultiSortTooltipTitle" />
             </a>
           }

--- a/packages/common-ui/lib/tooltip/Tooltip.tsx
+++ b/packages/common-ui/lib/tooltip/Tooltip.tsx
@@ -17,6 +17,7 @@ export function Tooltip({ id, visibleElement }: TooltipProps) {
   return (
     <span className="m-2">
       <RcTooltip
+        id={id}
         overlay={
           <div style={{ maxWidth: "15rem" }}>
             <FormattedMessage id={id} />
@@ -25,7 +26,13 @@ export function Tooltip({ id, visibleElement }: TooltipProps) {
         placement="top"
       >
         <span>
-          {visibleElement ?? <img src="/static/images/iconInformation.gif" />}
+          {visibleElement ?? (
+            <img
+              src="/static/images/iconInformation.gif"
+              alt=""
+              aria-describedby={id}
+            />
+          )}
         </span>
       </RcTooltip>
     </span>


### PR DESCRIPTION
-  Add aria-describedby to default and not default trigger elements for screenreader to attach to tooltip
-  Add alt="" to default trigger element image