### PR TITLE
27608_classification_display_issue

### DIFF
--- a/packages/dina-ui/components/collection/global-names/GlobalNamesField.tsx
+++ b/packages/dina-ui/components/collection/global-names/GlobalNamesField.tsx
@@ -124,14 +124,19 @@ export function GlobalNamesReadOnly({
   const initTaxonTree = (
     <span>
       {" "}
-      {speciesRank ? <b>Species : </b> : undefined} {speciesRank}
+      {speciesRank ? (
+        <a>
+          <b>Species : </b> {speciesRank} &gt;
+        </a>
+      ) : undefined}
       {genusRank ? (
         <>
           {" "}
-          &gt; <b> Genus : </b>{" "}
+          <a>
+            <b>Genus : </b> {genusRank}
+          </a>{" "}
         </>
       ) : undefined}{" "}
-      {genusRank}
     </span>
   );
 


### PR DESCRIPTION
- Classification path shows up as expected without any relevant code changes
- Fixed a bug where a ">" sign was showing before Genus when there is no Species