### PR TITLE
28998 Form Template useLocalStorage use UUID

### DIFF
--- a/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
+++ b/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
@@ -17,8 +17,7 @@ import {
 import { materialSampleFormTemplateSchema } from "./materialSampleFormViewConfigSchema";
 import { useMaterialSampleFormTemplateProps } from "./useMaterialSampleFormTemplateProps";
 import { useLocalStorage } from "@rehooks/local-storage";
-import { PcrBatch } from "packages/dina-ui/types/seqdb-api";
-import { useApiClient } from "packages/common-ui/lib";
+import { useApiClient } from "../../../../common-ui/lib";
 
 const SAMPLE_FORM_TEMPLATE_KEY = "sampleFormTemplateKey";
 /**

--- a/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
+++ b/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
@@ -28,10 +28,6 @@ const SAMPLE_FORM_TEMPLATE_KEY = "sampleFormTemplateKey";
 export function useMaterialSampleFormTemplateSelectState() {
   const { apiClient } = useApiClient();
 
-  // const [formTemplateUUID, setFormTemplateUUID] = useLocalStorage<
-  //   string | undefined
-  // >(SAMPLE_FORM_TEMPLATE_KEY, undefined);
-
   const [sampleFormTemplate, setSampleFormTemplate] = useLocalStorage<
     PersistedResource<FormTemplate> | undefined
   >(SAMPLE_FORM_TEMPLATE_KEY, undefined);

--- a/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
+++ b/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
@@ -17,6 +17,8 @@ import {
 import { materialSampleFormTemplateSchema } from "./materialSampleFormViewConfigSchema";
 import { useMaterialSampleFormTemplateProps } from "./useMaterialSampleFormTemplateProps";
 import { useLocalStorage } from "@rehooks/local-storage";
+import { PcrBatch } from "packages/dina-ui/types/seqdb-api";
+import { useApiClient } from "packages/common-ui/lib";
 
 const SAMPLE_FORM_TEMPLATE_KEY = "sampleFormTemplateKey";
 /**
@@ -25,9 +27,32 @@ const SAMPLE_FORM_TEMPLATE_KEY = "sampleFormTemplateKey";
  * Only handles Form Templates (e.g. show/hide fields), not default values.
  */
 export function useMaterialSampleFormTemplateSelectState() {
+  const { apiClient } = useApiClient();
+
+  // const [formTemplateUUID, setFormTemplateUUID] = useLocalStorage<
+  //   string | undefined
+  // >(SAMPLE_FORM_TEMPLATE_KEY, undefined);
+
   const [sampleFormTemplate, setSampleFormTemplate] = useLocalStorage<
     PersistedResource<FormTemplate> | undefined
   >(SAMPLE_FORM_TEMPLATE_KEY, undefined);
+
+  useEffect(() => {
+    if (sampleFormTemplate?.id) {
+      getFormTemplate();
+    }
+  }, [sampleFormTemplate]);
+
+  async function getFormTemplate() {
+    await apiClient
+      .get<FormTemplate>(
+        `collection-api/form-template/${sampleFormTemplate?.id}`,
+        {}
+      )
+      .then((response) => {
+        setSampleFormTemplate(response?.data);
+      });
+  }
 
   // Get initial values of data components
   const materialSampleComponent =


### PR DESCRIPTION
- Now uses the local storage Form Template's UUID to retrieve Form from back end
- This should allow Material Sample to reflect any changes made to Form Template