### PR TITLE
Feedback 25677

### DIFF
--- a/packages/common-ui/lib/formik-connected/__tests__/MetersField.test.tsx
+++ b/packages/common-ui/lib/formik-connected/__tests__/MetersField.test.tsx
@@ -13,10 +13,18 @@ describe("MetersField component", () => {
     expect(toMeters("1 Feet")).toEqual("0.3048");
     expect(toMeters("1 ft")).toEqual("0.3048");
     expect(toMeters("1 FT")).toEqual("0.3048");
+    expect(toMeters("1ft")).toEqual("0.3048");
+    expect(toMeters("1ft.")).toEqual("0.3048");
+    expect(toMeters("1'")).toEqual("0.3048");
     expect(toMeters("1 Inches")).toEqual("0.0254");
     expect(toMeters("1 in")).toEqual("0.0254");
+    expect(toMeters("1 in.")).toEqual("0.0254");
+    expect(toMeters("1in.")).toEqual("0.0254");
     expect(toMeters("4ft 3in")).toEqual("1.2954");
     expect(toMeters("4 ft 3 in")).toEqual("1.2954");
+    expect(toMeters("4 ft. 3 in.")).toEqual("1.2954");
+    expect(toMeters(`4'3"`)).toEqual("1.2954");
+    expect(toMeters("4' 3\"")).toEqual("1.2954");
     expect(toMeters("4 feet 3 inches")).toEqual("1.2954");
     expect(toMeters("4 Feet 3 Inches")).toEqual("1.2954");
     expect(toMeters("4 Pied 3 Pouce")).toEqual("1.2954");
@@ -43,6 +51,16 @@ describe("MetersField component", () => {
     expect(toMeters("1 pouces")).toEqual("0.0254");
     expect(toMeters("3pd 3po")).toEqual("0.9906");
 
+    // Works with decimals:
+    expect(toMeters(`0.1 feet 0.1 inches`)).toEqual("0.03302");
+    expect(toMeters(`0.1' 0.1"`)).toEqual("0.03302");
+    expect(toMeters(`.1 feet .1 inches`)).toEqual("0.03302");
+    expect(toMeters(`.1' .1"`)).toEqual("0.03302");
+    expect(toMeters(`.1'.1"`)).toEqual("0.03302");
+    expect(toMeters(`0.1'0.1"`)).toEqual("0.03302");
+
+    expect(toMeters('10"')).toEqual("0.254");
+
     // Accepts french units with the accent:
     expect(toMeters("1 kilomètre")).toEqual("1000");
 
@@ -59,6 +77,15 @@ describe("MetersField component", () => {
     // Trailing zeroes should be kept:
     expect(toMeters("4 feet 3 inches", 2)).toEqual("1.30");
     expect(toMeters("4 feet 4 inches", 2)).toEqual("1.32");
+  });
+
+  it("Returns number-only values as-is without changing the decimals.", () => {
+    expect(toMeters("0", 2)).toEqual("0");
+    expect(toMeters("12345", 2)).toEqual("12345");
+    expect(toMeters("0.30", 2)).toEqual("0.30");
+    expect(toMeters("0.300", 2)).toEqual("0.300");
+    expect(toMeters("0.0", 2)).toEqual("0.0");
+    expect(toMeters("0.0000", 2)).toEqual("0.0000");
   });
 
   it("Does the unit conversion onBlur.", () => {


### PR DESCRIPTION
Added regex to pre-clean the input for values the mathjs parser can't handle
- Abbreviations: (ft. -> ft)
- quotes/apostrophes: (5' -> 5 feet)

-Added more tests.