### PR TITLE
Feedback 26236

### DIFF
--- a/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
@@ -19,7 +19,7 @@ import { useState } from "react";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import SpreadSheetColumn from "spreadsheet-column";
 import * as yup from "yup";
-import { CollectionSelectField } from "..";
+import { CollectionSelectField, GroupSelectField } from "..";
 import { DinaMessage, useDinaIntl } from "../../intl/dina-ui-intl";
 import { MaterialSample } from "../../types/collection-api/resources/MaterialSample";
 import { useLastUsedCollection } from "../collection";
@@ -61,6 +61,7 @@ export function MaterialSampleGenerationForm({
         parentMaterialSample: parentId
           ? { id: parentId, type: "material-sample" }
           : undefined,
+        group: submittedValues.group,
         collection: submittedValues.collection,
         publiclyReleasable: true,
         // Batch mode generates samples with the same name, so allow duplicate names in batch mode:
@@ -95,7 +96,7 @@ export function MaterialSampleGenerationForm({
   }
 
   return (
-    <DinaForm<GeneratorFormValues>
+    <DinaForm<Partial<GeneratorFormValues>>
       initialValues={
         initialValues || {
           numberToCreate: 0,
@@ -123,6 +124,13 @@ export function MaterialSampleGenerationForm({
             </Link>
           </h2>
         ))}
+      <div className="row">
+        <GroupSelectField
+          name="group"
+          className="col-sm-6"
+          enableStoredDefaultGroup={true}
+        />
+      </div>
       <div style={{ width: "25rem" }}>
         <NumberSpinnerField
           name="numberToCreate"
@@ -348,6 +356,7 @@ function generateSeriesSuffix({ index, formState }: GenerateNameParams) {
 }
 
 const generatorFormSchema = yup.object({
+  group: yup.string().required(),
   collection: yup.mixed().required(),
   numberToCreate: yup.number().required(),
   samples: yup

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleGenerationForm.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleGenerationForm.test.tsx
@@ -1,7 +1,9 @@
+import { writeStorage } from "@rehooks/local-storage";
 import { ResourceSelect } from "common-ui";
-import { mountWithAppContext } from "../../../test-util/mock-app-context";
-import { MaterialSampleGenerationForm } from "../MaterialSampleGenerationForm";
 import Select from "react-select";
+import { mountWithAppContext } from "../../../test-util/mock-app-context";
+import { DEFAULT_GROUP_STORAGE_KEY } from "../../group-select/useStoredDefaultGroup";
+import { MaterialSampleGenerationForm } from "../MaterialSampleGenerationForm";
 
 const mockGet = jest.fn<any, any>(async path => {
   switch (path) {
@@ -31,6 +33,12 @@ const testCtx = {
 
 describe("MaterialSampleGenerationForm", () => {
   beforeEach(jest.clearAllMocks);
+
+  beforeEach(() => {
+    // Set the deault group selection:
+    writeStorage(DEFAULT_GROUP_STORAGE_KEY, "aafc");
+    jest.clearAllMocks();
+  });
 
   it("Generates the initial values for the new samples in series mode.", async () => {
     const wrapper = mountWithAppContext(
@@ -93,6 +101,7 @@ describe("MaterialSampleGenerationForm", () => {
       samples: expectedNames.map(name => ({
         allowDuplicateName: false,
         collection: { id: "100", name: "test-collection", type: "collection" },
+        group: "aafc",
         materialSampleName: name,
         publiclyReleasable: true,
         type: "material-sample"
@@ -104,6 +113,7 @@ describe("MaterialSampleGenerationForm", () => {
           name: "test-collection",
           type: "collection"
         },
+        group: "aafc",
         increment: "NUMERICAL",
         numberToCreate: "5",
         samples: [],
@@ -175,6 +185,7 @@ describe("MaterialSampleGenerationForm", () => {
       samples: expectedNames.map(name => ({
         allowDuplicateName: true,
         collection: { id: "100", name: "test-collection", type: "collection" },
+        group: "aafc",
         materialSampleName: name,
         publiclyReleasable: true,
         type: "material-sample"
@@ -186,6 +197,7 @@ describe("MaterialSampleGenerationForm", () => {
           name: "test-collection",
           type: "collection"
         },
+        group: "aafc",
         increment: "NUMERICAL",
         numberToCreate: "5",
         samples: [],
@@ -271,6 +283,7 @@ describe("MaterialSampleGenerationForm", () => {
           name: "test-collection",
           type: "collection"
         },
+        group: "aafc",
         increment: "LETTER",
         numberToCreate: "5",
         samples: [],
@@ -284,6 +297,7 @@ describe("MaterialSampleGenerationForm", () => {
           id: "test-collection-id",
           type: "collection"
         }),
+        group: "aafc",
         parentMaterialSample: { id: "test-parent-id", type: "material-sample" },
         publiclyReleasable: true,
         materialSampleName: name,

--- a/packages/dina-ui/components/bulk-material-sample/bulk-edit-tab.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/bulk-edit-tab.tsx
@@ -55,7 +55,6 @@ export function useBulkEditTab({
             materialSample={initialValues}
             disableAutoNamePrefix={true}
             disableSampleNameField={true}
-            omitGroupField={true}
             isOffScreen={!isSelected}
             // Disable the nav's Are You Sure prompt when removing components,
             // because you aren't actually deleting data.

--- a/packages/dina-ui/components/group-select/GroupSelectField.tsx
+++ b/packages/dina-ui/components/group-select/GroupSelectField.tsx
@@ -87,7 +87,7 @@ export function GroupSelectField(groupSelectFieldProps: GroupSelectFieldProps) {
         selectFieldProps.onChange?.(newValue, formik);
       }}
       options={options}
-      selectProps={{ isDisabled: hasOnlyOneOption }}
+      selectProps={{ isDisabled: hasOnlyOneOption, isClearable: true }}
     />
   );
 }

--- a/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
+++ b/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
@@ -1,4 +1,6 @@
+import { writeStorage } from "@rehooks/local-storage";
 import { ResourceSelect } from "common-ui";
+import { DEFAULT_GROUP_STORAGE_KEY } from "../../../../components/group-select/useStoredDefaultGroup";
 import { MaterialSampleBulkCreatePage } from "../../../../pages/collection/material-sample/bulk-create";
 import { mountWithAppContext } from "../../../../test-util/mock-app-context";
 
@@ -33,6 +35,12 @@ const testCtx = {
 
 describe("MaterialSampleBulkCreatePage", () => {
   beforeEach(jest.clearAllMocks);
+
+  beforeEach(() => {
+    // Set the deault group selection:
+    writeStorage(DEFAULT_GROUP_STORAGE_KEY, "aafc");
+    jest.clearAllMocks();
+  });
 
   it("Can click the 'previous' button to go back to the previous step", async () => {
     const wrapper = mountWithAppContext(

--- a/packages/dina-ui/pages/collection/material-sample/bulk-create.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/bulk-create.tsx
@@ -44,7 +44,7 @@ export function MaterialSampleBulkCreatePage({ router }: WithRouterProps) {
     <div>
       <Head title={formatMessage(title)} />
       <Nav />
-      <main className={generatedSamples ? "container-fluid" : "container"}>
+      <main className={mode === "EDIT" ? "container-fluid" : "container"}>
         <h1 id="wb-cont">{formatMessage(title)}</h1>
         {mode === "EDIT" && generatedSamples && (
           <MaterialSampleBulkEditor

--- a/packages/dina-ui/pages/collection/material-sample/edit.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/edit.tsx
@@ -98,7 +98,8 @@ export default function MaterialSampleEditPage() {
 
   const title = id ? "editMaterialSampleTitle" : "addMaterialSampleTitle";
 
-  const sampleFormProps = {
+  const sampleFormProps: Partial<MaterialSampleFormProps> = {
+    enableStoredDefaultGroup: true,
     buttonBar: (
       <ButtonBar>
         <BackButton
@@ -206,8 +207,6 @@ export interface MaterialSampleFormProps {
   /** Makes the sample name field (Primary ID) read-only. */
   disableSampleNameField?: boolean;
 
-  omitGroupField?: boolean;
-
   materialSampleFormRef?: Ref<FormikProps<InputResource<MaterialSample>>>;
 
   /** Disables the "Are You Sure" prompt in the nav when removing a data component. */
@@ -221,6 +220,9 @@ export interface MaterialSampleFormProps {
 
   /** Reduces the rendering to improve performance when bulk editing many material samples. */
   reduceRendering?: boolean;
+
+  /** Sets a default group from local storage when the group is not already set. */
+  enableStoredDefaultGroup?: boolean;
 }
 
 export function MaterialSampleForm({
@@ -234,10 +236,10 @@ export function MaterialSampleForm({
   disableAutoNamePrefix,
   materialSampleFormRef,
   disableSampleNameField,
-  omitGroupField,
   disableNavRemovePrompt,
   isOffScreen,
   reduceRendering,
+  enableStoredDefaultGroup,
   buttonBar = (
     <ButtonBar>
       <BackButton
@@ -321,12 +323,12 @@ export function MaterialSampleForm({
                 materialSample={materialSample as any}
               />
             )}
-            {!isTemplate && !omitGroupField && (
+            {!isTemplate && (
               <div className="row">
                 <div className="col-md-6">
                   <GroupSelectField
                     name="group"
-                    enableStoredDefaultGroup={true}
+                    enableStoredDefaultGroup={enableStoredDefaultGroup}
                   />
                 </div>
               </div>

--- a/packages/dina-ui/pages/collection/workflow-template/run.tsx
+++ b/packages/dina-ui/pages/collection/workflow-template/run.tsx
@@ -94,6 +94,7 @@ export function CreateMaterialSampleFromWorkflowForm({
 
   return (
     <MaterialSampleForm
+      enableStoredDefaultGroup={true}
       buttonBar={
         <ButtonBar className="d-flex">
           <BackButton


### PR DESCRIPTION
-Added the group select (invisible if you only have 1 group) to the bulk create form. (accessed by the Split or Create Multiple New buttons).
-Enabled editing the group field in bulk edit.
-Only enable the auto group selection (last selected group from localstorage) on Material Sample for the edit page and workflow run pages. Disabled for template creation, and bulk edit pages.