### PR TITLE
Changed DateField:

### DIFF
--- a/packages/common-ui/lib/formik-connected/__tests__/DateField.test.tsx
+++ b/packages/common-ui/lib/formik-connected/__tests__/DateField.test.tsx
@@ -32,23 +32,39 @@ describe("DateField component", () => {
 
   it("Changes the Formik field's value.", () => {
     const wrapper = getWrapper();
-    const { onChange } = wrapper.find<any>(ReactDatePicker).props();
+    wrapper
+      .find("input")
+      .simulate("change", { target: { value: "2019-05-25" } });
 
-    onChange(new Date("2019-05-25T12:00:00Z"), undefined);
-    wrapper.update();
-
-    expect(wrapper.find(ReactDatePicker).prop("selected")).toEqual(
-      new Date("2019-05-25T12:00:00.000Z")
-    );
+    expect(wrapper.find("input").prop("value")).toEqual("2019-05-25");
   });
 
   it("Can set the date field to null.", () => {
     const wrapper = getWrapper();
-    const { onChange } = wrapper.find<any>(ReactDatePicker).props();
-
-    onChange(null, undefined);
-    wrapper.update();
+    wrapper.find("input").simulate("change", { target: { value: "" } });
 
     expect(wrapper.find(ReactDatePicker).prop("selected")).toEqual(null);
+  });
+
+  it("Shows an error on non-existing dates.", () => {
+    const wrapper = getWrapper();
+    wrapper
+      .find("input")
+      .simulate("change", { target: { value: "2021-02-29" } });
+    wrapper.find("input").simulate("blur");
+
+    expect(wrapper.find(".invalid-feedback").text()).toEqual(
+      "Invalid Date: 2021-02-29"
+    );
+  });
+
+  it("Shows an error on invalid date formats.", () => {
+    const wrapper = getWrapper();
+    wrapper.find("input").simulate("change", { target: { value: "2021" } });
+    wrapper.find("input").simulate("blur");
+
+    expect(wrapper.find(".invalid-feedback").text()).toEqual(
+      "Date must be formatted as YYYY-MM-DD"
+    );
   });
 });

--- a/packages/common-ui/lib/intl/common-ui-en.ts
+++ b/packages/common-ui/lib/intl/common-ui-en.ts
@@ -27,6 +27,7 @@ export const COMMON_UI_MESSAGES_ENGLISH = {
   created: "created",
   createNew: "Create New",
   date: "Date",
+  dateMustBeFormattedYyyyMmDd: "Date must be formatted as YYYY-MM-DD",
   deleteAllButtonText: "Delete All",
   deleteButtonText: "Delete",
   description: "Description",
@@ -61,6 +62,7 @@ export const COMMON_UI_MESSAGES_ENGLISH = {
   geoSuggest: "Geo-Suggest",
   geoSuggestTooltip:
     "This button shows some suggested geo-locations based on what you've typed into the field.",
+  invalidDate: "Invalid Date",
   jumpToPage: "jump to page",
   rowsPerPage: "rows per page",
   languageOfPage: "eng",


### PR DESCRIPTION
-No more autocorrect.
-Shows an error message on blur and on form submit when there is either an invalid date (like 2021-02-29) or bad format (like '20210105' or 'asdfasdf').

-Added an error boundary to the FieldWrapper so an error in one field doesn't kill the whole page.