### PR TITLE
23187

### DIFF
--- a/packages/dina-ui/page-tests/collection/material-sample-type/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/material-sample-type/__tests__/edit.test.tsx
@@ -38,11 +38,9 @@ describe("MaterialSampleTypeForm component", () => {
       <MaterialSampleTypeForm onSaved={mockOnSaved} />,
       { apiContext }
     );
-
     wrapper
       .find(".name-field input")
       .simulate("change", { target: { value: "my-mst" } });
-
     wrapper.update();
 
     wrapper.find("form").simulate("submit");
@@ -55,28 +53,5 @@ describe("MaterialSampleTypeForm component", () => {
       type: "material-sample-type",
       name: "my-mst"
     });
-  });
-
-  it("Edits an existing Material Sample Type", async () => {
-    const wrapper = mountWithAppContext(
-      <MaterialSampleTypeForm
-        fetchedMaterialSampleType={TEST_MST}
-        onSaved={mockOnSaved}
-      />,
-      { apiContext }
-    );
-
-    wrapper
-      .find(".name-field input")
-      .simulate("change", { target: { value: "edited name" } });
-
-    wrapper.update();
-
-    wrapper.find("form").simulate("submit");
-
-    await new Promise(setImmediate);
-    wrapper.update();
-
-    expect(mockOnSaved).lastCalledWith({ ...TEST_MST, name: "edited name" });
   });
 });

--- a/packages/dina-ui/pages/collection/material-sample-type/edit.tsx
+++ b/packages/dina-ui/pages/collection/material-sample-type/edit.tsx
@@ -93,7 +93,11 @@ export function MaterialSampleTypeForm({
   };
 
   return (
-    <DinaForm initialValues={initialValues} onSubmit={onSubmit}>
+    <DinaForm
+      initialValues={initialValues}
+      readOnly={!!fetchedMaterialSampleType?.id}
+      onSubmit={onSubmit}
+    >
       <ButtonBar>
         <BackButton
           entityId={fetchedMaterialSampleType?.id}

--- a/packages/dina-ui/pages/collection/material-sample-type/edit.tsx
+++ b/packages/dina-ui/pages/collection/material-sample-type/edit.tsx
@@ -95,7 +95,7 @@ export function MaterialSampleTypeForm({
   return (
     <DinaForm
       initialValues={initialValues}
-      readOnly={!!fetchedMaterialSampleType?.id}
+      readOnly={fetchedMaterialSampleType?.id ? true : false}
       onSubmit={onSubmit}
     >
       <ButtonBar>

--- a/packages/dina-ui/pages/collection/material-sample-type/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample-type/view.tsx
@@ -3,7 +3,6 @@ import {
   ButtonBar,
   DeleteButton,
   DinaForm,
-  EditButton,
   useQuery,
   withResponse
 } from "common-ui";
@@ -12,6 +11,7 @@ import { withRouter } from "next/router";
 import { Head, Nav } from "../../../components";
 import { useDinaIntl } from "../../../intl/dina-ui-intl";
 import { MaterialSampleType } from "../../../types/collection-api";
+
 import { MaterialSampleTypeFormFields } from "./edit";
 
 export function MaterialSampleTypeDetailsPage({ router }: WithRouterProps) {
@@ -32,11 +32,6 @@ export function MaterialSampleTypeDetailsPage({ router }: WithRouterProps) {
             entityId={id}
             entityLink="/collection/material-sample-type"
             byPassView={true}
-          />
-          <EditButton
-            className="ms-auto"
-            entityId={id}
-            entityLink="collection/material-sample-type"
           />
           <DeleteButton
             className="ms-5"


### PR DESCRIPTION
- Remove view page edit button
- Make edit page readonly when this is existing materail sample type
and editable when add new one.
- Remove the test to verify field editable as it is not applicable anymore