### PR TITLE
Feedback 22420

### DIFF
--- a/packages/dina-ui/components/object-store/attachment-list/AttachmentReadOnlySection.tsx
+++ b/packages/dina-ui/components/object-store/attachment-list/AttachmentReadOnlySection.tsx
@@ -2,8 +2,9 @@ import { DinaMessage } from "../../../intl/dina-ui-intl";
 import { ExistingAttachmentsTable } from "./ExistingAttachmentsTable";
 import { TotalAttachmentsIndicator } from "./TotalAttachmentsIndicator";
 import { useState } from "react";
+import { useQuery } from "common-ui";
 
-export interface AttachmentReadOnlySection {
+export interface AttachmentReadOnlySectionProps {
   attachmentPath: string;
   detachTotalSelected?: boolean;
 }
@@ -11,9 +12,15 @@ export interface AttachmentReadOnlySection {
 export function AttachmentReadOnlySection({
   attachmentPath,
   detachTotalSelected
-}: AttachmentReadOnlySection) {
+}: AttachmentReadOnlySectionProps) {
   // JSX key to reload the child components after editing Metadatas.
   const [lastSave, setLastSave] = useState<number>();
+
+  // Just check if the object-store is up:
+  const { error } = useQuery<[]>(
+    { path: "objectstore-api/metadata" },
+    { deps: [lastSave] }
+  );
 
   return (
     <div key={lastSave}>
@@ -21,11 +28,15 @@ export function AttachmentReadOnlySection({
         <DinaMessage id="attachments" />{" "}
         <TotalAttachmentsIndicator attachmentPath={attachmentPath} />
       </h2>
-      <ExistingAttachmentsTable
-        attachmentPath={attachmentPath}
-        onMetadatasEdited={() => setLastSave(Date.now())}
-        detachTotalSelected={detachTotalSelected}
-      />
+      {error ? (
+        <DinaMessage id="objectStoreDataUnavailable" />
+      ) : (
+        <ExistingAttachmentsTable
+          attachmentPath={attachmentPath}
+          onMetadatasEdited={() => setLastSave(Date.now())}
+          detachTotalSelected={detachTotalSelected}
+        />
+      )}
     </div>
   );
 }

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -245,6 +245,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   noFileToDisplay: "No file to display",
   noResultsFound: "No results found.",
   objectListTitle: "Stored Objects",
+  objectStoreDataUnavailable: "Object Store data unavailable",
   objectStoreDetailsTitle: "Object Store Details",
   objectStoreTitle: "Object Store",
   objectSubtypeListTitle: "Object Subtypes",


### PR DESCRIPTION
-Added fallback message to UI (Collecting Event and Catalogued Object edit and view pages) when the object-store is unavailable.
-Fixed issue with Catalogued Object edit page where Collecting Event attachments weren't showing up; Made the attachments list reinitizlize when the fetched Collecting Event changes.