### PR TITLE
Feedback 25658

### DIFF
--- a/packages/dina-ui/components/object-store/attachment-list/AttachmentsField.tsx
+++ b/packages/dina-ui/components/object-store/attachment-list/AttachmentsField.tsx
@@ -18,6 +18,7 @@ import { AttachmentReadOnlySection } from "./AttachmentReadOnlySection";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import { Metadata } from "../../../types/objectstore-api";
 import Link from "next/link";
+import { uniqBy, isEqual } from "lodash";
 
 export interface AttachmentsFieldProps {
   name: string;
@@ -89,7 +90,12 @@ export function AttachmentsEditor({
   });
 
   async function addAttachedMetadatas(newIds: string[]) {
-    onChange([...value, ...newIds.map(it => ({ id: it, type: "metadata" }))]);
+    onChange(
+      uniqBy(
+        [...value, ...newIds.map(it => ({ id: it, type: "metadata" }))],
+        val => val.id
+      )
+    );
     closeModal();
   }
 


### PR DESCRIPTION
-Added dataloader usage to bulkGet to batch together find-one requests with the same ID.
-Updated Attachments Editor to remove duplicate attachment IDs when they are added.