### PR TITLE
25308

### DIFF
--- a/packages/dina-ui/components/collection/DeterminationField.tsx
+++ b/packages/dina-ui/components/collection/DeterminationField.tsx
@@ -8,10 +8,9 @@ import {
   ResourceSelectField,
   TextField,
   TextFieldWithMultiplicationButton,
-  useDinaFormContext,
-  Tooltip
+  Tooltip,
+  useDinaFormContext
 } from "common-ui";
-import DOMPurify from "dompurify";
 import { FieldArray, FormikContextType } from "formik";
 import { clamp, get } from "lodash";
 import { useState } from "react";
@@ -317,12 +316,7 @@ export function DeterminationField({ className }: DeterminationFieldProps) {
                     suggestions={(_, formik) =>
                       formik.values.determination?.flatMap(det => [
                         det.verbatimScientificName,
-                        // Scientific name can be html:
-                        det.scientificName &&
-                          new DOMParser().parseFromString(
-                            DOMPurify.sanitize(det.scientificName),
-                            "text/html"
-                          ).documentElement.textContent
+                        det.scientificName
                       ]) ?? []
                     }
                   />

--- a/packages/dina-ui/components/collection/catalogue-of-life/CatalogueOfLifeNameField.tsx
+++ b/packages/dina-ui/components/collection/catalogue-of-life/CatalogueOfLifeNameField.tsx
@@ -2,8 +2,7 @@ import { FieldWrapper, FieldWrapperProps } from "common-ui";
 import { FormikProps } from "formik";
 import { DinaMessage } from "../../../intl/dina-ui-intl";
 import { CatalogueOfLifeSearchBox } from "./CatalogueOfLifeSearchBox";
-import DOMPurify from "dompurify";
-
+import isArray from "lodash";
 export interface CatalogueOfLifeNameFieldProps extends FieldWrapperProps {
   scientificNameSourceField?: string;
   onChange?: (selection: string | null, formik: FormikProps<any>) => void;
@@ -62,8 +61,9 @@ export function CatalogueOfLifeNameField({
           <CatalogueOfLifeSearchBox
             fetchJson={fetchJson}
             onSelect={newValue => {
-              onChange?.(newValue, formik);
-              setValue(newValue);
+              const val = isArray(newValue) ? newValue?.[1] : newValue;
+              onChange?.(val as any, formik);
+              setValue(val);
             }}
             index={index}
           />
@@ -74,12 +74,9 @@ export function CatalogueOfLifeNameField({
 }
 
 function CatalogueOfLifeNameReadOnly({ value, scientificNameSource }) {
-  const sanitizedHtml = DOMPurify.sanitize(value, {
-    ADD_ATTR: ["target", "rel"]
-  });
   return (
     <div style={{ whiteSpace: "pre-wrap" }}>
-      <p dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />{" "}
+      <p> {value} </p>
       {scientificNameSource && (
         <p>
           <strong>

--- a/packages/dina-ui/components/collection/catalogue-of-life/CatalogueOfLifeSearchBox.tsx
+++ b/packages/dina-ui/components/collection/catalogue-of-life/CatalogueOfLifeSearchBox.tsx
@@ -4,7 +4,7 @@ import {
   Tooltip,
   useThrottledFetch
 } from "common-ui";
-import { useState, ReactNode } from "react";
+import { useState } from "react";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import { DataSetResult } from "./dataset-search-types";
 import { NameUsageSearchResult } from "./nameusage-types";
@@ -15,7 +15,7 @@ export interface CatalogueOfLifeSearchBoxProps {
   /** Optionally mock out the HTTP fetch for testing. */
   fetchJson?: (url: string) => Promise<any>;
 
-  onSelect?: (selection: string | null) => void;
+  onSelect?: (selection: string | string[] | null) => void;
 
   /** The determination index within the material sample. */
   index?: number;
@@ -148,6 +148,10 @@ export function CatalogueOfLifeSearchBox({
             const safeHtmlLink: string = DOMPurify.sanitize(link.outerHTML, {
               ADD_ATTR: ["target", "rel"]
             });
+
+            const resultArray: string[] = [];
+            resultArray.push(safeHtmlLink);
+            resultArray.push(result.label ?? "");
             return (
               <div
                 key={result.id ?? idx}
@@ -159,7 +163,7 @@ export function CatalogueOfLifeSearchBox({
                 <FormikButton
                   className="btn btn-primary col-name-select-button"
                   buttonProps={() => ({ style: { width: "8rem" } })}
-                  onClick={() => onSelect?.(safeHtmlLink)}
+                  onClick={() => onSelect?.(resultArray)}
                 >
                   <DinaMessage id="select" />
                 </FormikButton>

--- a/packages/dina-ui/components/collection/catalogue-of-life/__tests__/CatalogueOfLifeNameField.test.tsx
+++ b/packages/dina-ui/components/collection/catalogue-of-life/__tests__/CatalogueOfLifeNameField.test.tsx
@@ -52,7 +52,7 @@ describe("CatalogueOfLifeNameField component", () => {
     wrapper.find("button.col-name-select-button").at(1).simulate("click");
 
     expect(mockOnChange).lastCalledWith(
-      '<a rel="noopener" target="_blank" href="https://data.catalogueoflife.org/dataset/2328/name/f3d46805-704b-459a-a3f6-58816dad2138"><i>Poa muralis</i> Wibel, nom. illeg.</a>',
+      "Poa muralis Wibel, nom. illeg.",
       expect.anything()
     );
     // The whitespace for the query string should be trimmed:
@@ -68,8 +68,7 @@ describe("CatalogueOfLifeNameField component", () => {
     wrapper.update();
 
     expect(mockOnSubmit).lastCalledWith({
-      scientificName:
-        '<a rel="noopener" target="_blank" href="https://data.catalogueoflife.org/dataset/2328/name/f3d46805-704b-459a-a3f6-58816dad2138"><i>Poa muralis</i> Wibel, nom. illeg.</a>',
+      scientificName: "Poa muralis Wibel, nom. illeg.",
       scientificNameSource: "COLPLUS"
     });
   });


### PR DESCRIPTION
- Make the CatalogueOfLifeSearchBox sending the search result label instead of the html to api, which fixed both association hostorganism and the determination
scientific name.
- Removed code to parse html when display the value which was expecting a link
- Update test to reflect the changes