### PR TITLE
23670

### DIFF
--- a/packages/dina-ui/pages/collection/material-sample/workflows/split-config.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/workflows/split-config.tsx
@@ -98,7 +98,7 @@ export function ConfigAction({ router }: WithRouterProps) {
   const onSubmit = async ({ submittedValues: configActionFields }) => {
     const childSampleNames: string[] = [];
     for (let i = 0; i < configActionFields.numOfChildToCreate; i++) {
-      childSampleNames.push(configActionFields?.sampleName?.[i]);
+      childSampleNames.push(configActionFields?.sampleNames?.[i]);
     }
 
     const runConfig: MaterialSampleRunConfig = {
@@ -151,9 +151,10 @@ export function ConfigAction({ router }: WithRouterProps) {
   if (materialSampleQuery.loading) return null;
   const { materialSampleName, dwcCatalogNumber } =
     materialSampleQuery?.response?.data ?? {};
-  Object.assign(computedInitConfigValues, {
-    baseName: materialSampleName ?? dwcCatalogNumber
-  });
+  if (materialSampleName || dwcCatalogNumber)
+    Object.assign(computedInitConfigValues, {
+      baseName: materialSampleName ?? dwcCatalogNumber
+    });
 
   return (
     <div>
@@ -269,7 +270,7 @@ function SplitChildRow({
       <TextField
         className={`col-md-3 sampleName${index}`}
         hideLabel={true}
-        name={`sampleName[${index}]`}
+        name={`sampleNames[${index}]`}
         placeholder={`${baseName || BASE_NAME}${computedSuffix}`}
       />
     </div>
@@ -382,7 +383,7 @@ function SplitConfigFormFields({ generationMode }: SplitConfigFormProps) {
                   generationMode === "BATCH"
                     ? suffix || ""
                     : generationMode === "SERIES"
-                    ? `-${computeSuffix({
+                    ? `${computeSuffix({
                         index,
                         start,
                         suffixType

--- a/packages/dina-ui/pages/collection/material-sample/workflows/split-run.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/workflows/split-run.tsx
@@ -174,7 +174,7 @@ export default function SplitRunAction() {
     const generatedSampleName =
       generationMode === "BATCH"
         ? `${baseName}${suffix}`
-        : `${baseName}-${computedSuffix}`;
+        : `${baseName}${computedSuffix}`;
 
     initialChildSamples.push({
       group: groupNames?.[0],
@@ -286,7 +286,10 @@ export default function SplitRunAction() {
   };
 
   function computeDefaultSampleName(index) {
-    return baseName + "-" + computeSuffix({ index, start, suffixType });
+    return (
+      initialChildSamples[index + 1].materialSampleName ??
+      baseName + computeSuffix({ index, start, suffixType })
+    );
   }
 
   function childSampleInternal(index, form) {


### PR DESCRIPTION
- Remove the dash in split config and run page
- Fix some issue in name inconsistency for SampleNames
- Making sure tab head and material sample name is consistent in split run page
- Override initial config with baseName only when there is material sample name or catalog number, otherwise use stored default if any in split config page