### PR TITLE
24543

### DIFF
--- a/packages/dina-ui/components/collection/ParseVerbatimToRangeButton.tsx
+++ b/packages/dina-ui/components/collection/ParseVerbatimToRangeButton.tsx
@@ -4,7 +4,6 @@ import {
   toMeters,
   useDinaFormContext
 } from "common-ui";
-import { useField } from "formik";
 import { get } from "lodash";
 import { CollectingEvent } from "../../types/collection-api";
 
@@ -23,20 +22,13 @@ export function ParseVerbatimToRangeButton({
     values,
     formik
   ) => {
-    const currentMin = get(values, minField);
-    const currentMax = get(values, maxField);
-
     const verbatimText: string = get(values, verbatimField)?.toString() ?? "";
     const [newMin, newMax] = verbatimText
       .split(/to|\-/)
       .map(text => toMeters(text));
 
-    if (newMin && !currentMin) {
-      formik.setFieldValue(minField, newMin);
-      if (newMax && !currentMax) {
-        formik.setFieldValue(maxField, newMax);
-      }
-    }
+    formik.setFieldValue(minField, newMin);
+    formik.setFieldValue(maxField, newMax);
   };
 
   const { readOnly } = useDinaFormContext();
@@ -45,7 +37,6 @@ export function ParseVerbatimToRangeButton({
     <FormikButton
       className="btn btn-info mb-3 parse-verbatim-to-range-button"
       onClick={convertToMinMax}
-      buttonProps={({ values }) => ({ disabled: !!get(values, minField) })}
     >
       {buttonText}
     </FormikButton>

--- a/packages/dina-ui/components/collection/__tests__/ParseVerbatimToRangeButton.test.tsx
+++ b/packages/dina-ui/components/collection/__tests__/ParseVerbatimToRangeButton.test.tsx
@@ -57,21 +57,4 @@ describe("ParseVerbatimToRangeButton component", () => {
       min: "1"
     });
   });
-
-  it("Disables the button when there is a current min value.", async () => {
-    const wrapper = mountWithAppContext(
-      <DinaForm
-        initialValues={{ verbatim: "1m to 20m ", min: "4.5" }}
-        onSubmit={({ submittedValues }) => mockSubmit(submittedValues)}
-      >
-        <ParseVerbatimToRangeButton
-          buttonText="buttonText"
-          rangeFields={["min", "max"]}
-          verbatimField="verbatim"
-        />
-      </DinaForm>
-    );
-
-    expect(wrapper.find("button").prop("disabled")).toEqual(true);
-  });
 });


### PR DESCRIPTION
- Remove the restriction so the convertion buttons for elevation and depth are always available
- Remove the test to expect those buttons to be disabled when there is min value