### PR TITLE
Support_21822_Display_roles_per_group

### DIFF
--- a/packages/common-ui/lib/key-value-table/KeyValueTable.tsx
+++ b/packages/common-ui/lib/key-value-table/KeyValueTable.tsx
@@ -1,7 +1,7 @@
 import { DefaultTd, FieldHeader } from "common-ui";
 import { toPairs } from "lodash";
 import { ComponentType } from "react";
-import ReactTable, { CellInfo } from "react-table";
+import ReactTable, { CellInfo, TableCellRenderer } from "react-table";
 import { CommonMessage } from "../intl/common-ui-intl";
 
 export interface KeyValueTableProps {
@@ -10,10 +10,25 @@ export interface KeyValueTableProps {
 
   /** The value cell Component for a specific field can be overriden for displaying complex object types. */
   customValueCells?: Record<string, ComponentType<CellInfo>>;
+
+  attributeHeader?: JSX.Element;
+  valueHeader?: JSX.Element;
+
+  attributeCell?: TableCellRenderer;
 }
 
 /** Table that shows an object's keys in the left column and values in the right column. */
-export function KeyValueTable({ customValueCells, data }: KeyValueTableProps) {
+export function KeyValueTable({
+  customValueCells,
+  data,
+  attributeHeader = <CommonMessage id="attributeLabel" />,
+  attributeCell = ({ original: { field } }) => (
+    <strong>
+      <FieldHeader name={field} />
+    </strong>
+  ),
+  valueHeader = <CommonMessage id="valueLabel" />
+}: KeyValueTableProps) {
   const pairs = toPairs(data);
   const entries = pairs.map(([field, value]) => ({
     field,
@@ -26,12 +41,8 @@ export function KeyValueTable({ customValueCells, data }: KeyValueTableProps) {
       columns={[
         // Render the intl name of the field, or by default a title-case field:
         {
-          Cell: ({ original: { field } }) => (
-            <strong>
-              <FieldHeader name={field} />
-            </strong>
-          ),
-          Header: <CommonMessage id="attributeLabel" />,
+          Cell: attributeCell,
+          Header: attributeHeader,
           className: "key-cell",
           accessor: "field",
           width: 200
@@ -45,7 +56,7 @@ export function KeyValueTable({ customValueCells, data }: KeyValueTableProps) {
             }
             return props.value;
           },
-          Header: <CommonMessage id="valueLabel" />,
+          Header: valueHeader,
           accessor: "value",
           className: "value-cell"
         }

--- a/packages/common-ui/lib/table/QueryTable.tsx
+++ b/packages/common-ui/lib/table/QueryTable.tsx
@@ -71,30 +71,6 @@ export interface QueryTableProps<TData extends KitsuResource> {
 
 const DEFAULT_PAGE_SIZE = 25;
 
-const queryTableStyle = `
-  /* Wraps long text instead of shortening it. */
-  .rt-td {
-    white-space: unset !important;
-  }
-
-  /* Align the header titles to the left to match the cell text alignment. */ 
-  .ReactTable .rt-thead .rt-tr {
-    text-align: left;
-  }
-
-  /*
-   * Hides the page-jump input's spin button, which on this component would not
-   * otherwise trigger a page jump.
-   */
-  input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
-  }
-  input[type=number] {
-    -moz-appearance:textfield;
-  }
-`;
-
 /**
  * Table component that fetches data from the backend API.
  */
@@ -207,7 +183,6 @@ export function QueryTable<TData extends KitsuResource>({
 
   return (
     <div className="query-table-wrapper" ref={divWrapperRef}>
-      <style>{queryTableStyle}</style>
       {!omitPaging && (
         <span>
           <CommonMessage id="tableTotalCount" values={{ totalCount }} />

--- a/packages/common-ui/lib/table/react-table-style.css
+++ b/packages/common-ui/lib/table/react-table-style.css
@@ -1,0 +1,22 @@
+/* Wraps long text instead of shortening it. */
+.ReactTable .rt-td {
+  white-space: unset !important;
+}
+
+/* Align the header titles to the left to match the cell text alignment. */
+.ReactTable .rt-thead .rt-tr {
+  text-align: left;
+}
+
+/*
+* Hides the page-jump input's spin button, which on this component would not
+* otherwise trigger a page jump.
+*/
+.ReactTable input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
+}
+
+.ReactTable input[type="number"] {
+  -moz-appearance: textfield;
+}

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -154,6 +154,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   forTestingPurposesOnlyMessage:
     "For testing purpose only. Only unclassified data should be uploaded. Any uploaded data can be deleted at any given moment.",
   governmentOfCanada: "Government of Canada",
+  group: "Group",
   groupMustBeSelected: "Group must be selected",
   managedAttributeEditTitle: "Edit Managed Attribute",
   managedAttributeListTitle: "Managed Attributes",
@@ -200,6 +201,8 @@ export const DINAUI_MESSAGES_ENGLISH = {
   resetMetadataEditorAttributesButtonText: "Reset to initial attributes layout",
   revisionsButtonText: "Revisions",
   revisionsByUserPageTitle: "Revisions by user",
+  roles: "Roles",
+  rolesPerGroup: "Roles Per Group",
   searchButton: "Search",
   selectCollectorGroupLabel:
     "Select a collector group to pre-poplulate 'Collectors' field",

--- a/packages/dina-ui/page-tests/dina-user/__test__/view.test.tsx
+++ b/packages/dina-ui/page-tests/dina-user/__test__/view.test.tsx
@@ -11,7 +11,8 @@ const TEST_DINAUSER: DinaUser = {
   roles: ["/dao/staff", "/cnd/collection-manager"],
   agentId: "e3a18289-4a9d-4ad6-ad06-3c7f1837406e",
   id: "1",
-  type: "user"
+  type: "user",
+  rolesPerGroup: { cnc: ["collection-manager"] }
 };
 
 const TEST_AGENT: Person = {

--- a/packages/dina-ui/pages/_app.tsx
+++ b/packages/dina-ui/pages/_app.tsx
@@ -18,6 +18,7 @@ import { ErrorBoundaryPage } from "../components";
 import "../components/button-bar/nav/app-top.css";
 import "../components/button-bar/nav/nav.css";
 import "../components/button-bar/nav/wet-beow-bootstrap-4.css";
+import "common-ui/lib/table/react-table-style.css";
 import { FileUploadProviderImpl } from "../components/object-store/file-upload/FileUploadProvider";
 import { DinaIntlProvider } from "../intl/dina-ui-intl";
 

--- a/packages/dina-ui/pages/dina-user/view.tsx
+++ b/packages/dina-ui/pages/dina-user/view.tsx
@@ -3,17 +3,32 @@ import {
   CancelButton,
   DinaForm,
   FieldView,
-  LoadingSpinner,
-  Query,
-  useAccount
+  KeyValueTable,
+  useAccount,
+  useQuery,
+  withResponse
 } from "common-ui";
-import { Footer, Head, Nav } from "../../components";
+import { Footer, GroupLabel, Head, Nav } from "../../components";
 import { DinaMessage, useDinaIntl } from "../../intl/dina-ui-intl";
 import { DinaUser } from "../../types/user-api/resources/DinaUser";
 
 export default function DinaUserDetailsPage() {
   const { subject } = useAccount();
   const { formatMessage } = useDinaIntl();
+
+  const userQuery = useQuery<DinaUser>(
+    { path: `user-api/user/${subject}` },
+    {
+      joinSpecs: [
+        {
+          apiBaseUrl: "/agent-api",
+          idField: "agentId",
+          joinField: "agent",
+          path: user => `person/${user.agentId}?include=organizations`
+        }
+      ]
+    }
+  );
 
   return (
     <div>
@@ -22,58 +37,73 @@ export default function DinaUserDetailsPage() {
       <ButtonBar>
         <CancelButton entityLink="/user" navigateTo={`/`} />
       </ButtonBar>
-      <Query<DinaUser>
-        query={{ path: `user-api/user/${subject}` }}
-        options={{
-          joinSpecs: [
-            {
-              apiBaseUrl: "/agent-api",
-              idField: "agentId",
-              joinField: "agent",
-              path: user => `person/${user.agentId}?include=organizations`
-            }
-          ]
-        }}
-      >
-        {({ loading, response }) => {
-          const dinaUser = response && {
-            ...response.data
-          };
-
-          return (
-            <main className="container-fluid">
-              <h1>
-                <DinaMessage id="whoAmITitle" />
-              </h1>
-              <LoadingSpinner loading={loading} />
-              {dinaUser && (
-                <DinaForm<DinaUser> initialValues={dinaUser}>
-                  <div>
-                    <div className="form-group">
-                      <div className="row">
-                        <FieldView className="col-md-2" name="username" />
-                        <FieldView className="col-md-2" name="groups" />
-                        <FieldView className="col-md-2" name="roles" />
-                        <FieldView
-                          className="col-md-2"
-                          label={formatMessage("associatedAgent")}
-                          name="agent.displayName"
-                          link={
-                            dinaUser.agentId
-                              ? `/person/view?id=${dinaUser.agentId}`
-                              : ""
-                          }
-                        />
-                      </div>
-                    </div>
+      {withResponse(userQuery, ({ data: dinaUser }) => (
+        <main className="container-fluid">
+          <h1>
+            <DinaMessage id="whoAmITitle" />
+          </h1>
+          <DinaForm<DinaUser> initialValues={dinaUser}>
+            <div>
+              <div className="form-group">
+                <div className="row">
+                  <FieldView className="col-md-2" name="username" />
+                  <FieldView className="col-md-2" name="groups" />
+                  <FieldView className="col-md-2" name="roles" />
+                  <FieldView
+                    className="col-md-2"
+                    label={formatMessage("associatedAgent")}
+                    name="agent.displayName"
+                    link={
+                      dinaUser.agentId
+                        ? `/person/view?id=${dinaUser.agentId}`
+                        : ""
+                    }
+                  />
+                </div>
+                <div className="row">
+                  <div className="col-4">
+                    <RolesPerGroupTable
+                      rolesPerGroup={dinaUser.rolesPerGroup}
+                    />
                   </div>
-                </DinaForm>
-              )}
-            </main>
-          );
-        }}
-      </Query>
+                </div>
+              </div>
+            </div>
+          </DinaForm>
+        </main>
+      ))}
       <Footer />
+    </div>
+  );
+}
+
+interface RolesPerGroupTableProps {
+  rolesPerGroup: Record<string, string[] | undefined>;
+}
+
+function RolesPerGroupTable({ rolesPerGroup }: RolesPerGroupTableProps) {
+  // Convert the rolesPerGroup to an object with comma-separated strings instead of arrays:
+  const stringRolesPerGroup: Record<string, string> = {};
+  // tslint:disable-next-line
+  for (const key in rolesPerGroup) {
+    stringRolesPerGroup[key] = rolesPerGroup[key]?.join(", ") ?? "";
+  }
+
+  return (
+    <div>
+      <h2>
+        <DinaMessage id="rolesPerGroup" />
+      </h2>
+      <KeyValueTable
+        data={stringRolesPerGroup}
+        attributeCell={({ original: { field } }) => (
+          <strong>
+            <GroupLabel groupName={field} />
+          </strong>
+        )}
+        attributeHeader={<DinaMessage id="group" />}
+        valueHeader={<DinaMessage id="roles" />}
+      />
     </div>
   );
 }

--- a/packages/dina-ui/types/user-api/resources/DinaUser.ts
+++ b/packages/dina-ui/types/user-api/resources/DinaUser.ts
@@ -9,6 +9,7 @@ export interface DinaUserAttributes {
   agentId: string;
   firstName?: string;
   lastName?: string;
+  rolesPerGroup: Record<string, string[] | undefined>;
 }
 
 export type DinaUser = KitsuResource & DinaUserAttributes;


### PR DESCRIPTION
-Made KeyValueTable more customizable.
-Moved QueryTable css to a separate css file so it applies to other ReactTable components.
-Added RolesPerGroupTable to user view page.