### PR TITLE
23937

### DIFF
--- a/packages/common-ui/lib/formik-connected/ErrorViewer.tsx
+++ b/packages/common-ui/lib/formik-connected/ErrorViewer.tsx
@@ -15,8 +15,10 @@ export const ErrorViewer = connect(function ErrorViewerInternal({
     () => {
       const fieldErrorMsg = toPairs(errors)
         .map(
-          ([field, error]) =>
-            `${getFieldLabel({ name: field }).fieldLabel}: ${error}`
+          ([field, error], index) =>
+            `${index + 1} : ${
+              getFieldLabel({ name: field }).fieldLabel
+            } - ${error}`
         )
         .join("\n");
 
@@ -39,6 +41,7 @@ export const ErrorViewer = connect(function ErrorViewerInternal({
         <div
           className="alert alert-danger"
           style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}
+          role="status"
         >
           {errorMessage}
         </div>

--- a/packages/common-ui/lib/text-field-with-coord-buttons/TextFieldWithCoordButtons.tsx
+++ b/packages/common-ui/lib/text-field-with-coord-buttons/TextFieldWithCoordButtons.tsx
@@ -70,7 +70,7 @@ export function InputWithCoordButtons({
       {["°", "′", "″"].map(symbol => (
         <button
           key={symbol}
-          tabIndex={-1}
+          tabIndex={0}
           className={
             !isExternallyControlled
               ? "btn btn-info coord-button"

--- a/packages/dina-ui/components/collection/CollectingEventFormLayout.tsx
+++ b/packages/dina-ui/components/collection/CollectingEventFormLayout.tsx
@@ -388,13 +388,6 @@ export function CollectingEventFormLayout({
             <Field name="endEventDateTime">
               {({ field: { value: endEventDateTime }, form }) => (
                 <div>
-                  {(rangeEnabled || endEventDateTime) && (
-                    <FormattedTextField
-                      name="endEventDateTime"
-                      label={formatMessage("endEventDateTimeLabel")}
-                      placeholder={"YYYY-MM-DDTHH:MM:SS.MMM"}
-                    />
-                  )}
                   {!readOnly && (
                     <label
                       className="mb-3"
@@ -409,6 +402,13 @@ export function CollectingEventFormLayout({
                         className="react-switch dateRange"
                       />
                     </label>
+                  )}
+                  {(rangeEnabled || endEventDateTime) && (
+                    <FormattedTextField
+                      name="endEventDateTime"
+                      label={formatMessage("endEventDateTimeLabel")}
+                      placeholder={"YYYY-MM-DDTHH:MM:SS.MMM"}
+                    />
                   )}
                 </div>
               )}


### PR DESCRIPTION
- Make the teal button on TextFieldWithCoordinate keyboard accessible
- Move the EndEventDatetime field to underneath the enable range Switch so that after swith on, the tab focus in  on the EndEventDatetime
- Make Error readable by screen reader and also add the index in form level error message