### PR TITLE
29175 handle 403 error

### DIFF
--- a/packages/dina-ui/components/object-store/file-upload/FileUploadProvider.tsx
+++ b/packages/dina-ui/components/object-store/file-upload/FileUploadProvider.tsx
@@ -1,5 +1,5 @@
 import { ApiClientContext } from "common-ui";
-import { useDinaIntl } from "packages/dina-ui/intl/dina-ui-intl";
+import { useDinaIntl } from "../../../../dina-ui/intl/dina-ui-intl";
 import { createContext, useContext } from "react";
 import { ObjectUpload } from "../../../types/objectstore-api/resources/ObjectUpload";
 import { IFileWithMeta } from "./FileUploader";

--- a/packages/dina-ui/components/object-store/file-upload/FileUploadProvider.tsx
+++ b/packages/dina-ui/components/object-store/file-upload/FileUploadProvider.tsx
@@ -1,4 +1,5 @@
 import { ApiClientContext } from "common-ui";
+import { useDinaIntl } from "packages/dina-ui/intl/dina-ui-intl";
 import { createContext, useContext } from "react";
 import { ObjectUpload } from "../../../types/objectstore-api/resources/ObjectUpload";
 import { IFileWithMeta } from "./FileUploader";
@@ -27,6 +28,7 @@ export const FileUploadProvider = FileUploadContext.Provider;
 
 export function FileUploadProviderImpl({ children }) {
   const { apiClient } = useContext(ApiClientContext);
+  const { formatMessage } = useDinaIntl();
 
   async function uploadFiles({ files, group }: UploadFileParams) {
     const uploadRespsT: ObjectUpload[] = [];
@@ -40,7 +42,8 @@ export function FileUploadProviderImpl({ children }) {
         `/objectstore-api/file/${group}`,
         formData,
         {
-          transformResponse: (data) => fileUploadErrorHandler(data, file),
+          transformResponse: (data) =>
+            fileUploadErrorHandler(data, file, formatMessage),
           timeout: 0
         }
       );
@@ -56,7 +59,11 @@ export function FileUploadProviderImpl({ children }) {
 }
 
 /** Errors are handled differently here because they come from Spring Boot instead of Crnk. */
-export function fileUploadErrorHandler(data: string, file: File) {
+export function fileUploadErrorHandler(
+  data: string,
+  file: File,
+  formatMessage
+) {
   // Custom spring boot error handling to get the correct error message:
   let parsedData;
 
@@ -66,10 +73,10 @@ export function fileUploadErrorHandler(data: string, file: File) {
     // Check if the error is a Unsupported Media Type error.
     if (data.includes("Unsupported Media Type")) {
       throw new Error(
-        "The '" +
-          file.name +
-          "' file cannot be uploaded since it's an unsupported file type."
+        formatMessage("unsupportedFileTypeError", { fileName: file.name })
       );
+    } else if (data.includes("HTTP Status 403")) {
+      throw new Error(formatMessage("http403ForbiddenError"));
     }
 
     // Otherwise, just display the error message.

--- a/packages/dina-ui/components/object-store/metadata/useMetadata.tsx
+++ b/packages/dina-ui/components/object-store/metadata/useMetadata.tsx
@@ -22,6 +22,7 @@ export function useMetadataEditQuery(id?: string | null) {
       include: "dcCreator,derivatives"
     },
     {
+      disabled: !id,
       joinSpecs: [
         // Join to persons api:
         {

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -811,5 +811,8 @@ export const DINAUI_MESSAGES_ENGLISH = {
   yearMonthDayTime: "Year-Month-Day-Time",
   dataType: "Type: ",
   dataValue: "Value: ",
-  unit: "Unit: "
+  unit: "Unit: ",
+  http403ForbiddenError: "Access is denied",
+  unsupportedFileTypeError:
+    'The "{fileName}" file cannot be uploaded since it\'s an unsupported file type.'
 };

--- a/packages/dina-ui/page-tests/object-store/__tests__/upload.test.tsx
+++ b/packages/dina-ui/page-tests/object-store/__tests__/upload.test.tsx
@@ -12,6 +12,7 @@ import UploadPage, {
 import { mountWithAppContext } from "../../../test-util/mock-app-context";
 
 const mockPush = jest.fn();
+const mockFormatMessage = jest.fn();
 
 jest.mock("next/router", () => ({
   useRouter: () => ({
@@ -121,9 +122,13 @@ describe("Upload page", () => {
   it("Throws file upload errors with a readable message.", (done) => {
     const exampleErrorResponse = `{"errors": [{ "detail": "Error from Spring" }]}`;
     try {
-      fileUploadErrorHandler(exampleErrorResponse, {
-        name: "fileName"
-      } as File);
+      fileUploadErrorHandler(
+        exampleErrorResponse,
+        {
+          name: "fileName"
+        } as File,
+        mockFormatMessage
+      );
     } catch (error) {
       expect(error.message).toEqual("Error from Spring");
       done();
@@ -133,13 +138,34 @@ describe("Upload page", () => {
   it("Throws file upload error when unsupported file type is provided.", (done) => {
     const exampleErrorResponse = "<h1>Unsupported Media Type</h1>";
     try {
-      fileUploadErrorHandler(exampleErrorResponse, {
-        name: "fileName_test.png"
-      } as File);
-    } catch (error) {
-      expect(error.message).toEqual(
-        "The 'fileName_test.png' file cannot be uploaded since it's an unsupported file type."
+      fileUploadErrorHandler(
+        exampleErrorResponse,
+        {
+          name: "fileName_test.png"
+        } as File,
+        mockFormatMessage
       );
+    } catch (error) {
+      expect(mockFormatMessage).toHaveBeenCalledWith(
+        "unsupportedFileTypeError",
+        { fileName: "fileName_test.png" }
+      );
+      done();
+    }
+  });
+
+  it("Handle http status 403 error", (done) => {
+    const exampleErrorResponse = "HTTP Status 403 forbidden";
+    try {
+      fileUploadErrorHandler(
+        exampleErrorResponse,
+        {
+          name: "fileName_test.png"
+        } as File,
+        mockFormatMessage
+      );
+    } catch (error) {
+      expect(mockFormatMessage).toHaveBeenCalledWith("http403ForbiddenError");
       done();
     }
   });

--- a/packages/dina-ui/pages/_app.tsx
+++ b/packages/dina-ui/pages/_app.tsx
@@ -44,8 +44,8 @@ export default function DinaUiApp({ Component, pageProps }: AppProps) {
     <ApiClientImplProvider>
       <KeycloakAccountProvider>
         <AuthenticatedApiClientProvider>
-          <FileUploadProviderImpl>
-            <DinaIntlProvider>
+          <DinaIntlProvider>
+            <FileUploadProviderImpl>
               <ErrorBoundaryPage>
                 <DndProvider backend={HTML5Backend}>
                   <ModalProvider appElement={appElement}>
@@ -53,8 +53,8 @@ export default function DinaUiApp({ Component, pageProps }: AppProps) {
                   </ModalProvider>
                 </DndProvider>
               </ErrorBoundaryPage>
-            </DinaIntlProvider>
-          </FileUploadProviderImpl>
+            </FileUploadProviderImpl>
+          </DinaIntlProvider>
         </AuthenticatedApiClientProvider>
       </KeycloakAccountProvider>
     </ApiClientImplProvider>

--- a/packages/dina-ui/test-util/mock-app-context.tsx
+++ b/packages/dina-ui/test-util/mock-app-context.tsx
@@ -29,6 +29,7 @@ interface MockAppContextProviderProps {
 export function MockAppContextProvider({
   accountContext,
   apiContext = { apiClient: { get: () => undefined as any } },
+
   children
 }: MockAppContextProviderProps) {
   const DEFAULT_MOCK_ACCOUNT_CONTEXT: AccountContextI = useMemo(
@@ -88,8 +89,8 @@ export function MockAppContextProvider({
         <ApiClientProvider
           value={merge({}, DEFAULT_API_CONTEXT_VALUE, apiContextWithWarnings)}
         >
-          <FileUploadProviderImpl>
-            <DinaIntlProvider>
+          <DinaIntlProvider>
+            <FileUploadProviderImpl>
               <DndProvider backend={HTML5Backend}>
                 <div ref={modalWrapperRef}>
                   <ModalProvider appElement={modalWrapperRef.current}>
@@ -97,8 +98,8 @@ export function MockAppContextProvider({
                   </ModalProvider>
                 </div>
               </DndProvider>
-            </DinaIntlProvider>
-          </FileUploadProviderImpl>
+            </FileUploadProviderImpl>
+          </DinaIntlProvider>
         </ApiClientProvider>
       </AccountProvider>
     </SWRConfig>


### PR DESCRIPTION
1. Handle http status 403 error.
2. Turn unsupported file type error message to support multiplelingual message.
3. Fixed the undefined primary key get issue.