### PR TITLE
26887 add support for new managed attribute types

### DIFF
--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -318,6 +318,8 @@ export const DINAUI_MESSAGES_ENGLISH = {
   field_managedAttributeType_integer_label: "Numerical",
   field_managedAttributeType_picklist_label: "Pick List",
   field_managedAttributeType_text_label: "Text",
+  field_managedAttributeType_date_label: "Date",
+  field_managedAttributeType_boolean_label: "Boolean",
   field_materialSampleName: "Primary ID",
   field_materialSampleState_tooltip:
     "Represents the state of a material sample when its condition is negatively impacted.",

--- a/packages/dina-ui/types/collection-api/resources/ManagedAttribute.ts
+++ b/packages/dina-ui/types/collection-api/resources/ManagedAttribute.ts
@@ -19,7 +19,7 @@ export type ManagedAttributeType =
   | "STRING"
   | "PICKLIST"
   | "DATE"
-  | "BOOLEAN";
+  | "BOOL";
 
 export const COLLECTION_MODULE_TYPES = [
   "COLLECTING_EVENT",
@@ -58,7 +58,7 @@ export const MANAGED_ATTRIBUTE_TYPE_OPTIONS: {
   },
   {
     labelKey: "field_managedAttributeType_boolean_label",
-    value: "BOOLEAN"
+    value: "BOOL"
   }
 ];
 

--- a/packages/dina-ui/types/collection-api/resources/ManagedAttribute.ts
+++ b/packages/dina-ui/types/collection-api/resources/ManagedAttribute.ts
@@ -14,7 +14,12 @@ export interface ManagedAttributeAttributes<TComponent = string> {
   multilingualDescription?: MultilingualDescription;
 }
 
-export type ManagedAttributeType = "INTEGER" | "STRING" | "PICKLIST" | "DATE";
+export type ManagedAttributeType =
+  | "INTEGER"
+  | "STRING"
+  | "PICKLIST"
+  | "DATE"
+  | "BOOLEAN";
 
 export const COLLECTION_MODULE_TYPES = [
   "COLLECTING_EVENT",
@@ -46,6 +51,14 @@ export const MANAGED_ATTRIBUTE_TYPE_OPTIONS: {
   {
     labelKey: "field_managedAttributeType_picklist_label",
     value: "PICKLIST"
+  },
+  {
+    labelKey: "field_managedAttributeType_date_label",
+    value: "DATE"
+  },
+  {
+    labelKey: "field_managedAttributeType_boolean_label",
+    value: "BOOLEAN"
   }
 ];
 


### PR DESCRIPTION
Date and Boolean options added to Managed Attribute Type dropdown
![managedattributetypedropdown](https://user-images.githubusercontent.com/30186948/158209044-1890abc3-0b9c-4dad-bcdc-f29d4125afc3.png)

Can create new Managed Attributes with Managed Attribute Type Date and Boolean in the Transactions tab
![image](https://user-images.githubusercontent.com/30186948/158209174-f6bc88a2-7546-4e8a-84a9-d30b4d43d538.png)

