### PR TITLE
Feedback 25963

### DIFF
--- a/packages/common-ui/lib/formik-connected/AssociatedMaterialSampleSearchBox.tsx
+++ b/packages/common-ui/lib/formik-connected/AssociatedMaterialSampleSearchBox.tsx
@@ -1,26 +1,19 @@
+import classNames from "classnames";
+import { FastField } from "formik";
 import React from "react";
 import { RiDeleteBinLine } from "react-icons/ri";
 import { FieldWrapper } from "..";
 import { MaterialSampleLink } from "../../../dina-ui/components/collection/MaterialSampleAssociationsField";
 import { useDinaIntl } from "../../../dina-ui/intl/dina-ui-intl";
 import { SampleListLayout } from "../../../dina-ui/pages/collection/material-sample/list";
-import classNames from "classnames";
 
 export function AssociatedMaterialSampleSearchBoxField({
   showSearchBtn,
-  listRef,
+  onSearchClicked,
+  onRemoveEntry,
   props
 }) {
   const { formatMessage } = useDinaIntl();
-
-  function onSearchClicked() {
-    if (listRef.current) {
-      listRef.current.className = listRef.current.className.replace(
-        "d-none",
-        ""
-      );
-    }
-  }
 
   function defaultReadOnlyRender(value) {
     return value && <MaterialSampleLink id={value} />;
@@ -34,18 +27,17 @@ export function AssociatedMaterialSampleSearchBoxField({
           disableLabelClick={true}
           readOnlyRender={(value, _) => defaultReadOnlyRender(value)}
         >
-          {({ setValue, value }) => {
+          {({ setValue, value, invalid }) => {
             /** Clear the input value */
             function removeEntry() {
               setValue(null);
-              if (listRef.current) {
-                listRef.current.className =
-                  listRef.current.className.replaceAll("d-none", "");
-              }
+              onRemoveEntry();
             }
             return (
               <>
-                <div className={"row mb-2"}>
+                <div
+                  className={classNames("row mb-2", invalid && "is-invalid")}
+                >
                   {showSearchBtn ? (
                     <button
                       type="button"
@@ -88,17 +80,15 @@ export function AssociatedMaterialSampleSearchBoxField({
 }
 
 export function MaterialSampleSearchHelper({
-  listRef,
+  showSearch,
+  fieldName,
   onAssociatedSampleSelected,
   onCloseClicked
 }) {
   const { formatMessage } = useDinaIntl();
-  return (
-    <div
-      ref={listRef}
-      className={classNames("p-2 mt-2 d-none")}
-      style={{ borderStyle: "dashed" }}
-    >
+
+  return showSearch ? (
+    <div className="p-2 mt-2" style={{ borderStyle: "dashed" }}>
       <div className="mb-4">
         <span className="me-2 fw-bold" style={{ fontSize: "1.2em" }}>
           {formatMessage("search")}
@@ -107,13 +97,18 @@ export function MaterialSampleSearchHelper({
           {formatMessage("closeButtonText")}
         </button>
       </div>
-      <SampleListLayout
-        onSelect={onAssociatedSampleSelected}
-        classNames="btn btn-primary associated-sample-search"
-        btnMsg={formatMessage("select")}
-        hideTopPagination={true}
-        hideGroupFilter={true}
-      />
+      {/** The table is expensive to render, so avoid unnecessary re-renders with FastField. */}
+      <FastField name={fieldName}>
+        {() => (
+          <SampleListLayout
+            onSelect={onAssociatedSampleSelected}
+            classNames="btn btn-primary associated-sample-search"
+            btnMsg={formatMessage("select")}
+            hideTopPagination={true}
+            hideGroupFilter={true}
+          />
+        )}
+      </FastField>
     </div>
-  );
+  ) : null;
 }

--- a/packages/dina-ui/components/collection/MaterialSampleAssociationsField.tsx
+++ b/packages/dina-ui/components/collection/MaterialSampleAssociationsField.tsx
@@ -83,23 +83,24 @@ function AssociationTabPanel({
   fieldProps,
   index
 }: TabPanelCtx<MaterialSampleAssociation>) {
-  const listRef = useRef<HTMLDivElement>(null);
+  const [showSearch, setShowSearch] = useState(false);
   const formikCtx = useFormikContext<MaterialSample>();
   const [showSearchBtn, setShowSearchBtn] = useState(
     formikCtx.values.associations?.[index].associatedSample ? false : true
   );
 
-  function onCloseClicked() {
-    if (listRef.current) {
-      listRef.current.className = listRef.current.className + " d-none";
-    }
+  function resetSearchState() {
+    setShowSearch(false);
+    setShowSearchBtn(true);
   }
 
   function onAssociatedSampleSelected(
     sample: PersistedResource<MaterialSample>
   ) {
-    formikCtx.setFieldValue(fieldProps("associatedSample").name, sample.id);
-    onCloseClicked();
+    const fieldName = fieldProps("associatedSample").name;
+    formikCtx.setFieldValue(fieldName, sample.id);
+    formikCtx.setFieldError(fieldName, undefined);
+    resetSearchState();
     setShowSearchBtn(false);
   }
   return (
@@ -115,7 +116,8 @@ function AssociationTabPanel({
           <div className="associated-sample">
             <AssociatedMaterialSampleSearchBoxField
               showSearchBtn={showSearchBtn}
-              listRef={listRef}
+              onRemoveEntry={resetSearchState}
+              onSearchClicked={() => setShowSearch(true)}
               props={fieldProps("associatedSample")}
             />
           </div>
@@ -125,9 +127,10 @@ function AssociationTabPanel({
         </div>
       </div>
       <MaterialSampleSearchHelper
-        listRef={listRef}
+        fieldName={fieldProps("associatedSample").name}
+        showSearch={showSearch}
         onAssociatedSampleSelected={onAssociatedSampleSelected}
-        onCloseClicked={onCloseClicked}
+        onCloseClicked={resetSearchState}
       />
     </div>
   );

--- a/packages/dina-ui/page-tests/collection/material-sample/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/material-sample/__tests__/edit.test.tsx
@@ -1180,7 +1180,7 @@ describe("Material Sample Edit Page", () => {
   });
 
   it("Add the associated sample selected from search result list to a new association  .", async () => {
-    //Mount a new material sample with no values
+    // Mount a new material sample with no values
     const wrapper = mountWithAppContext(
       <MaterialSampleForm onSaved={mockOnSaved} />,
       testCtx
@@ -1208,18 +1208,21 @@ describe("Material Sample Edit Page", () => {
     // Click the search button to find from a material sample list
     wrapper.find("button.searchSample").simulate("click");
 
+    await new Promise(setImmediate);
+    wrapper.update();
+
     // Search table is shown:
     expect(wrapper.find(".associated-sample-search").exists()).toEqual(true);
 
-    // Select one sample from search result list 
+    // Select one sample from search result list
     wrapper.find("button.associated-sample-search").simulate("click");
 
     await new Promise(setImmediate);
     wrapper.update();
 
-    // Expect the selected sample being populated to the sample input     
+    // Expect the selected sample being populated to the sample input
     expect(wrapper.find(".associated-sample-link").text()).toEqual(
       "my-sample-name"
     );
-  }); 
+  });
 });

--- a/packages/dina-ui/pages/collection/material-sample/edit.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/edit.tsx
@@ -630,6 +630,7 @@ function useMaterialSampleSchema() {
       yup.object({
         associatedSample: yup
           .string()
+          .nullable()
           .required()
           .label(getFieldLabel({ name: "associatedSample" }).fieldLabel),
         associationType: yup


### PR DESCRIPTION
-Changed listRef + d-none usage to use useState.
-Wrapped the table in a FastField to avoid unnecessary re-renders.
-Added the is-invalid class when the associatedSample is invalid so the error message shows below the Search box