### PR TITLE
Feedback 21627

### DIFF
--- a/packages/common-ui/lib/formik-connected/SelectField.tsx
+++ b/packages/common-ui/lib/formik-connected/SelectField.tsx
@@ -18,7 +18,6 @@ export interface SelectFieldProps<T = string> extends LabelWrapperParams {
   onChange?: (value?: T | T[] | null) => void;
   options: SelectOption<T>[];
   styles?: Partial<Styles>;
-  defaultValue?: any;
 }
 
 /** Formik-connected select input. */
@@ -29,7 +28,6 @@ export function SelectField<T = string>(props: SelectFieldProps<T>) {
     onChange,
     options,
     styles,
-    defaultValue,
     ...labelWrapperProps
   } = props;
   const { name } = labelWrapperProps;
@@ -38,22 +36,8 @@ export function SelectField<T = string>(props: SelectFieldProps<T>) {
     <FastField name={name}>
       {({
         field: { value },
-        form: { setFieldValue, setFieldTouched, initialValues, touched }
+        form: { setFieldValue, setFieldTouched }
       }: FieldProps) => {
-        // handle when there is no localstorage, storage has null value , first time visit the form
-        // will set the defaultvalue
-        if (
-          !value &&
-          defaultValue &&
-          (!initialValues ||
-            !touched ||
-            ((!initialValues[name] || initialValues[name] === null) &&
-              !touched[name]))
-        ) {
-          setFieldValue(name, defaultValue.value);
-          setFieldTouched(name);
-          onChange?.(defaultValue.value);
-        }
         function onChangeInternal(
           change: SelectOption<T>[] | SelectOption<T> | null
         ) {
@@ -64,11 +48,16 @@ export function SelectField<T = string>(props: SelectFieldProps<T>) {
 
           const newValue = isArray(change)
             ? change.map(option => option.value)
-            : change?.value ?? null;
+            : change?.value;
           setFieldValue(name, newValue);
           setFieldTouched(name);
           onChange?.(newValue);
         }
+
+        const selectedOption = isMulti
+          ? options?.filter(option => value?.includes(option.value))
+          : options.find(option => option.value === value) ?? null;
+
         return (
           <FieldWrapper {...labelWrapperProps}>
             <Select
@@ -77,11 +66,7 @@ export function SelectField<T = string>(props: SelectFieldProps<T>) {
               options={options}
               onChange={onChangeInternal}
               styles={styles}
-              value={
-                (isMulti
-                  ? options?.filter(option => value?.includes(option.value))
-                  : options.find(option => option.value === value)) ?? null
-              }
+              value={selectedOption}
             />
           </FieldWrapper>
         );

--- a/packages/dina-ui/pages/collecting-event/edit.tsx
+++ b/packages/dina-ui/pages/collecting-event/edit.tsx
@@ -103,7 +103,7 @@ function CollectingEventFormInternal() {
     <div>
       <div className="form-group">
         <div style={{ width: "300px" }}>
-          <GroupSelectField name="group" showAnyOption={true} />
+          <GroupSelectField name="group" />
         </div>
       </div>
       <div className="row">

--- a/packages/dina-ui/pages/collecting-event/list.tsx
+++ b/packages/dina-ui/pages/collecting-event/list.tsx
@@ -33,6 +33,10 @@ export default function CollectingEventListPage() {
           <CreateButton entityLink="/collecting-event" />
         </ButtonBar>
         <ListPageLayout
+          additionalFilters={filterForm => ({
+            // Apply group filter:
+            ...(filterForm.group && { rsql: `group==${filterForm.group}` })
+          })}
           filterAttributes={COLLECTING_EVENT_FILTER_ATTRIBUTES}
           id="collecting-event-list"
           queryTableProps={{

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -166,9 +166,10 @@ export default function MetadataListPage() {
           <div className={`table-section col-${tableSectionWidth}`}>
             <SplitPagePanel>
               <ListPageLayout<Metadata>
-                // Filter out the derived objects e.g. thumbnails:
                 additionalFilters={filterForm => ({
+                  // Apply group filter:
                   ...(filterForm.group && { bucket: filterForm.group }),
+                  // Filter out the derived objects e.g. thumbnails:
                   rsql: "acSubTypeId==null"
                 })}
                 defaultSort={[
@@ -186,7 +187,6 @@ export default function MetadataListPage() {
                         name="group"
                         showAnyOption={true}
                         showAllGroups={true}
-                        showDefaultValue={true}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
-Fixed bug that was disabling the groupo selects:
-Removed defaultValue prop from SelectField. It shouldn't be needed now that the current group is always included in the GroupSelect options.
-Added group filter rsql to collecting event list page.
-Removed showAnyOption from collecting event edit page.