### PR TITLE
Feedback 22245

### DIFF
--- a/packages/dina-ui/components/collection/CollectingEventFormLayout.tsx
+++ b/packages/dina-ui/components/collection/CollectingEventFormLayout.tsx
@@ -294,21 +294,6 @@ export function CollectingEventFormLayout() {
                         {assertions.length
                           ? assertions.map((assertion, index) => (
                               <TabPanel key={assertion.id}>
-                                <div className="form-group">
-                                  {!readOnly && (
-                                    <SetCoordinatesFromVerbatimButton
-                                      sourceLatField="dwcVerbatimLatitude"
-                                      sourceLonField="dwcVerbatimLongitude"
-                                      targetLatField={`geoReferenceAssertions[${index}].dwcDecimalLatitude`}
-                                      targetLonField={`geoReferenceAssertions[${index}].dwcDecimalLongitude`}
-                                      onClick={({ lat, lon }) =>
-                                        setGeoSearchValue(`${lat}, ${lon}`)
-                                      }
-                                    >
-                                      <DinaMessage id="latLongAutoSetterButton" />
-                                    </SetCoordinatesFromVerbatimButton>
-                                  )}
-                                </div>
                                 <GeoReferenceAssertionRow
                                   index={index}
                                   openAddPersonModal={openAddPersonModal}
@@ -390,7 +375,7 @@ export function CollectingEventFormLayout() {
                           </div>
                         </div>
                       </div>
-                    ) : (
+                    ) : !readOnly ? (
                       <GeographySearchBox
                         inputValue={geoSearchValue}
                         onInputChange={setGeoSearchValue}
@@ -448,7 +433,7 @@ export function CollectingEventFormLayout() {
                           </div>
                         }
                       />
-                    )
+                    ) : null
                   }
                 </Field>
               </div>

--- a/packages/dina-ui/components/collection/SetCoordinatesFromVerbatimButton.tsx
+++ b/packages/dina-ui/components/collection/SetCoordinatesFromVerbatimButton.tsx
@@ -1,4 +1,4 @@
-import { FormikButton } from "common-ui";
+import { FormikButton, useDinaFormContext } from "common-ui";
 import Coordinates from "coordinate-parser";
 import { FormikContextType } from "formik";
 import { get } from "lodash";
@@ -28,6 +28,7 @@ export function SetCoordinatesFromVerbatimButton({
   className = "btn btn-info",
   children
 }: SetCoordinatesFromVerbatimButtonProps) {
+  const { readOnly } = useDinaFormContext();
   const [error, setError] = useState<string>("");
 
   function doConversion(values: any, formik: FormikContextType<any>) {
@@ -54,15 +55,18 @@ export function SetCoordinatesFromVerbatimButton({
   }
 
   return (
-    <FormikButton
-      onClick={doConversion}
-      className={className}
-      buttonProps={({ values }) => ({
-        disabled: !get(values, sourceLatField) || !get(values, sourceLonField)
-      })}
-    >
-      {error && <div className="alert alert-danger">{error}</div>}
-      {children}
-    </FormikButton>
+    // Don't render in read-only mode.
+    !readOnly && (
+      <FormikButton
+        onClick={doConversion}
+        className={className}
+        buttonProps={({ values }) => ({
+          disabled: !get(values, sourceLatField) || !get(values, sourceLonField)
+        })}
+      >
+        {error && <div className="alert alert-danger">{error}</div>}
+        {children}
+      </FormikButton>
+    )
   );
 }

--- a/packages/dina-ui/components/collection/SetCoordinatesFromVerbatimButton.tsx
+++ b/packages/dina-ui/components/collection/SetCoordinatesFromVerbatimButton.tsx
@@ -54,19 +54,17 @@ export function SetCoordinatesFromVerbatimButton({
     }
   }
 
-  return (
-    // Don't render in read-only mode.
-    !readOnly && (
-      <FormikButton
-        onClick={doConversion}
-        className={className}
-        buttonProps={({ values }) => ({
-          disabled: !get(values, sourceLatField) || !get(values, sourceLonField)
-        })}
-      >
-        {error && <div className="alert alert-danger">{error}</div>}
-        {children}
-      </FormikButton>
-    )
+  // Don't render in read-only mode.
+  return readOnly ? null : (
+    <FormikButton
+      onClick={doConversion}
+      className={className}
+      buttonProps={({ values }) => ({
+        disabled: !get(values, sourceLatField) || !get(values, sourceLonField)
+      })}
+    >
+      {error && <div className="alert alert-danger">{error}</div>}
+      {children}
+    </FormikButton>
   );
 }


### PR DESCRIPTION
-Made GeographySearchBox not render in readOnly mode.
-Made GeographySearchBoxSetCoordinatesFromVerbatimButton not render in readOnly mode.
-Got rid of the duplicate SetCoordinatesFromVerbatimButton in the Georeferencing section.