### PR TITLE
28919 Remove Virus Name checkbox on name search

### DIFF
--- a/packages/common-ui/lib/util/useThrottledFetch.tsx
+++ b/packages/common-ui/lib/util/useThrottledFetch.tsx
@@ -6,14 +6,12 @@ export interface UseThrottledFetchParams<TData> {
   fetcher: (query: string) => Promise<TData>;
   timeoutMs: number;
   initSearchValue?: string;
-  isVirusName?: boolean;
 }
 
 export function useThrottledFetch<TData>({
   fetcher,
   timeoutMs,
-  initSearchValue,
-  isVirusName
+  initSearchValue
 }: UseThrottledFetchParams<TData>) {
   /** The value of the input element. */
   const [inputValue, setInputValue] = useState(initSearchValue ?? "");
@@ -35,10 +33,10 @@ export function useThrottledFetch<TData>({
       const throttleReset = setTimeout(() => setThrottled(false), timeoutMs);
       return () => clearTimeout(throttleReset);
     }
-  }, [searchValue, isVirusName]);
+  }, [searchValue]);
 
   const { isValidating: searchIsLoading, data: mySearchResult } = useSWR(
-    [searchValue, isVirusName],
+    [searchValue],
     () => fetcher(searchValue),
     {
       shouldRetryOnError: false,
@@ -47,11 +45,7 @@ export function useThrottledFetch<TData>({
     }
   );
 
-  let searchResult;
-
-  // tslint:disable: no-string-literal
-  if (isVirusName) searchResult = mySearchResult?.["names"];
-  else searchResult = mySearchResult;
+  const searchResult: any = mySearchResult;
 
   const searchIsDisabled = throttled || !inputValue || searchIsLoading;
 

--- a/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
+++ b/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
@@ -46,6 +46,9 @@ export function useMaterialSampleFormTemplateSelectState() {
       )
       .then((response) => {
         setSampleFormTemplate(response?.data);
+      })
+      .catch(() => {
+        setSampleFormTemplate(undefined);
       });
   }
 

--- a/packages/dina-ui/components/collection/global-names/GlobalNamesSearchBox.tsx
+++ b/packages/dina-ui/components/collection/global-names/GlobalNamesSearchBox.tsx
@@ -54,7 +54,6 @@ export function GlobalNamesSearchBox({
   dateSupplier = () => moment().format("YYYY-MM-DD") // Today
 }: GlobalNamesSearchBoxProps) {
   const { formatMessage } = useDinaIntl();
-  const [isVirusName, setIsVirusName] = useState(false);
 
   const {
     searchIsLoading,
@@ -67,9 +66,7 @@ export function GlobalNamesSearchBox({
     fetcher: (searchValue) => {
       searchValue = searchValue.replace(/\s+/g, " ").trim();
       return globalNamesQuery<GlobalNamesSearchResult[]>({
-        url: `https://verifier.globalnames.org/api/${
-          isVirusName ? "v0" : "v1"
-        }/verifications/${
+        url: `https://verifier.globalnames.org/api/v1/verifications/${
           searchValue[0].toUpperCase() + searchValue.substring(1)
         }`,
         params: {
@@ -80,8 +77,7 @@ export function GlobalNamesSearchBox({
       });
     },
     timeoutMs: 1000,
-    initSearchValue,
-    isVirusName
+    initSearchValue
   });
 
   const onInputChange = (value) => {
@@ -92,10 +88,6 @@ export function GlobalNamesSearchBox({
       setValue?.(value);
       onChange?.(value, formik as any);
     }
-  };
-
-  const onVirusNameChange = (value) => {
-    setIsVirusName(value.checked);
   };
 
   return (
@@ -117,20 +109,6 @@ export function GlobalNamesSearchBox({
                 }}
                 value={inputValue}
               />
-              <label className="mx-2">
-                <strong>{formatMessage("virusNames")}</strong>
-                <input
-                  type="checkbox"
-                  className="global-name-virus-check"
-                  style={{
-                    display: "block",
-                    height: "20px",
-                    marginLeft: "15px",
-                    width: "20px"
-                  }}
-                  onChange={(e) => onVirusNameChange(e.target)}
-                />
-              </label>
               <button
                 style={{ width: "10rem" }}
                 onClick={doThrottledSearch}

--- a/packages/dina-ui/components/collection/global-names/GlobalNamesSearchBox.tsx
+++ b/packages/dina-ui/components/collection/global-names/GlobalNamesSearchBox.tsx
@@ -1,16 +1,10 @@
-import {
-  FormikButton,
-  LoadingSpinner,
-  Tooltip,
-  useThrottledFetch
-} from "common-ui";
+import { FormikButton, LoadingSpinner, useThrottledFetch } from "common-ui";
 import DOMPurify from "dompurify";
 import { Field, FormikProps } from "formik";
 import moment from "moment";
 import { ScientificNameSourceDetails } from "../../../../dina-ui/types/collection-api/resources/Determination";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import { GlobalNamesSearchResult } from "./global-names-search-result-type";
-import { useState } from "react";
 
 export type Selection =
   | string

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -792,7 +792,6 @@ export const DINAUI_MESSAGES_ENGLISH = {
   viewDetailButtonLabel: " View Detail",
   viewOnMap: "View on Map",
   viewPreviewButtonText: "Preview",
-  virusNames: "Virus Names",
   warningMessage: "Warning Message",
   whoAmITitle: "Who Am I",
   withAKeyboard: "With a keyboard",

--- a/packages/dina-ui/intl/dina-ui-fr.ts
+++ b/packages/dina-ui/intl/dina-ui-fr.ts
@@ -665,7 +665,6 @@ export const DINAUI_MESSAGES_FRENCH: Partial<typeof DINAUI_MESSAGES_ENGLISH> = {
   viewDetailButtonLabel: "Afficher détails",
   viewOnMap: "Visualiser sur la carte",
   viewPreviewButtonText: "Prévisualiser",
-  virusNames: "Nom du virus",
   warningMessage: "Messages d’avertissement",
   whoAmITitle: "Qui suis-je?",
   withAKeyboard: "Avec un clavier",


### PR DESCRIPTION
- Removed Virus Name checkbox and code
- Now correctly finds virus names by default
- Fixed a bug when a Form Template is saved in Material Sample local storage but the Form Template is deleted