### PR TITLE
Update to add h2 heading to titles of fieldsets

### DIFF
--- a/packages/common-ui/common-ui-style.css
+++ b/packages/common-ui/common-ui-style.css
@@ -24,3 +24,9 @@ input[id^="react-select"] {
 .css-1wa3eu0-placeholder {
   color: #333333 !important;
 }
+
+.fieldset-h2-adjustment {
+  font-size: 1.7rem!important;
+  margin-top: 15px!important;
+  margin-bottom: 10px!important;
+}

--- a/packages/common-ui/lib/formik-connected/FieldSet.tsx
+++ b/packages/common-ui/lib/formik-connected/FieldSet.tsx
@@ -21,7 +21,7 @@ export function FieldSet({
       className={`mb-3 border card px-4 py-2 ${className ?? ""}`}
       id={id}
     >
-      <legend className="w-auto">{legend}</legend>
+      <legend className="w-auto"><h2 className="fieldset-h2-adjustment">{legend}</h2></legend>
       <DinaFormSection {...formSectionProps} />
     </fieldset>
   );


### PR DESCRIPTION
Provided customization to h2 font size to make it smaller than h1 title and to the top and bottom margins to provide balanced distancing between fieldset border and content.