### PR TITLE
Feedback Support 21256

### DIFF
--- a/packages/common-ui/lib/bulk-data-editor/BulkDataEditor.tsx
+++ b/packages/common-ui/lib/bulk-data-editor/BulkDataEditor.tsx
@@ -12,6 +12,7 @@ import { LoadingSpinner } from "../loading-spinner/LoadingSpinner";
 import { difference, RecursivePartial } from "./difference";
 import { getUserFriendlyAutoCompleteRenderer } from "./resource-select-cell";
 import { useBulkEditorFrontEndValidation } from "./useBulkEditorFrontEndValidation";
+import { useHeaderWidthFix } from "./useHeaderWidthFix";
 
 export interface RowChange<TRow> {
   original: TRow;
@@ -50,6 +51,8 @@ export function BulkDataEditor<TRow>({
     afterValidate,
     validationAlertJsx
   } = useBulkEditorFrontEndValidation();
+
+  const { tableWrapperRef } = useHeaderWidthFix({ columns });
 
   // Loads the initial data and shows an error message on fail:
   const loadDataInternal = safeSubmit(async () => {
@@ -98,12 +101,12 @@ export function BulkDataEditor<TRow>({
   };
 
   return (
-    <>
+    <div ref={tableWrapperRef}>
       <style>{`
         /* Prevent the handsontable header from covering the Dropdown menu options: */
-        .ht_clone_top {
+        .ht_clone_top, .ht_clone_left, .ht_clone_top_left_corner {
           z-index: 0 !important;
-        }  
+        }
       `}</style>
       <ErrorViewer />
       {validationAlertJsx}
@@ -124,7 +127,7 @@ export function BulkDataEditor<TRow>({
       >
         <CommonMessage id="submitBtnText" />
       </FormikButton>
-    </>
+    </div>
   );
 }
 

--- a/packages/common-ui/lib/bulk-data-editor/useHeaderWidthFix.tsx
+++ b/packages/common-ui/lib/bulk-data-editor/useHeaderWidthFix.tsx
@@ -1,0 +1,37 @@
+import { GridSettings } from "handsontable";
+import { useEffect, useRef } from "react";
+
+interface HeaderWidthFixParams {
+  columns: GridSettings[];
+}
+
+/** Fixes a bug with HandsOnTable where enabling the rowHeaders
+ * (numbered cells on the left side of the grid) cuts off the right side of the
+ * column headers.
+ */
+export function useHeaderWidthFix({ columns }: HeaderWidthFixParams) {
+  const tableWrapperRef = useRef<HTMLDivElement>(null);
+
+  // Whenever the columns change, run some code to manually set the width of the header row:
+  useEffect(() => {
+    setImmediate(() => {
+      const wrapper = tableWrapperRef.current;
+
+      if (wrapper) {
+        const header = wrapper.querySelector<HTMLDivElement>(
+          ".ht_clone_top .wtHider"
+        );
+        const htCore = wrapper.querySelector<HTMLDivElement>(
+          ".ht_master .htCore"
+        );
+
+        if (header && htCore) {
+          const requiredHeaderWidth = `${htCore.clientWidth}px`;
+          header.style.width = requiredHeaderWidth;
+        }
+      }
+    });
+  }, [columns.map(col => col.data).join()]);
+
+  return { tableWrapperRef };
+}


### PR DESCRIPTION
-Added useEffect hook to manually fix the header width on columns change.
-Added css zIndex fix so the row headers don't overlap the dropdown menus.