### PR TITLE
Feedback 22197

### DIFF
--- a/packages/common-ui/lib/key-value-table/KeyValueTable.tsx
+++ b/packages/common-ui/lib/key-value-table/KeyValueTable.tsx
@@ -54,7 +54,9 @@ export function KeyValueTable({
             if (CustomCell) {
               return <CustomCell {...props} />;
             }
-            return props.value;
+            return typeof props.value === "object"
+              ? JSON.stringify(props.value)
+              : props.value;
           },
           Header: valueHeader,
           accessor: "value",

--- a/packages/dina-ui/components/revisions/revision-row-configs/collection-revision-row-configs.ts
+++ b/packages/dina-ui/components/revisions/revision-row-configs/collection-revision-row-configs.ts
@@ -1,7 +1,9 @@
 import { RevisionRowConfigsByType } from "../revision-row-config";
 import { COLLECTING_EVENT_REVISION_ROW_CONFIG } from "./collectingevent-revision-row-config";
+import { GEOREFERENCE_ASSERTION_REVISION_ROW_CONFIG } from "./georeference-assertion-revision-row-config";
 
 /** Custom revision row behavior for Object Store Resources. */
 export const COLLECTION_REVISION_ROW_CONFIG: RevisionRowConfigsByType = {
-  "collecting-event": COLLECTING_EVENT_REVISION_ROW_CONFIG
+  "collecting-event": COLLECTING_EVENT_REVISION_ROW_CONFIG,
+  "georeference-assertion": GEOREFERENCE_ASSERTION_REVISION_ROW_CONFIG
 };

--- a/packages/dina-ui/components/revisions/revision-row-configs/georeference-assertion-revision-row-config.tsx
+++ b/packages/dina-ui/components/revisions/revision-row-configs/georeference-assertion-revision-row-config.tsx
@@ -1,0 +1,56 @@
+import { DateView } from "common-ui";
+import Link from "next/link";
+import { CollectingEvent } from "../../../types/collection-api/resources/CollectingEvent";
+import { GeoReferenceAssertion } from "../../../types/collection-api/resources/GeoReferenceAssertion";
+import { Person } from "../../../types/objectstore-api";
+import { ReferenceLink } from "../ReferenceLink";
+import { RevisionRowConfig } from "../revision-row-config";
+
+export const GEOREFERENCE_ASSERTION_REVISION_ROW_CONFIG: RevisionRowConfig<GeoReferenceAssertion> = {
+  name: ({
+    collectingEvent,
+    dwcDecimalLatitude,
+    dwcDecimalLongitude,
+    literalGeoreferencedBy
+  }) => (
+    <Link
+      href={`/collection/collecting-event/view?id=${
+        (collectingEvent as any)?.cdoId
+      }`}
+    >
+      <a>
+        {literalGeoreferencedBy ||
+          `${dwcDecimalLatitude}, ${dwcDecimalLongitude}`}
+      </a>
+    </Link>
+  ),
+  customValueCells: {
+    createdOn: ({ original: { value } }) => <DateView date={value} />,
+    collectingEvent: ({ original: { value: instanceId } }) => {
+      return (
+        <ReferenceLink<CollectingEvent>
+          baseApiPath="collection-api"
+          instanceId={instanceId}
+          link={({ id }) => (
+            <Link href={`/collection/collecting-event/view?id=${id}`}>
+              <a>{id}</a>
+            </Link>
+          )}
+        />
+      );
+    },
+    georeferencedBy: ({ original: { value: relation } }) =>
+      relation?.map(rel => (
+        <ReferenceLink<Person>
+          key={rel.id}
+          baseApiPath="agent-api"
+          instanceId={{ typeName: "person", cdoId: rel.id }}
+          link={({ id, displayName }) => (
+            <>
+              <Link href={`/person/view?id=${id}`}>{displayName}</Link> <br />
+            </>
+          )}
+        />
+      ))
+  }
+};

--- a/packages/dina-ui/types/collection-api/resources/GeoReferenceAssertion.ts
+++ b/packages/dina-ui/types/collection-api/resources/GeoReferenceAssertion.ts
@@ -1,4 +1,5 @@
 import { KitsuResource } from "kitsu";
+import { CollectingEvent } from "./CollectingEvent";
 
 export interface GeoReferenceAssertionAttributes {
   createdBy?: string;
@@ -14,6 +15,7 @@ export interface GeoReferenceAssertionAttributes {
 }
 
 export interface GeoReferenceAssertionRelationships {
+  collectingEvent?: CollectingEvent;
   georeferencedBy?: KitsuResource[];
 }
 


### PR DESCRIPTION
-Updated KeyValueTable so non-renderable objects are at least rendered as JSON as a fallback instead of throwing an error.
-Added GeoReferenceAssertion customValueCells to render fields on revision records.