### PR TITLE
Feedback 22215

### DIFF
--- a/packages/dina-ui/pages/collection/collecting-event/edit.tsx
+++ b/packages/dina-ui/pages/collection/collecting-event/edit.tsx
@@ -201,9 +201,9 @@ function CollectingEventFormInternal() {
       setFieldValue("dwcStateProvince", null);
       setFieldValue("geographicPlaceName", null);
     } else {
-      setFieldValue("dwcCountry", result?.address?.country);
-      setFieldValue("dwcStateProvince", result?.address?.state);
-      setFieldValue("geographicPlaceName", result?.display_name);
+      setFieldValue("dwcCountry", result?.address?.country || null);
+      setFieldValue("dwcStateProvince", result?.address?.state || null);
+      setFieldValue("geographicPlaceName", result?.display_name || null);
     }
     setSelectedSearchResult(result as any);
   };


### PR DESCRIPTION
Changed the setFieldValue call to default to null instead of undefined when the province field is blank.
Setting a form field to undefined will leave it unchanged from the previous value when submitted to the back-end.