### PR TITLE
Support 22138 thumbnail download endpont

### DIFF
--- a/packages/dina-ui/components/object-store/metadata/MetadataDetails.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataDetails.tsx
@@ -38,16 +38,6 @@ export function MetadataDetails({ metadata }: MetadataDetailsProps) {
             value: <DateView date={metadata.xmpMetadataDate} />
           },
           "acMetadataCreator.displayName",
-          {
-            name: "acDerivedFrom",
-            value: metadata.acDerivedFrom ? (
-              <Link
-                href={`/object-store/object/view?id=${metadata.acDerivedFrom.id}`}
-              >
-                <a>{metadata.acDerivedFrom.originalFilename}</a>
-              </Link>
-            ) : null
-          },
           "acSubType"
         ]}
         title={formatMessage("metadataUploadDetailsLabel")}

--- a/packages/dina-ui/components/object-store/metadata/MetadataPreview.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataPreview.tsx
@@ -41,7 +41,7 @@ export function MetadataPreview({ metadataId }: MetadataPreviewProps) {
 
   const { loading, response } = useQuery<Metadata, ObjectUpload>(
     {
-      include: "acDerivedFrom,managedAttributeMap,acMetadataCreator,dcCreator",
+      include: "managedAttributeMap,acMetadataCreator,dcCreator",
       path: `objectstore-api/metadata/${metadataId}`
     },
     {

--- a/packages/dina-ui/components/object-store/stored-object-gallery/StoredObjectGallery.tsx
+++ b/packages/dina-ui/components/object-store/stored-object-gallery/StoredObjectGallery.tsx
@@ -75,15 +75,18 @@ function GalleryItem({
 }: GalleryItemProps) {
   const { id, acCaption } = metadata;
 
-  const { formatMessage } = useDinaIntl();
-  const { response: thumbnailResponse } = useQuery<Metadata[]>({
-    filter: {
-      "acDerivedFrom.id": id
-    },
-    path: "objectstore-api/metadata"
-  });
+  const fileId =
+    metadata.acSubType === "THUMBNAIL"
+      ? `${metadata.fileIdentifier}.thumbnail`
+      : metadata.fileIdentifier;
 
-  const thumbnail = thumbnailResponse?.data?.[0];
+  const filePath = `/api/objectstore-api/file/${metadata.bucket}/${fileId}`;
+
+  const { formatMessage } = useDinaIntl();
+  // fileExtension should always be available when getting the Metadata from the back-end:
+  const fileType = (metadata.fileExtension as string)
+    .replace(/\./, "")
+    .toLowerCase();
 
   return (
     <div
@@ -93,17 +96,12 @@ function GalleryItem({
         maxWidth: "15rem"
       }}
     >
-      {thumbnail ? (
-        <FileView
-          filePath={`/api/objectstore-api/file/${thumbnail.bucket}/${thumbnail.fileIdentifier}.thumbnail`}
-          fileType="jpg"
-          imgAlt={formatMessage("thumbnailNotAvailableText")}
-        />
-      ) : (
-        <div style={{ height: "7rem" }}>
-          <DinaMessage id="thumbnailNotAvailableText" />
-        </div>
-      )}
+      <FileView
+        filePath={filePath}
+        fileType={fileType}
+        imgAlt={formatMessage("thumbnailNotAvailableText")}
+      />
+
       <Link href={`/object-store/object/view?id=${id}`}>
         <a
           style={{

--- a/packages/dina-ui/components/object-store/stored-object-gallery/StoredObjectGallery.tsx
+++ b/packages/dina-ui/components/object-store/stored-object-gallery/StoredObjectGallery.tsx
@@ -94,7 +94,7 @@ function GalleryItem({
     >
       <FileView
         filePath={filePath}
-        fileType={fileType}
+        fileType="jpg"
         imgAlt={formatMessage("thumbnailNotAvailableText")}
       />
 

--- a/packages/dina-ui/components/object-store/stored-object-gallery/StoredObjectGallery.tsx
+++ b/packages/dina-ui/components/object-store/stored-object-gallery/StoredObjectGallery.tsx
@@ -75,11 +75,7 @@ function GalleryItem({
 }: GalleryItemProps) {
   const { id, acCaption } = metadata;
 
-  const fileId =
-    metadata.acSubType === "THUMBNAIL"
-      ? `${metadata.fileIdentifier}.thumbnail`
-      : metadata.fileIdentifier;
-
+  const fileId = `${metadata.fileIdentifier}/thumbnail`;
   const filePath = `/api/objectstore-api/file/${metadata.bucket}/${fileId}`;
 
   const { formatMessage } = useDinaIntl();

--- a/packages/dina-ui/components/revisions/revision-row-configs/metadata-revision-row-config.tsx
+++ b/packages/dina-ui/components/revisions/revision-row-configs/metadata-revision-row-config.tsx
@@ -16,20 +16,6 @@ export const METADATA_REVISION_ROW_CONFIG: RevisionRowConfig<Metadata> = {
     createdDate: ({ original: { value } }) => <DateView date={value} />,
     xmpMetadataDate: ({ original: { value } }) => <DateView date={value} />,
     acDigitizationDate: ({ original: { value } }) => <DateView date={value} />,
-    // Link to the original metadata:
-    acDerivedFrom: ({ original: { value: instanceId } }) => {
-      return (
-        <ReferenceLink<Metadata>
-          baseApiPath="objectstore-api"
-          instanceId={instanceId}
-          link={({ id, originalFilename }) => (
-            <Link href={`/object-store/object/view?id=${id}`}>
-              <a>{originalFilename}</a>
-            </Link>
-          )}
-        />
-      );
-    },
     // Link to the Metadata creator:
     acMetadataCreator: ({ original: { value: relation } }) => {
       return (

--- a/packages/dina-ui/page-tests/object-store/object/__tests__/view.test.tsx
+++ b/packages/dina-ui/page-tests/object-store/object/__tests__/view.test.tsx
@@ -59,7 +59,7 @@ describe("Single Stored Object details page", () => {
     wrapper.update();
 
     expect(wrapper.find(FileView).find("img").prop("src")).toEqual(
-      "/api/objectstore-api/file/testbucket/cf99c285-0353-4fed-a15d-ac963e0514f3.thumbnail?access_token=test-token"
+      "/api/objectstore-api/file/testbucket/cf99c285-0353-4fed-a15d-ac963e0514f3/thumbnail?access_token=test-token"
     );
   });
 });

--- a/packages/dina-ui/pages/object-store/object/view.tsx
+++ b/packages/dina-ui/pages/object-store/object/view.tsx
@@ -80,7 +80,7 @@ export default function MetadataViewPage() {
 
     const fileId =
       metadata.acSubType === "THUMBNAIL"
-        ? `${metadata.fileIdentifier}.thumbnail`
+        ? `${metadata.fileIdentifier}/thumbnail`
         : metadata.fileIdentifier;
 
     const filePath = `/api/objectstore-api/file/${metadata.bucket}/${fileId}`;

--- a/packages/dina-ui/pages/object-store/object/view.tsx
+++ b/packages/dina-ui/pages/object-store/object/view.tsx
@@ -49,7 +49,7 @@ export default function MetadataViewPage() {
 
   const { loading, response } = useQuery<Metadata, ObjectUpload>(
     {
-      include: "acDerivedFrom,managedAttributeMap,acMetadataCreator,dcCreator",
+      include: "managedAttributeMap,acMetadataCreator,dcCreator",
       path: `objectstore-api/metadata/${id}`
     },
     {

--- a/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
+++ b/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
@@ -38,7 +38,6 @@ export interface MetadataRelationships {
   acMetadataCreator?: Person | KitsuResource | null;
   dcCreator?: Person | KitsuResource | null;
   managedAttributeMap?: ManagedAttributeMap | null;
-  acDerivedFrom?: Metadata | null;
 }
 
 export type Metadata = KitsuResource &


### PR DESCRIPTION
- Update object gallery thumbnail to use the new end point instead of getting the thumbmail response via acDerivedFrom