### PR TITLE
Support-22408-removed-DMS-buttons-where-it-should-not-be

### DIFF
--- a/packages/dina-ui/components/collection/CollectingEventFormLayout.tsx
+++ b/packages/dina-ui/components/collection/CollectingEventFormLayout.tsx
@@ -255,7 +255,7 @@ export function CollectingEventFormLayout({
           </legend>
           <div className="row">
             <div className="col-md-6">
-              <TextFieldWithCoordButtons name="dwcVerbatimLocality" />
+              <TextField name="dwcVerbatimLocality" />
               <AutoSuggestTextField<CoordinateSystem>
                 name="dwcVerbatimCoordinateSystem"
                 configQuery={() => ({

--- a/packages/dina-ui/components/collection/GeographySearchBox.tsx
+++ b/packages/dina-ui/components/collection/GeographySearchBox.tsx
@@ -123,7 +123,7 @@ export function GeographySearchBox({
           <Tooltip id="geographySearchBoxTooltip" />
         </label>
         <div className="flex-grow-1">
-          <InputWithCoordButtons
+          <input
             className="form-control"
             onChange={e => onInputChange(e.target.value)}
             onFocus={e => e.target.select()}


### PR DESCRIPTION
-Remove DMS buttons from verbatim locality and current place search input