### PR TITLE
Feedback 21416

### DIFF
--- a/packages/common-ui/lib/filter-builder/__tests__/rsql.test.ts
+++ b/packages/common-ui/lib/filter-builder/__tests__/rsql.test.ts
@@ -1,3 +1,4 @@
+import { KitsuResource } from "kitsu";
 import { FilterGroupModel } from "../FilterGroup";
 import { rsql } from "../rsql";
 
@@ -438,5 +439,31 @@ describe("rsql conversion", () => {
     expect(rsqlFilter).toEqual(
       "myDateField=ge=2020-10-06T00:00:00+00:00;myDateField=le=2020-10-12T23:59:59+00:00"
     );
+  });
+
+  it("Converts a dropdown-type filter with a null ID value.", () => {
+    const model: FilterGroupModel = {
+      children: [
+        {
+          attribute: {
+            name: "acMetadataCreator",
+            type: "DROPDOWN",
+            resourcePath: "agent-api/person"
+          },
+          id: 3,
+          predicate: "IS",
+          searchType: "EXACT_MATCH",
+          type: "FILTER_ROW",
+          // Null ID:
+          value: { id: null } as any
+        }
+      ],
+      id: 4,
+      operator: "AND",
+      type: "FILTER_GROUP"
+    };
+
+    const rsqlFilter = rsql(model);
+    expect(rsqlFilter).toEqual("acMetadataCreator==null");
   });
 });

--- a/packages/common-ui/lib/filter-builder/rsql.ts
+++ b/packages/common-ui/lib/filter-builder/rsql.ts
@@ -169,7 +169,7 @@ function toPredicate(
   ) {
     searchValue =
       attributeConfig.type === "DROPDOWN"
-        ? (value as KitsuResource).id
+        ? String((value as KitsuResource).id)
         : (value as string);
 
     if (searchType === "PARTIAL_MATCH") {

--- a/packages/common-ui/lib/list-page-layout/ListPageLayout.tsx
+++ b/packages/common-ui/lib/list-page-layout/ListPageLayout.tsx
@@ -36,7 +36,7 @@ export function ListPageLayout<TData extends KitsuResource>({
 
   // Use a localStorage hook to get the filter form state,
   // and re-render when the watched localStorage key is changed.
-  const [filterForm] = useLocalStorage<any>(filterformKey, {});
+  const [filterForm, setFilterForm] = useLocalStorage<any>(filterformKey, {});
 
   // Default sort and page-size from the QueryTable. These are only used on the initial
   // QueryTable render, and are saved in localStorage when the table's sort or page-size is changed.
@@ -49,7 +49,15 @@ export function ListPageLayout<TData extends KitsuResource>({
     tablePageSizeKey
   );
 
-  const filterBuilderRsql = rsql(filterForm.filterBuilderModel);
+  let filterBuilderRsql = "";
+  try {
+    filterBuilderRsql = rsql(filterForm.filterBuilderModel);
+  } catch (error) {
+    // If there is an error, ignore the filter form rsql instead of crashing the page.
+    // tslint:disable-next-line
+    console.error(error);
+    setImmediate(() => setFilterForm({}));
+  }
 
   const additionalFilters =
     typeof additionalFiltersProp === "function"


### PR DESCRIPTION
-Converted the resource ID to string so 'null' is searched correctly.
-Updated ListPageLayout so an rsql conversion error can't crash the page, you will get an error logged instead and the FilterBuilder is ignored.