### PR TITLE
Feedback 22158

### DIFF
--- a/packages/common-ui/lib/formik-connected/NumberField.tsx
+++ b/packages/common-ui/lib/formik-connected/NumberField.tsx
@@ -1,5 +1,5 @@
 import { FastField, FieldProps } from "formik";
-import { ChangeEventHandler, useRef } from "react";
+import { ChangeEvent, ChangeEventHandler, useRef } from "react";
 import NumberFormat, { NumberFormatValues } from "react-number-format";
 import { FieldWrapper, LabelWrapperParams } from "./FieldWrapper";
 
@@ -58,29 +58,23 @@ export function NumberField(props: NumberFieldProps) {
 function InputWithErrorNotify(inputProps) {
   const inputRef = useRef<HTMLInputElement>();
 
-  function withErrorNotify(onChangeFn: ChangeEventHandler<HTMLInputElement>) {
-    return e => {
-      const inputValue = e.target.value;
-      onChangeFn(e);
-      const actualValue = e.target.value;
+  function onChangeWithErrorNotify(event: ChangeEvent<HTMLInputElement>) {
+    const inputValue = event.target.value;
+    inputProps.onChange?.(event);
+    const actualValue = event.target.value;
 
-      // When the user input is blocked then notify the user with a red outline around the input:
-      const input = inputRef.current;
-      if (inputValue !== actualValue && input) {
-        input.className = input.className + " is-invalid";
-        setTimeout(
-          () => (input.className = input.className.replace(" is-invalid", "")),
-          1000
-        );
-      }
-    };
+    // When the user input is blocked then notify the user with a red outline around the input:
+    const input = inputRef.current;
+    if (inputValue !== actualValue && input) {
+      input.className = input.className + " is-invalid";
+      setTimeout(
+        () => (input.className = input.className.replace(" is-invalid", "")),
+        1000
+      );
+    }
   }
 
   return (
-    <input
-      {...inputProps}
-      ref={inputRef}
-      onChange={withErrorNotify(inputProps.onChange)}
-    />
+    <input {...inputProps} ref={inputRef} onChange={onChangeWithErrorNotify} />
   );
 }

--- a/packages/common-ui/lib/formik-connected/NumberField.tsx
+++ b/packages/common-ui/lib/formik-connected/NumberField.tsx
@@ -1,6 +1,6 @@
 import { FastField, FieldProps } from "formik";
-import NumberFormat from "react-number-format";
-import { NumberFormatValues } from "react-number-format";
+import { ChangeEventHandler, useRef } from "react";
+import NumberFormat, { NumberFormatValues } from "react-number-format";
 import { FieldWrapper, LabelWrapperParams } from "./FieldWrapper";
 
 export interface NumberFieldProps extends LabelWrapperParams {
@@ -35,6 +35,7 @@ export function NumberField(props: NumberFieldProps) {
               className="form-control"
               onValueChange={onValueChange}
               readOnly={readOnly}
+              customInput={InputWithErrorNotify}
               value={
                 typeof value === "number"
                   ? value
@@ -47,5 +48,39 @@ export function NumberField(props: NumberFieldProps) {
         }}
       </FastField>
     </FieldWrapper>
+  );
+}
+
+/**
+ * Wraps the normal input onChange function to show a red outline around the input when
+ * the NumberFormat blocks invalid input.
+ */
+function InputWithErrorNotify(inputProps) {
+  const inputRef = useRef<HTMLInputElement>();
+
+  function withErrorNotify(onChangeFn: ChangeEventHandler<HTMLInputElement>) {
+    return e => {
+      const inputValue = e.target.value;
+      onChangeFn(e);
+      const actualValue = e.target.value;
+
+      // When the user input is blocked then notify the user with a red outline around the input:
+      const input = inputRef.current;
+      if (inputValue !== actualValue && input) {
+        input.className = input.className + " is-invalid";
+        setTimeout(
+          () => (input.className = input.className.replace(" is-invalid", "")),
+          1000
+        );
+      }
+    };
+  }
+
+  return (
+    <input
+      {...inputProps}
+      ref={inputRef}
+      onChange={withErrorNotify(inputProps.onChange)}
+    />
   );
 }

--- a/packages/common-ui/lib/formik-connected/NumberField.tsx
+++ b/packages/common-ui/lib/formik-connected/NumberField.tsx
@@ -1,6 +1,7 @@
 import { FastField, FieldProps } from "formik";
-import { ChangeEvent, ChangeEventHandler, useRef } from "react";
+import { ChangeEvent, useState } from "react";
 import NumberFormat, { NumberFormatValues } from "react-number-format";
+import { CommonMessage } from "../intl/common-ui-intl";
 import { FieldWrapper, LabelWrapperParams } from "./FieldWrapper";
 
 export interface NumberFieldProps extends LabelWrapperParams {
@@ -30,20 +31,25 @@ export function NumberField(props: NumberFieldProps) {
           }
 
           return (
-            <NumberFormat
-              isAllowed={props.isAllowed}
-              className="form-control"
-              onValueChange={onValueChange}
-              readOnly={readOnly}
-              customInput={InputWithErrorNotify}
-              value={
-                typeof value === "number"
-                  ? value
-                  : typeof value === "string"
-                  ? Number(value)
-                  : ""
-              }
-            />
+            <div>
+              <NumberFormat
+                isAllowed={props.isAllowed}
+                className="form-control"
+                onValueChange={onValueChange}
+                readOnly={readOnly}
+                customInput={InputWithErrorNotify}
+                value={
+                  typeof value === "number"
+                    ? value
+                    : typeof value === "string"
+                    ? Number(value)
+                    : ""
+                }
+              />
+              <div className="invalid-feedback">
+                <CommonMessage id="validNumberOnlyError" />
+              </div>
+            </div>
           );
         }}
       </FastField>
@@ -56,7 +62,7 @@ export function NumberField(props: NumberFieldProps) {
  * the NumberFormat blocks invalid input.
  */
 function InputWithErrorNotify(inputProps) {
-  const inputRef = useRef<HTMLInputElement>();
+  const [classNames, setClassNames] = useState("");
 
   function onChangeWithErrorNotify(event: ChangeEvent<HTMLInputElement>) {
     const inputValue = event.target.value;
@@ -64,17 +70,20 @@ function InputWithErrorNotify(inputProps) {
     const actualValue = event.target.value;
 
     // When the user input is blocked then notify the user with a red outline around the input:
-    const input = inputRef.current;
-    if (inputValue !== actualValue && input) {
-      input.className = input.className + " is-invalid";
+    if (inputValue !== actualValue) {
+      setClassNames(current => current + " is-invalid");
       setTimeout(
-        () => (input.className = input.className.replace(" is-invalid", "")),
+        () => setClassNames(current => current.replace(" is-invalid", "")),
         1000
       );
     }
   }
 
   return (
-    <input {...inputProps} ref={inputRef} onChange={onChangeWithErrorNotify} />
+    <input
+      {...inputProps}
+      className={`${inputProps.className ?? ""} ${classNames}`}
+      onChange={onChangeWithErrorNotify}
+    />
   );
 }

--- a/packages/common-ui/lib/intl/common-ui-en.ts
+++ b/packages/common-ui/lib/intl/common-ui-en.ts
@@ -77,7 +77,7 @@ export const COMMON_UI_MESSAGES_ENGLISH = {
   true: "True",
   typeHereToSearch: "Type here to search.",
   uiAppVersion: "UI Application Version: {version}",
-  validNumberOnlyError: "You can only enter a valid number.",
+  validNumberOnlyError: "Invalid entry blocked.",
   valueLabel: "Value",
   valueSourceType: "Value Source Type",
   yes: "Yes"

--- a/packages/common-ui/lib/intl/common-ui-en.ts
+++ b/packages/common-ui/lib/intl/common-ui-en.ts
@@ -77,6 +77,7 @@ export const COMMON_UI_MESSAGES_ENGLISH = {
   true: "True",
   typeHereToSearch: "Type here to search.",
   uiAppVersion: "UI Application Version: {version}",
+  validNumberOnlyError: "You can only enter a valid number.",
   valueLabel: "Value",
   valueSourceType: "Value Source Type",
   yes: "Yes"


### PR DESCRIPTION
-Made the number inputs show a red outline for a second when it blocks the user's invalid input.

react-number-format doesn't have a built in callback for errors so this is a bit of a workaround.