### PR TITLE
28612 thumbnails not appearing for embedded object store upload

### DIFF
--- a/packages/dina-ui/components/table/__tests__/thumbnail-cell.test.tsx
+++ b/packages/dina-ui/components/table/__tests__/thumbnail-cell.test.tsx
@@ -16,8 +16,8 @@ describe("Thumbnail cell component", () => {
   it("Using data from the API, display the thumbnail", async () => {
     const wrapper = mountWithAppContext(
       thumbnailCell({
-        bucketField: "bucket",
-        fileIdentifierField: "fileIdentifier"
+        bucketField: "data.attributes.bucket",
+        fileIdentifierField: "data.attributes.fileIdentifier"
       }).Cell({ original: METADATA_RESPONSE })
     );
 

--- a/packages/dina-ui/components/table/thumbnail-cell.tsx
+++ b/packages/dina-ui/components/table/thumbnail-cell.tsx
@@ -41,8 +41,8 @@ export function thumbnailCell({ fileIdentifierField, bucketField }) {
     // These fields are required in the elastic search response for this cell to work.
     additionalAccessors: [
       "data.attributes.resourceExternalURL",
-      "data.attributes.fileIdentifier",
-      "data.attributes.bucket"
+      fileIdentifierField,
+      bucketField
     ]
   };
 }

--- a/packages/dina-ui/components/table/thumbnail-cell.tsx
+++ b/packages/dina-ui/components/table/thumbnail-cell.tsx
@@ -8,13 +8,10 @@ export function thumbnailCell({ fileIdentifierField, bucketField }) {
   return {
     Cell: ({ original }) => {
       const fileIdentifier = get<string | undefined>(
-        original?.data?.attributes,
+        original,
         fileIdentifierField
       );
-      const bucket = get<string | undefined>(
-        original?.data?.attributes,
-        bucketField
-      );
+      const bucket = get<string | undefined>(original, bucketField);
 
       const fileId = `${fileIdentifier}/thumbnail`;
       const filePath = `/api/objectstore-api/file/${bucket}/${fileId}`;
@@ -44,8 +41,8 @@ export function thumbnailCell({ fileIdentifierField, bucketField }) {
     // These fields are required in the elastic search response for this cell to work.
     additionalAccessors: [
       "data.attributes.resourceExternalURL",
-      "data.attributes." + fileIdentifierField,
-      "data.attributes." + bucketField
+      "data.attributes.fileIdentifier",
+      "data.attributes.bucket"
     ]
   };
 }

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -52,15 +52,15 @@ export default function MetadataListPage() {
   const [listLayoutType, setListLayoutType] =
     useLocalStorage<MetadataListLayoutType>(LIST_LAYOUT_STORAGE_KEY);
 
-  const [previewMetadata, setPreviewMetadata] = useState<Metadata | null>(null);
+  const [previewMetadata, setPreviewMetadata] = useState<any | null>(null);
   const [tableSectionWidth, previewSectionWidth] = previewMetadata?.id
     ? [8, 4]
     : [12, 0];
 
   const METADATA_TABLE_COLUMNS: TableColumn<Metadata>[] = [
     thumbnailCell({
-      bucketField: "bucket",
-      fileIdentifierField: "fileIdentifier"
+      bucketField: "data.attributes.bucket",
+      fileIdentifierField: "data.attributes.fileIdentifier"
     }),
     {
       Cell: ({ original: { id, data } }) =>

--- a/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
+++ b/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
@@ -39,7 +39,6 @@ export interface MetadataAttributes {
   acHashValue?: string;
 
   resourceExternalURL?: string;
-  data?: any;
 }
 
 export interface MetadataRelationships {


### PR DESCRIPTION
- Refactored thumbnail-cell to use original object into get
- Changed the passed in fileIdentifierField and bucketField from object/list to destructure the object instead of destructuring original in thumbnail-cell
- Removed the data property from MetadataAttributes
- This will make the code for object/list and AttachmentsTable more consistent