### PR TITLE
Feedback 24271

### DIFF
--- a/packages/common-ui/lib/account/AuthenticatedApiClientProvider.tsx
+++ b/packages/common-ui/lib/account/AuthenticatedApiClientProvider.tsx
@@ -9,6 +9,8 @@ export function AuthenticatedApiClientProvider({
   const apiContext = useApiClient();
   const { authenticated, initialized, login, token } = useAccount();
   const authTokenRef = useRef<string>();
+  // Update the token ref on every render:
+  authTokenRef.current = token;
 
   // All pages require authentication.
   // Redirect to the login page if not logged in:
@@ -28,11 +30,6 @@ export function AuthenticatedApiClientProvider({
       return config;
     });
   }, [apiContext.apiClient.axios]);
-
-  // Update the token ref when useAccount's token changes:
-  useEffect(() => {
-    authTokenRef.current = token;
-  }, [token]);
 
   return <>{authenticated && initialized ? children : null}</>;
 }


### PR DESCRIPTION
-Changed the AuthenticatedApiClientProvider to set the token ref on render instead of inside useEffect. This makes the token available on the initial render and fixes the "Unauthorized" error.