### PR TITLE
25928

### DIFF
--- a/packages/dina-ui/pages/object-store/managedAttributesView/listView.tsx
+++ b/packages/dina-ui/pages/object-store/managedAttributesView/listView.tsx
@@ -2,7 +2,7 @@ import {
   ColumnDefinition,
   ListPageLayout,
   ButtonBar,
-  CreateButton
+  descriptionCell
 } from "common-ui";
 import Link from "next/link";
 import { Footer, Head, Nav } from "../../../components";
@@ -25,19 +25,7 @@ const ATTRIBUTES_LIST_COLUMNS: ColumnDefinition<ManagedAttribute>[] = [
     accessor: "name"
   },
   "createdBy",
-  {
-    Cell: ({ original: { description } }) =>
-      description?.en && description?.fr ? (
-        <>
-          en : {description?.en} | fr : {description?.fr}
-        </>
-      ) : description?.en ? (
-        description.en
-      ) : (
-        description.fr
-      ),
-    accessor: "description"
-  },
+  descriptionCell("multilingualDescription"),
   {
     Cell: ({ original: { acceptedValues, managedAttributeType } }) => {
       const labelKey: keyof typeof DINAUI_MESSAGES_ENGLISH | undefined =

--- a/packages/dina-ui/types/objectstore-api/resources/ManagedAttribute.ts
+++ b/packages/dina-ui/types/objectstore-api/resources/ManagedAttribute.ts
@@ -1,5 +1,6 @@
 import { KitsuResource } from "kitsu";
 import { DINAUI_MESSAGES_ENGLISH } from "../../../intl/dina-ui-en";
+import { MultilingualDescription } from "../../collection-api";
 
 export interface ManagedAttributeAttributes {
   type: string;
@@ -9,7 +10,7 @@ export interface ManagedAttributeAttributes {
   acceptedValues?: string[] | null;
   createdBy?: string;
   createdOn?: string;
-  description?: Map<string, string>;
+  multilingualDescription?: MultilingualDescription;
 }
 
 export type ManagedAttributeType = "INTEGER" | "STRING" | "PICKLIST";


### PR DESCRIPTION
- Change description to multilingualDescription in object store managed attribute ts file to match API
- Update the list and edit/view pages for query and saving multilingualDescription
- Adjust object store managed attribute view page to make it similar to that of collection managed attribute