### PR TITLE
29988 Hide acquisition event

### DIFF
--- a/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
+++ b/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
@@ -243,11 +243,7 @@ describe("Material sample bulk edit tab", () => {
       // Keeps the name and type:
       type: "material-sample",
       materialSampleName: "test-sample",
-      // Adds the acq event and Col event:
-      acquisitionEvent: {
-        id: "11111111-1111-1111-1111-111111111111",
-        type: "acquisition-event"
-      },
+      // Adds the Col event:
       collectingEvent: {
         id: "11111111-1111-1111-1111-111111111111",
         type: "collecting-event"

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
@@ -2796,10 +2796,10 @@ describe("MaterialSampleBulkEditor", () => {
       .find(ReactSwitch)
       .prop<any>("onChange")(true);
     // Enable the acquisition event section:
-    wrapper
-      .find(".sample-tabpanel-0 .enable-acquisition-event")
-      .find(ReactSwitch)
-      .prop<any>("onChange")(true);
+    // wrapper
+    //   .find(".sample-tabpanel-0 .enable-acquisition-event")
+    //   .find(ReactSwitch)
+    //   .prop<any>("onChange")(true);
 
     await new Promise(setImmediate);
     wrapper.update();
@@ -2811,13 +2811,13 @@ describe("MaterialSampleBulkEditor", () => {
           " .dwcVerbatimLocality-field input"
       )
       .simulate("change", { target: { value: "test locality" } });
-    wrapper
-      .find(
-        ".sample-tabpanel-0 #" +
-          ACQUISITION_EVENT_COMPONENT_NAME +
-          " .receptionRemarks-field textarea"
-      )
-      .simulate("change", { target: { value: "test remarks" } });
+    // wrapper
+    //   .find(
+    //     ".sample-tabpanel-0 #" +
+    //       ACQUISITION_EVENT_COMPONENT_NAME +
+    //       " .receptionRemarks-field textarea"
+    //   )
+    //   .simulate("change", { target: { value: "test remarks" } });
 
     // Save the samples:
     wrapper.find("button.bulk-save-button").simulate("click");
@@ -2840,27 +2840,27 @@ describe("MaterialSampleBulkEditor", () => {
         { apiBaseUrl: "/collection-api" }
       ],
       // Creates the new Acq Event:
-      [
-        [
-          {
-            resource: {
-              receptionRemarks: "test remarks",
-              type: "acquisition-event"
-            },
-            type: "acquisition-event"
-          }
-        ],
-        { apiBaseUrl: "/collection-api" }
-      ],
+      // [
+      //   [
+      //     {
+      //       resource: {
+      //         receptionRemarks: "test remarks",
+      //         type: "acquisition-event"
+      //       },
+      //       type: "acquisition-event"
+      //     }
+      //   ],
+      //   { apiBaseUrl: "/collection-api" }
+      // ],
       [
         [
           // Creates the first sample with the attached events:
           {
             resource: expect.objectContaining({
-              acquisitionEvent: {
-                id: "11111",
-                type: "acquisition-event"
-              },
+              // acquisitionEvent: {
+              //   id: "11111",
+              //   type: "acquisition-event"
+              // },
               collectingEvent: {
                 id: "11111",
                 type: "collecting-event"
@@ -2872,10 +2872,10 @@ describe("MaterialSampleBulkEditor", () => {
           // Creates the next 2 samples without the attached events:
           {
             resource: expect.objectContaining({
-              acquisitionEvent: {
-                id: null,
-                type: "acquisition-event"
-              },
+              // acquisitionEvent: {
+              //   id: null,
+              //   type: "acquisition-event"
+              // },
               collectingEvent: {
                 id: null,
                 type: "collecting-event"
@@ -2886,10 +2886,10 @@ describe("MaterialSampleBulkEditor", () => {
           },
           {
             resource: expect.objectContaining({
-              acquisitionEvent: {
-                id: null,
-                type: "acquisition-event"
-              },
+              // acquisitionEvent: {
+              //   id: null,
+              //   type: "acquisition-event"
+              // },
               collectingEvent: {
                 id: null,
                 type: "collecting-event"

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -273,36 +273,37 @@ export function MaterialSampleForm({
           targetType="materialSample"
         />
       ),
-    [ACQUISITION_EVENT_COMPONENT_NAME]: (id) =>
-      dataComponentState.enableAcquisitionEvent && (
-        <TabbedResourceLinker<AcquisitionEvent>
-          fieldSetId={id}
-          legend={<DinaMessage id="acquisitionEvent" />}
-          briefDetails={(acqEvent) => (
-            <DinaForm initialValues={acqEvent} readOnly={true}>
-              <AcquisitionEventFormLayout />
-            </DinaForm>
-          )}
-          linkerTabContent={
-            reduceRendering ? null : (
-              <AcquisitionEventLinker
-                onAcquisitionEventSelect={(acqEventToLink) => {
-                  setAcqEventId(acqEventToLink.id);
-                }}
-              />
-            )
-          }
-          nestedForm={nestedAcqEventForm}
-          useResourceQuery={useAcquisitionEvent}
-          setResourceId={setAcqEventId}
-          disableLinkerTab={templateAttachesAcquisitionEvent}
-          readOnlyLink="/collection/acquisition-event/view?id="
-          resourceId={acqEventId}
-          fieldName="acquisitionEvent"
-          targetType="materialSample"
-          hideLinkerTab={hideLinkerTab}
-        />
-      ),
+    // TODO: Remove this block when Acquisition Event is confirmed to be removed entirely
+    // [ACQUISITION_EVENT_COMPONENT_NAME]: (id) =>
+    //   dataComponentState.enableAcquisitionEvent && (
+    //     <TabbedResourceLinker<AcquisitionEvent>
+    //       fieldSetId={id}
+    //       legend={<DinaMessage id="acquisitionEvent" />}
+    //       briefDetails={(acqEvent) => (
+    //         <DinaForm initialValues={acqEvent} readOnly={true}>
+    //           <AcquisitionEventFormLayout />
+    //         </DinaForm>
+    //       )}
+    //       linkerTabContent={
+    //         reduceRendering ? null : (
+    //           <AcquisitionEventLinker
+    //             onAcquisitionEventSelect={(acqEventToLink) => {
+    //               setAcqEventId(acqEventToLink.id);
+    //             }}
+    //           />
+    //         )
+    //       }
+    //       nestedForm={nestedAcqEventForm}
+    //       useResourceQuery={useAcquisitionEvent}
+    //       setResourceId={setAcqEventId}
+    //       disableLinkerTab={templateAttachesAcquisitionEvent}
+    //       readOnlyLink="/collection/acquisition-event/view?id="
+    //       resourceId={acqEventId}
+    //       fieldName="acquisitionEvent"
+    //       targetType="materialSample"
+    //       hideLinkerTab={hideLinkerTab}
+    //     />
+    //   ),
     [PREPARATIONS_COMPONENT_NAME]: (id) =>
       !reduceRendering &&
       dataComponentState.enablePreparations && <PreparationField id={id} />,

--- a/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
+++ b/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
@@ -12,7 +12,7 @@ import {
   COLLECTING_EVENT_COMPONENT_NAME,
   MaterialSample,
   ORGANISMS_COMPONENT_NAME,
-  STORAGE_COMPONENT_NAME,
+  STORAGE_COMPONENT_NAME
 } from "../../../../types/collection-api";
 
 // Mock out the dynamic component, which should only be rendered in the browser
@@ -28,7 +28,7 @@ function testCollectionEvent(): Partial<CollectingEvent> {
     verbatimEventDateTime: "2021-04-13",
     id: "1",
     type: "collecting-event",
-    group: "test group",
+    group: "test group"
   };
 }
 
@@ -39,7 +39,7 @@ function testAcquisitionEvent(): Partial<AcquisitionEvent> {
     group: "test group",
     createdBy: "poffm",
     createdOn: "2021-11-15",
-    receptionRemarks: "test reception remarks",
+    receptionRemarks: "test reception remarks"
   };
 }
 
@@ -51,14 +51,14 @@ function testMaterialSample(): InputResource<MaterialSample> {
     materialSampleName: "my-sample-name",
     collectingEvent: {
       id: "1",
-      type: "collecting-event",
+      type: "collecting-event"
     },
     acquisitionEvent: {
       id: "1",
-      type: "acquisition-event",
+      type: "acquisition-event"
     },
     attachment: [{ id: "attach-1", type: "metadata" }],
-    ...blankMaterialSample(),
+    ...blankMaterialSample()
   };
 }
 
@@ -80,8 +80,8 @@ const mockGet = jest.fn<any, any>(async (path) => {
     case "collection-api/material-sample":
       return {
         data: [
-          { id: "1", materialSampleName: "test name", type: "material-sample" },
-        ],
+          { id: "1", materialSampleName: "test name", type: "material-sample" }
+        ]
       };
     case "collection-api/preparation-type":
     case "collection-api/managed-attribute":
@@ -122,7 +122,7 @@ const mockSave = jest.fn<any, any>(async (saves) => {
     }
     return {
       ...save.resource,
-      id: save.resource.id ?? "11111111-1111-1111-1111-111111111111",
+      id: save.resource.id ?? "11111111-1111-1111-1111-111111111111"
     };
   });
 });
@@ -153,9 +153,9 @@ const testCtx = {
     bulkGet: mockBulkGet,
     save: mockSave,
     apiClient: {
-      get: mockGet,
-    },
-  },
+      get: mockGet
+    }
+  }
 };
 
 const mockOnSaved = jest.fn();
@@ -208,22 +208,22 @@ describe("Material Sample Edit Page", () => {
               dwcVerbatimSRS: "WGS84 (EPSG:4326)",
               geoReferenceAssertions: [
                 {
-                  isPrimary: true,
-                },
+                  isPrimary: true
+                }
               ],
               relationships: {
                 attachment: {
-                  data: [],
-                },
+                  data: []
+                }
               },
               verbatimEventDateTime: "2019-12-21T16:00",
               publiclyReleasable: true, // Default value
-              type: "collecting-event",
+              type: "collecting-event"
             },
-            type: "collecting-event",
-          },
+            type: "collecting-event"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       [
         // New material-sample:
@@ -232,12 +232,12 @@ describe("Material Sample Edit Page", () => {
             resource: {
               acquisitionEvent: {
                 id: null,
-                type: "acquisition-event",
+                type: "acquisition-event"
               },
               associations: [],
               collectingEvent: {
                 id: "11111111-1111-1111-1111-111111111111",
-                type: "collecting-event",
+                type: "collecting-event"
               },
               storageUnit: { id: null, type: "storage-unit" },
               materialSampleName: "test-material-sample-id",
@@ -256,13 +256,13 @@ describe("Material Sample Edit Page", () => {
               restrictionRemarks: null,
               scheduledAction: undefined,
               preparationMethod: undefined,
-              collection: undefined,
+              collection: undefined
             },
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -310,12 +310,12 @@ describe("Material Sample Edit Page", () => {
             resource: {
               acquisitionEvent: {
                 id: null,
-                type: "acquisition-event",
+                type: "acquisition-event"
               },
               associations: [],
               collectingEvent: {
                 id: "1",
-                type: "collecting-event",
+                type: "collecting-event"
               },
               storageUnit: { id: null, type: "storage-unit" },
               materialSampleName: "test-material-sample-id",
@@ -335,14 +335,14 @@ describe("Material Sample Edit Page", () => {
               restrictionRemarks: null,
               scheduledAction: undefined,
               relationships: {
-                organism: { data: [] },
-              },
+                organism: { data: [] }
+              }
             },
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -382,13 +382,13 @@ describe("Material Sample Edit Page", () => {
               id: "1",
               type: "material-sample",
               materialSampleName: "test-material-sample-id",
-              relationships: {},
+              relationships: {}
             },
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -444,22 +444,22 @@ describe("Material Sample Edit Page", () => {
               dwcVerbatimSRS: "WGS84 (EPSG:4326)",
               geoReferenceAssertions: [
                 {
-                  isPrimary: true,
-                },
+                  isPrimary: true
+                }
               ],
               relationships: {
                 attachment: {
-                  data: [],
-                },
+                  data: []
+                }
               },
               verbatimEventDateTime: "2019-12-21T16:00",
               publiclyReleasable: true, // Default Value
-              type: "collecting-event",
+              type: "collecting-event"
             },
-            type: "collecting-event",
-          },
+            type: "collecting-event"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       [
         // Existing material-sample updated:
@@ -468,17 +468,17 @@ describe("Material Sample Edit Page", () => {
             resource: {
               collectingEvent: {
                 id: "11111111-1111-1111-1111-111111111111",
-                type: "collecting-event",
+                type: "collecting-event"
               },
               id: "1",
               type: "material-sample",
-              relationships: {},
+              relationships: {}
             },
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -492,8 +492,8 @@ describe("Material Sample Edit Page", () => {
           preparationType: {
             id: "65765",
             type: "preparation-type",
-            name: "test-prep-type",
-          } as KitsuResourceLink,
+            name: "test-prep-type"
+          } as KitsuResourceLink
         }}
         onSaved={mockOnSaved}
       />,
@@ -519,8 +519,8 @@ describe("Material Sample Edit Page", () => {
           storageUnit: {
             id: "76575",
             type: "storage-unit",
-            name: "test-storage-unit",
-          } as KitsuResourceLink,
+            name: "test-storage-unit"
+          } as KitsuResourceLink
         }}
         onSaved={mockOnSaved}
       />,
@@ -548,10 +548,10 @@ describe("Material Sample Edit Page", () => {
             {
               type: "organism",
               determination: [
-                { verbatimScientificName: "test verbatim scientific name" },
-              ],
-            },
-          ],
+                { verbatimScientificName: "test verbatim scientific name" }
+              ]
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -576,8 +576,8 @@ describe("Material Sample Edit Page", () => {
           id: "333",
           materialSampleName: "test-ms",
           associations: [
-            { associatedSample: "test name", associationType: "host" },
-          ],
+            { associatedSample: "test name", associationType: "host" }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -603,7 +603,7 @@ describe("Material Sample Edit Page", () => {
           ...testMaterialSample(),
           id: "333",
           materialSampleName: "test-ms",
-          associations: [{ associatedSample: "1", associationType: "host" }],
+          associations: [{ associatedSample: "1", associationType: "host" }]
         }}
         onSaved={mockOnSaved}
       />,
@@ -636,15 +636,15 @@ describe("Material Sample Edit Page", () => {
               relationships: {},
               attachment: undefined,
               projects: undefined,
-              type: "material-sample",
+              type: "material-sample"
             },
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
         {
-          apiBaseUrl: "/collection-api",
-        },
-      ],
+          apiBaseUrl: "/collection-api"
+        }
+      ]
     ]);
   });
 
@@ -656,7 +656,7 @@ describe("Material Sample Edit Page", () => {
           id: "333",
           materialSampleName: "test-ms",
           attachment: [],
-          organism: [],
+          organism: []
         }}
         onSaved={mockOnSaved}
       />,
@@ -670,12 +670,12 @@ describe("Material Sample Edit Page", () => {
     expect(
       wrapper.find(".enable-collecting-event").find(ReactSwitch).prop("checked")
     ).toEqual(false);
-    expect(
-      wrapper
-        .find(".enable-acquisition-event")
-        .find(ReactSwitch)
-        .prop("checked")
-    ).toEqual(false);
+    // expect(
+    //   wrapper
+    //     .find(".enable-acquisition-event")
+    //     .find(ReactSwitch)
+    //     .prop("checked")
+    // ).toEqual(false);
     expect(
       wrapper.find(".enable-catalogue-info").find(ReactSwitch).prop("checked")
     ).toEqual(false);
@@ -701,8 +701,8 @@ describe("Material Sample Edit Page", () => {
           id: "333",
           materialSampleName: "test-ms",
           managedAttributes: {
-            test_attr: "do the test",
-          },
+            test_attr: "do the test"
+          }
         }}
         onSaved={mockOnSaved}
       />,
@@ -724,15 +724,15 @@ describe("Material Sample Edit Page", () => {
             resource: {
               id: "333",
               relationships: {},
-              type: "material-sample",
+              type: "material-sample"
             },
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
         {
-          apiBaseUrl: "/collection-api",
-        },
-      ],
+          apiBaseUrl: "/collection-api"
+        }
+      ]
     ]);
   });
 
@@ -748,7 +748,7 @@ describe("Material Sample Edit Page", () => {
     // Set the group:
     wrapper.find(".group-field Select").prop<any>("onChange")({
       label: "group",
-      value: "test group",
+      value: "test group"
     });
 
     wrapper
@@ -804,25 +804,25 @@ describe("Material Sample Edit Page", () => {
               determination: [
                 {
                   verbatimDeterminer: "test-agent-1",
-                  verbatimScientificName: "test-name-1",
+                  verbatimScientificName: "test-name-1"
                 },
                 {
                   verbatimDeterminer: "test-agent-2",
-                  verbatimScientificName: "test-name-2",
+                  verbatimScientificName: "test-name-2"
                 },
                 {
                   verbatimDeterminer: "test-agent-3",
-                  verbatimScientificName: "test-name-3",
-                },
+                  verbatimScientificName: "test-name-3"
+                }
               ],
               // The organism should get the same group as the Material Sample:
               group: "test group",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       // Submits the sample with the linked organism:
       [
@@ -835,18 +835,18 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     {
                       id: "11111111-1111-1111-1111-111111111111",
-                      type: "organism",
-                    },
-                  ],
-                },
+                      type: "organism"
+                    }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -857,36 +857,36 @@ describe("Material Sample Edit Page", () => {
         type: "material-sample",
         createdBy: "Mat",
         createdOn: "2020-05-04",
-        materialSampleName: "MY-SAMPLE-001",
+        materialSampleName: "MY-SAMPLE-001"
       })
     ).toEqual({
       // Omits id/createdBy/createdOn, increments the name:
       type: "material-sample",
-      materialSampleName: "MY-SAMPLE-002",
+      materialSampleName: "MY-SAMPLE-002"
     });
 
     expect(
       nextSampleInitialValues({
         id: "123",
         type: "material-sample",
-        materialSampleName: "MY-SAMPLE-9",
+        materialSampleName: "MY-SAMPLE-9"
       })
     ).toEqual({
       // Increments the name:
       type: "material-sample",
-      materialSampleName: "MY-SAMPLE-10",
+      materialSampleName: "MY-SAMPLE-10"
     });
 
     expect(
       nextSampleInitialValues({
         id: "123",
         type: "material-sample",
-        materialSampleName: "1-MY-SAMPLE",
+        materialSampleName: "1-MY-SAMPLE"
       })
     ).toEqual({
       // No way to increment the name, so it becomes blank:
       type: "material-sample",
-      materialSampleName: "",
+      materialSampleName: ""
     });
 
     // Organisms should not be linked to multiple Samples.
@@ -898,8 +898,8 @@ describe("Material Sample Edit Page", () => {
         materialSampleName: "MY-SAMPLE-100",
         organism: [
           { id: "organism-1", type: "organism", lifeStage: "test lifestage 1" },
-          { id: "organism-2", type: "organism", lifeStage: "test lifestage 2" },
-        ],
+          { id: "organism-2", type: "organism", lifeStage: "test lifestage 2" }
+        ]
       })
     ).toEqual({
       type: "material-sample",
@@ -907,195 +907,182 @@ describe("Material Sample Edit Page", () => {
       // The original organism IDs should be omitted:
       organism: [
         { type: "organism", lifeStage: "test lifestage 1" },
-        { type: "organism", lifeStage: "test lifestage 2" },
-      ],
+        { type: "organism", lifeStage: "test lifestage 2" }
+      ]
     });
   });
 
-  it("Creates a material sample with a new Acquisition Event", async () => {
-    const wrapper = mountWithAppContext(
-      <MaterialSampleForm onSaved={mockOnSaved} />,
-      testCtx
-    );
+  // it("Creates a material sample with a new Acquisition Event", async () => {
+  //   const wrapper = mountWithAppContext(
+  //     <MaterialSampleForm onSaved={mockOnSaved} />,
+  //     testCtx
+  //   );
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    // Enable Collecting Event and catalogue info form sections:
-    wrapper
-      .find(".enable-acquisition-event")
-      .find(Switch)
-      .prop<any>("onChange")(true);
+  //   // Enable Collecting Event and catalogue info form sections:
+  //   wrapper
+  //     .find(".enable-acquisition-event")
+  //     .find(Switch)
+  //     .prop<any>("onChange")(true);
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    wrapper
-      .find(".receptionRemarks-field textarea")
-      .simulate("change", { target: { value: "new acq event remarks" } });
+  //   wrapper
+  //     .find(".receptionRemarks-field textarea")
+  //     .simulate("change", { target: { value: "new acq event remarks" } });
 
-    wrapper.find("form").simulate("submit");
+  //   wrapper.find("form").simulate("submit");
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    // Saves the Acq Event and the Material Sample:
-    expect(mockSave.mock.calls).toEqual([
-      [
-        [
-          {
-            resource: {
-              receptionRemarks: "new acq event remarks",
-              type: "acquisition-event",
-            },
-            type: "acquisition-event",
-          },
-        ],
-        {
-          apiBaseUrl: "/collection-api",
-        },
-      ],
-      [
-        [
-          {
-            resource: expect.objectContaining({
-              acquisitionEvent: {
-                id: "11111111-1111-1111-1111-111111111111",
-                type: "acquisition-event",
-              },
-            }),
-            type: "material-sample",
-          },
-        ],
-        { apiBaseUrl: "/collection-api" },
-      ],
-    ]);
-  });
+  //   // Saves the Acq Event and the Material Sample:
+  //   expect(mockSave.mock.calls).toEqual([
+  //     [
+  //       [
+  //         {
+  //           resource: {
+  //             receptionRemarks: "new acq event remarks",
+  //             type: "acquisition-event",
+  //           },
+  //           type: "acquisition-event",
+  //         },
+  //       ],
+  //       {
+  //         apiBaseUrl: "/collection-api",
+  //       },
+  //     ],
+  //     [
+  //       [
+  //         {
+  //           resource: expect.objectContaining({
+  //             acquisitionEvent: {
+  //               id: "11111111-1111-1111-1111-111111111111",
+  //               type: "acquisition-event",
+  //             },
+  //           }),
+  //           type: "material-sample",
+  //         },
+  //       ],
+  //       { apiBaseUrl: "/collection-api" },
+  //     ],
+  //   ]);
+  // });
 
-  it("Created a material sample linked to an existing Acquisition event", async () => {
-    const wrapper = mountWithAppContext(
-      <MaterialSampleForm onSaved={mockOnSaved} />,
-      testCtx
-    );
+  // it("Created a material sample linked to an existing Acquisition event", async () => {
+  //   const wrapper = mountWithAppContext(
+  //     <MaterialSampleForm onSaved={mockOnSaved} />,
+  //     testCtx
+  //   );
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    // Enable Collecting Event and catalogue info form sections:
-    wrapper
-      .find(".enable-acquisition-event")
-      .find(Switch)
-      .prop<any>("onChange")(true);
+  //   // Enable Collecting Event and catalogue info form sections:
+  //   wrapper.find("form").simulate("submit");
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    wrapper.find("button.acquisition-event-link-button").simulate("click");
+  //   // Saves the Material Sample:
+  //   expect(mockSave.mock.calls).toEqual([
+  //     [
+  //       [
+  //         {
+  //           resource: expect.objectContaining({
+  //             acquisitionEvent: {
+  //               id: "1",
+  //               type: "acquisition-event",
+  //             },
+  //           }),
+  //           type: "material-sample",
+  //         },
+  //       ],
+  //       {
+  //         apiBaseUrl: "/collection-api",
+  //       },
+  //     ],
+  //   ]);
+  // });
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  // it("Lets you remove the attached Acquisition Event", async () => {
+  //   const wrapper = mountWithAppContext(
+  //     <MaterialSampleForm
+  //       materialSample={testMaterialSample()}
+  //       onSaved={mockOnSaved}
+  //     />,
+  //     testCtx
+  //   );
 
-    wrapper.find("form").simulate("submit");
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   // Existing AcquisitionEvent should show up:
+  //   expect(
+  //     wrapper.find(".receptionRemarks-field textarea").prop("value")
+  //   ).toEqual("test reception remarks");
 
-    // Saves the Material Sample:
-    expect(mockSave.mock.calls).toEqual([
-      [
-        [
-          {
-            resource: expect.objectContaining({
-              acquisitionEvent: {
-                id: "1",
-                type: "acquisition-event",
-              },
-            }),
-            type: "material-sample",
-          },
-        ],
-        {
-          apiBaseUrl: "/collection-api",
-        },
-      ],
-    ]);
-  });
+  //   wrapper
+  //     .find(
+  //       "#" +
+  //         ACQUISITION_EVENT_COMPONENT_NAME +
+  //         " button.detach-resource-button"
+  //     )
+  //     .simulate("click");
 
-  it("Lets you remove the attached Acquisition Event", async () => {
-    const wrapper = mountWithAppContext(
-      <MaterialSampleForm
-        materialSample={testMaterialSample()}
-        onSaved={mockOnSaved}
-      />,
-      testCtx
-    );
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   // Existing AcquisitionEvent should be gone:
+  //   expect(
+  //     wrapper.find(".receptionRemarks-field textarea").prop("value")
+  //   ).toEqual("");
 
-    // Existing AcquisitionEvent should show up:
-    expect(
-      wrapper.find(".receptionRemarks-field textarea").prop("value")
-    ).toEqual("test reception remarks");
+  //   // Set the new Acquisition Event's receptionRemarks:
+  //   wrapper
+  //     .find(".receptionRemarks-field textarea")
+  //     .simulate("change", { target: { value: "new remarks value" } });
 
-    wrapper
-      .find(
-        "#" +
-          ACQUISITION_EVENT_COMPONENT_NAME +
-          " button.detach-resource-button"
-      )
-      .simulate("click");
+  //   wrapper.find("form").simulate("submit");
 
-    await new Promise(setImmediate);
-    wrapper.update();
+  //   await new Promise(setImmediate);
+  //   wrapper.update();
 
-    // Existing AcquisitionEvent should be gone:
-    expect(
-      wrapper.find(".receptionRemarks-field textarea").prop("value")
-    ).toEqual("");
-
-    // Set the new Acquisition Event's receptionRemarks:
-    wrapper
-      .find(".receptionRemarks-field textarea")
-      .simulate("change", { target: { value: "new remarks value" } });
-
-    wrapper.find("form").simulate("submit");
-
-    await new Promise(setImmediate);
-    wrapper.update();
-
-    expect(mockSave.mock.calls).toEqual([
-      [
-        [
-          {
-            resource: {
-              receptionRemarks: "new remarks value",
-              type: "acquisition-event",
-            },
-            type: "acquisition-event",
-          },
-        ],
-        { apiBaseUrl: "/collection-api" },
-      ],
-      [
-        [
-          {
-            resource: {
-              id: "1",
-              type: "material-sample",
-              acquisitionEvent: {
-                id: "11111111-1111-1111-1111-111111111111",
-                type: "acquisition-event",
-              },
-              relationships: {},
-            },
-            type: "material-sample",
-          },
-        ],
-        { apiBaseUrl: "/collection-api" },
-      ],
-    ]);
-  });
+  //   expect(mockSave.mock.calls).toEqual([
+  //     [
+  //       [
+  //         {
+  //           resource: {
+  //             receptionRemarks: "new remarks value",
+  //             type: "acquisition-event",
+  //           },
+  //           type: "acquisition-event",
+  //         },
+  //       ],
+  //       { apiBaseUrl: "/collection-api" },
+  //     ],
+  //     [
+  //       [
+  //         {
+  //           resource: {
+  //             id: "1",
+  //             type: "material-sample",
+  //             acquisitionEvent: {
+  //               id: "11111111-1111-1111-1111-111111111111",
+  //               type: "acquisition-event",
+  //             },
+  //             relationships: {},
+  //           },
+  //           type: "material-sample",
+  //         },
+  //       ],
+  //       { apiBaseUrl: "/collection-api" },
+  //     ],
+  //   ]);
+  // });
 
   it("Submits a new Material Sample with a duplicate sample name: Shows an error", async () => {
     const wrapper = mountWithAppContext(
@@ -1197,7 +1184,7 @@ describe("Material Sample Edit Page", () => {
           type: "material-sample",
           id: "333",
           group: "test-group",
-          materialSampleName: "test-ms",
+          materialSampleName: "test-ms"
         }}
         onSaved={mockOnSaved}
       />,
@@ -1236,12 +1223,12 @@ describe("Material Sample Edit Page", () => {
               // The group is copied from the sample:
               group: "test-group",
               lifeStage: "test lifestage",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       // Submits the sample:
       [
@@ -1254,18 +1241,18 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     {
                       id: "11111111-1111-1111-1111-111111111111",
-                      type: "organism",
-                    },
-                  ],
-                },
+                      type: "organism"
+                    }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1283,21 +1270,21 @@ describe("Material Sample Edit Page", () => {
               type: "organism",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              group: "test-group",
+              group: "test-group"
             },
             {
               type: "organism",
               id: "organism-2",
               lifeStage: "lifestage 2",
-              group: "test-group",
+              group: "test-group"
             },
             {
               type: "organism",
               id: "organism-3",
               lifeStage: "lifestage 3",
-              group: "test-group",
-            },
-          ],
+              group: "test-group"
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -1339,12 +1326,12 @@ describe("Material Sample Edit Page", () => {
               id: "organism-1",
               group: "test-group",
               lifeStage: "lifestage 1",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       [
         [
@@ -1356,18 +1343,18 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     {
                       id: "organism-1",
-                      type: "organism",
-                    },
-                  ],
-                },
+                      type: "organism"
+                    }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1385,15 +1372,15 @@ describe("Material Sample Edit Page", () => {
               type: "organism",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              group: "test-group",
+              group: "test-group"
             },
             {
               type: "organism",
               id: "organism-2",
               lifeStage: "lifestage 2",
-              group: "test-group",
-            },
-          ],
+              group: "test-group"
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -1432,12 +1419,12 @@ describe("Material Sample Edit Page", () => {
               group: "test-group",
               id: "organism-2",
               lifeStage: "lifestage 2",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       [
         [
@@ -1450,18 +1437,18 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     {
                       id: "organism-2",
-                      type: "organism",
-                    },
-                  ],
-                },
+                      type: "organism"
+                    }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1479,9 +1466,9 @@ describe("Material Sample Edit Page", () => {
               type: "organism",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              group: "test-group",
-            },
-          ],
+              group: "test-group"
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -1515,15 +1502,15 @@ describe("Material Sample Edit Page", () => {
           {
             resource: expect.objectContaining({
               relationships: expect.objectContaining({
-                organism: { data: [] },
+                organism: { data: [] }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1541,9 +1528,9 @@ describe("Material Sample Edit Page", () => {
               type: "organism",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              group: "test-group",
-            },
-          ],
+              group: "test-group"
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -1578,15 +1565,15 @@ describe("Material Sample Edit Page", () => {
           {
             resource: expect.objectContaining({
               relationships: expect.objectContaining({
-                organism: { data: [] },
+                organism: { data: [] }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1604,9 +1591,9 @@ describe("Material Sample Edit Page", () => {
               type: "organism",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              group: "test-group",
-            },
-          ],
+              group: "test-group"
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -1641,30 +1628,30 @@ describe("Material Sample Edit Page", () => {
               group: "test-group",
               id: "organism-1",
               lifeStage: "common-life-stage",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
+            type: "organism"
           },
           // New organism which is a copy of Organism #1:
           {
             resource: {
               group: "test-group",
               lifeStage: "common-life-stage",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
+            type: "organism"
           },
           // New organism which is a copy of Organism #1:
           {
             resource: {
               group: "test-group",
               lifeStage: "common-life-stage",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       [
         [
@@ -1677,26 +1664,26 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     {
                       id: "organism-1",
-                      type: "organism",
+                      type: "organism"
                     },
                     {
                       id: "11111111-1111-1111-1111-111111111111",
-                      type: "organism",
+                      type: "organism"
                     },
                     {
                       id: "11111111-1111-1111-1111-111111111111",
-                      type: "organism",
-                    },
-                  ],
-                },
+                      type: "organism"
+                    }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1714,21 +1701,21 @@ describe("Material Sample Edit Page", () => {
               type: "organism",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              group: "test-group",
+              group: "test-group"
             },
             {
               type: "organism",
               id: "organism-2",
               lifeStage: "lifestage 2",
-              group: "test-group",
+              group: "test-group"
             },
             {
               type: "organism",
               id: "organism-3",
               lifeStage: "lifestage 3",
-              group: "test-group",
-            },
-          ],
+              group: "test-group"
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -1777,18 +1764,18 @@ describe("Material Sample Edit Page", () => {
               group: "test-group",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
+            type: "organism"
           },
           {
             resource: {
               group: "test-group",
               id: "organism-2",
               lifeStage: "lifestage 2",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
+            type: "organism"
           },
           // Adds the new value to the 3rd organism:
           {
@@ -1796,12 +1783,12 @@ describe("Material Sample Edit Page", () => {
               group: "test-group",
               id: "organism-3",
               lifeStage: "lifestage 3 edited",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       [
         [
@@ -1813,17 +1800,17 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     { id: "organism-1", type: "organism" },
                     { id: "organism-2", type: "organism" },
-                    { id: "organism-3", type: "organism" },
-                  ],
-                },
+                    { id: "organism-3", type: "organism" }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1842,23 +1829,23 @@ describe("Material Sample Edit Page", () => {
               id: "organism-1",
               lifeStage: "lifestage 1",
               group: "test-group",
-              isTarget: true,
+              isTarget: true
             },
             {
               type: "organism",
               id: "organism-2",
               lifeStage: "lifestage 2",
               group: "test-group",
-              isTarget: false,
+              isTarget: false
             },
             {
               type: "organism",
               id: "organism-3",
               lifeStage: "lifestage 3",
               group: "test-group",
-              isTarget: false,
-            },
-          ],
+              isTarget: false
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -1905,9 +1892,9 @@ describe("Material Sample Edit Page", () => {
               id: "organism-1",
               lifeStage: "lifestage 1",
               type: "organism",
-              isTarget: null,
+              isTarget: null
             },
-            type: "organism",
+            type: "organism"
           },
           {
             resource: {
@@ -1915,9 +1902,9 @@ describe("Material Sample Edit Page", () => {
               id: "organism-2",
               lifeStage: "lifestage 1",
               type: "organism",
-              isTarget: null,
+              isTarget: null
             },
-            type: "organism",
+            type: "organism"
           },
           {
             resource: {
@@ -1925,12 +1912,12 @@ describe("Material Sample Edit Page", () => {
               id: "organism-3",
               lifeStage: "lifestage 1",
               type: "organism",
-              isTarget: null,
+              isTarget: null
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       // The material sample is saved with the same 3 organisms linked:
       [
@@ -1943,17 +1930,17 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     { id: "organism-1", type: "organism" },
                     { id: "organism-2", type: "organism" },
-                    { id: "organism-3", type: "organism" },
-                  ],
-                },
+                    { id: "organism-3", type: "organism" }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -1972,23 +1959,23 @@ describe("Material Sample Edit Page", () => {
               id: "organism-1",
               lifeStage: "lifestage 1",
               group: "test-group",
-              isTarget: false,
+              isTarget: false
             },
             {
               type: "organism",
               id: "organism-2",
               lifeStage: "lifestage 2",
               group: "test-group",
-              isTarget: true,
+              isTarget: true
             },
             {
               type: "organism",
               id: "organism-3",
               lifeStage: "lifestage 3",
               group: "test-group",
-              isTarget: false,
-            },
-          ],
+              isTarget: false
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -2036,9 +2023,9 @@ describe("Material Sample Edit Page", () => {
               id: "organism-1",
               lifeStage: "lifestage 1",
               type: "organism",
-              isTarget: true,
+              isTarget: true
             },
-            type: "organism",
+            type: "organism"
           },
           {
             resource: {
@@ -2046,9 +2033,9 @@ describe("Material Sample Edit Page", () => {
               id: "organism-2",
               lifeStage: "lifestage 2",
               type: "organism",
-              isTarget: false,
+              isTarget: false
             },
-            type: "organism",
+            type: "organism"
           },
           {
             resource: {
@@ -2056,12 +2043,12 @@ describe("Material Sample Edit Page", () => {
               id: "organism-3",
               lifeStage: "lifestage 3",
               type: "organism",
-              isTarget: false,
+              isTarget: false
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       // The material sample is saved with the same 3 organisms linked:
       [
@@ -2074,17 +2061,17 @@ describe("Material Sample Edit Page", () => {
                   data: [
                     { id: "organism-1", type: "organism" },
                     { id: "organism-2", type: "organism" },
-                    { id: "organism-3", type: "organism" },
-                  ],
-                },
+                    { id: "organism-3", type: "organism" }
+                  ]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -2110,9 +2097,9 @@ describe("Material Sample Edit Page", () => {
                     {
                       id: "person-1-uuid",
                       type: "person",
-                      displayName: "Person 1",
-                    },
-                  ],
+                      displayName: "Person 1"
+                    }
+                  ]
                 },
                 {
                   isPrimary: true,
@@ -2120,13 +2107,13 @@ describe("Material Sample Edit Page", () => {
                     {
                       id: "person-2-uuid",
                       type: "person",
-                      displayName: "Person 2",
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
+                      displayName: "Person 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }}
         onSaved={mockOnSaved}
       />,
@@ -2148,10 +2135,10 @@ describe("Material Sample Edit Page", () => {
         resource: {
           displayName: "Person 1",
           id: "person-1-uuid",
-          type: "person",
+          type: "person"
         },
-        value: "person-1-uuid",
-      },
+        value: "person-1-uuid"
+      }
     ]);
 
     // Add a second Person to the primary Determination's determiners:
@@ -2163,16 +2150,16 @@ describe("Material Sample Edit Page", () => {
         resource: {
           displayName: "Person 1",
           id: "person-1-uuid",
-          type: "person",
-        },
+          type: "person"
+        }
       },
       {
         resource: {
           displayName: "Person 2",
           id: "person-2-uuid",
-          type: "person",
-        },
-      },
+          type: "person"
+        }
+      }
     ]);
 
     await new Promise(setImmediate);
@@ -2194,22 +2181,22 @@ describe("Material Sample Edit Page", () => {
                 {
                   // The new value as IDs only:
                   determiner: ["person-1-uuid", "person-2-uuid"],
-                  isPrimary: true,
+                  isPrimary: true
                 },
                 {
                   determiner: ["person-2-uuid"],
-                  isPrimary: true,
-                },
+                  isPrimary: true
+                }
               ],
               group: "test-group",
               id: "organism-1",
               lifeStage: "lifestage 1",
-              type: "organism",
+              type: "organism"
             },
-            type: "organism",
-          },
+            type: "organism"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
+        { apiBaseUrl: "/collection-api" }
       ],
       [
         [
@@ -2218,16 +2205,16 @@ describe("Material Sample Edit Page", () => {
               id: "333",
               relationships: expect.objectContaining({
                 organism: {
-                  data: [{ id: "organism-1", type: "organism" }],
-                },
+                  data: [{ id: "organism-1", type: "organism" }]
+                }
               }),
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -2242,11 +2229,11 @@ describe("Material Sample Edit Page", () => {
           managedAttributes: {
             // Has existing attribute_1 and attribute_2 values:
             attribute_1: "attribute 1 value",
-            attribute_2: "attribute 2 value",
-          },
+            attribute_2: "attribute 2 value"
+          }
         }}
         visibleManagedAttributeKeys={{
-          materialSample: ["attribute_2", "attribute_3"],
+          materialSample: ["attribute_2", "attribute_3"]
         }}
         onSaved={mockOnSaved}
       />,
@@ -2285,15 +2272,15 @@ describe("Material Sample Edit Page", () => {
                 // The existing Attribute 1 value is kept event though it was hidden by the custom view:
                 attribute_1: "attribute 1 value",
                 // The new Attribute 2 value is saved:
-                attribute_2: "new attribute 2 value",
+                attribute_2: "new attribute 2 value"
               },
-              type: "material-sample",
+              type: "material-sample"
             }),
-            type: "material-sample",
-          },
+            type: "material-sample"
+          }
         ],
-        { apiBaseUrl: "/collection-api" },
-      ],
+        { apiBaseUrl: "/collection-api" }
+      ]
     ]);
   });
 
@@ -2304,10 +2291,10 @@ describe("Material Sample Edit Page", () => {
           type: "material-sample",
           id: "333",
           group: "test-group",
-          materialSampleName: "test-ms",
+          materialSampleName: "test-ms"
         }}
         visibleManagedAttributeKeys={{
-          collectingEvent: ["attribute_2", "attribute_3"],
+          collectingEvent: ["attribute_2", "attribute_3"]
         }}
         onSaved={mockOnSaved}
       />,
@@ -2348,10 +2335,10 @@ describe("Material Sample Edit Page", () => {
           type: "material-sample",
           id: "333",
           group: "test-group",
-          materialSampleName: "test-ms",
+          materialSampleName: "test-ms"
         }}
         visibleManagedAttributeKeys={{
-          determination: ["attribute_2", "attribute_3"],
+          determination: ["attribute_2", "attribute_3"]
         }}
         onSaved={mockOnSaved}
       />,

--- a/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
@@ -594,47 +594,9 @@ const formTemplate: PersistedResource<FormTemplate> = {
       ]
     },
     {
-      name: ACQUISITION_EVENT_COMPONENT_NAME,
-      visible: false,
-      order: 4,
-      sections: [
-        {
-          name: "acquisition-event-reception-section",
-          visible: true,
-          items: [
-            {
-              name: "group",
-              visible: false,
-              defaultValue: "aafc"
-            },
-            { defaultValue: undefined, name: "receivedFrom", visible: false },
-            { defaultValue: undefined, name: "receivedDate", visible: false },
-            {
-              defaultValue: undefined,
-              name: "receptionRemarks",
-              visible: false
-            }
-          ]
-        },
-        {
-          name: "acquisition-event-isolation-section",
-          visible: true,
-          items: [
-            { defaultValue: undefined, name: "isolatedBy", visible: false },
-            { defaultValue: undefined, name: "isolatedOn", visible: false },
-            {
-              defaultValue: undefined,
-              name: "isolationRemarks",
-              visible: false
-            }
-          ]
-        }
-      ]
-    },
-    {
       name: PREPARATIONS_COMPONENT_NAME,
       visible: false,
-      order: 5,
+      order: 4,
       sections: [
         {
           name: "general-section",
@@ -698,7 +660,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: ORGANISMS_COMPONENT_NAME,
       visible: false,
-      order: 6,
+      order: 5,
       sections: [
         {
           name: "organisms-general-section",
@@ -810,7 +772,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: ASSOCIATIONS_COMPONENT_NAME,
       visible: false,
-      order: 7,
+      order: 6,
       sections: [
         {
           name: "associations-host-organism-section",
@@ -854,7 +816,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: STORAGE_COMPONENT_NAME,
       visible: false,
-      order: 8,
+      order: 7,
       sections: [
         {
           name: "storage-selection-section",
@@ -868,7 +830,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: RESTRICTION_COMPONENT_NAME,
       visible: false,
-      order: 9,
+      order: 8,
       sections: [
         {
           name: "restriction-general-section",
@@ -891,7 +853,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: SCHEDULED_ACTIONS_COMPONENT_NAME,
       visible: false,
-      order: 10,
+      order: 9,
       sections: [
         {
           name: "scheduled-actions-add-section",
@@ -929,7 +891,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: FIELD_EXTENSIONS_COMPONENT_NAME,
       visible: undefined,
-      order: 11,
+      order: 10,
       sections: [
         {
           items: [
@@ -947,7 +909,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: MANAGED_ATTRIBUTES_COMPONENT_NAME,
       visible: true,
-      order: 12,
+      order: 11,
       sections: [
         {
           name: "managed-attributes-section",
@@ -959,7 +921,7 @@ const formTemplate: PersistedResource<FormTemplate> = {
     {
       name: MATERIAL_SAMPLE_ATTACHMENTS_COMPONENT_NAME,
       visible: true,
-      order: 13,
+      order: 12,
       sections: [
         {
           name: "material-sample-attachments-sections",
@@ -1012,7 +974,6 @@ describe("Form template edit page", () => {
       "identifiers-component",
       "material-sample-info-component",
       "collecting-event-component",
-      "acquisition-event-component",
       "preparations-component",
       "organisms-component",
       "associations-component",
@@ -1492,55 +1453,9 @@ describe("Form template edit page", () => {
           ]
         },
         {
-          name: "acquisition-event-component",
-          visible: false,
-          order: 4,
-          sections: [
-            {
-              name: "acquisition-event-reception-section",
-              visible: true,
-              items: [
-                {
-                  name: "group",
-                  visible: false,
-                  defaultValue: "aafc"
-                },
-                {
-                  defaultValue: undefined,
-                  name: "receivedFrom",
-                  visible: false
-                },
-                {
-                  defaultValue: undefined,
-                  name: "receivedDate",
-                  visible: false
-                },
-                {
-                  defaultValue: undefined,
-                  name: "receptionRemarks",
-                  visible: false
-                }
-              ]
-            },
-            {
-              name: "acquisition-event-isolation-section",
-              visible: true,
-              items: [
-                { defaultValue: undefined, name: "isolatedBy", visible: false },
-                { defaultValue: undefined, name: "isolatedOn", visible: false },
-                {
-                  defaultValue: undefined,
-                  name: "isolationRemarks",
-                  visible: false
-                }
-              ]
-            }
-          ]
-        },
-        {
           name: "preparations-component",
           visible: false,
-          order: 5,
+          order: 4,
           sections: [
             {
               name: "general-section",
@@ -1604,7 +1519,7 @@ describe("Form template edit page", () => {
         {
           name: "organisms-component",
           visible: false,
-          order: 6,
+          order: 5,
           sections: [
             {
               name: "organisms-general-section",
@@ -1716,7 +1631,7 @@ describe("Form template edit page", () => {
         {
           name: "associations-component",
           visible: false,
-          order: 7,
+          order: 6,
           sections: [
             {
               name: "associations-host-organism-section",
@@ -1760,7 +1675,7 @@ describe("Form template edit page", () => {
         {
           name: "storage-component",
           visible: false,
-          order: 8,
+          order: 7,
           sections: [
             {
               name: "storage-selection-section",
@@ -1778,7 +1693,7 @@ describe("Form template edit page", () => {
         {
           name: "restriction-component",
           visible: false,
-          order: 9,
+          order: 8,
           sections: [
             {
               name: "restriction-general-section",
@@ -1813,7 +1728,7 @@ describe("Form template edit page", () => {
         {
           name: "scheduled-actions-component",
           visible: false,
-          order: 10,
+          order: 9,
           sections: [
             {
               name: "scheduled-actions-add-section",
@@ -1851,7 +1766,7 @@ describe("Form template edit page", () => {
         {
           name: "field-extensions-component",
           visible: true,
-          order: 11,
+          order: 10,
           sections: [
             {
               items: [
@@ -1869,7 +1784,7 @@ describe("Form template edit page", () => {
         {
           name: "managed-attributes-component",
           visible: true,
-          order: 12,
+          order: 11,
           sections: [
             {
               name: "managed-attributes-section",
@@ -1892,7 +1807,7 @@ describe("Form template edit page", () => {
         {
           name: "material-sample-attachments-component",
           visible: true,
-          order: 13,
+          order: 12,
           sections: [
             {
               name: "material-sample-attachments-sections",

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -82,9 +82,10 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
       : materialSampleQuery.response?.data?.collectingEvent?.id
   );
 
-  const acqEventQuery = useAcquisitionEvent(
-    materialSampleQuery.response?.data?.acquisitionEvent?.id
-  );
+  // TODO: Remove this block when Acquisition Event is confirmed to be removed entirely
+  // const acqEventQuery = useAcquisitionEvent(
+  //   materialSampleQuery.response?.data?.acquisitionEvent?.id
+  // );
 
   const collectingEventParentLink = (
     <Link href={`/collection/material-sample/view?id=${highestParentId}`}>
@@ -186,10 +187,10 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
                   <AssemblageSelectSection />
                   {withResponse(
                     transactionElasticQuery as any,
-                    ({ data: transactionElasticQuery }) => {
+                    ({ data: query }) => {
                       return (
                         <TransactionMaterialDirectionSection
-                          transactionElasticQuery={transactionElasticQuery}
+                          transactionElasticQuery={query}
                         />
                       );
                     }
@@ -268,7 +269,9 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
                     </FieldSet>
                   );
                 })}
-                {withResponse(acqEventQuery, ({ data: acqEvent }) => (
+                {
+                  // TODO: Remove this block when Acquisition Event is confirmed to be removed entirely
+                  /* {withResponse(acqEventQuery, ({ data: acqEvent }) => (
                   <FieldSet
                     id={ACQUISITION_EVENT_COMPONENT_NAME}
                     legend={<DinaMessage id="acquisitionEvent" />}
@@ -286,7 +289,8 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
                       <AcquisitionEventFormLayout />
                     </DinaForm>
                   </FieldSet>
-                ))}
+                ))} */
+                }
                 {hasPreparations && <PreparationField />}
                 {hasOrganism && <OrganismsField name="organism" />}
                 {hasInheritedDetermination && (

--- a/packages/dina-ui/types/collection-api/resources/form-legends/MaterialSampleForm.ts
+++ b/packages/dina-ui/types/collection-api/resources/form-legends/MaterialSampleForm.ts
@@ -348,49 +348,50 @@ export const MATERIAL_SAMPLE_FORM_LEGEND: FormLegendComponentInformation[] = [
       }
     ]
   },
-  {
-    id: ACQUISITION_EVENT_COMPONENT_NAME,
-    labelKey: "acquisitionEvent",
-    maxGridSizeX: 2,
-    switchClassName: "enable-acquisition-event",
-    sections: [
-      {
-        id: "acquisition-event-reception-section",
-        labelKey: "reception",
-        maxGridSizeX: 2,
-        items: [
-          {
-            id: "group"
-          },
-          {
-            id: "receivedFrom"
-          },
-          {
-            id: "receivedDate"
-          },
-          {
-            id: "receptionRemarks"
-          }
-        ]
-      },
-      {
-        id: "acquisition-event-isolation-section",
-        labelKey: "isolation",
-        maxGridSizeX: 2,
-        items: [
-          {
-            id: "isolatedBy"
-          },
-          {
-            id: "isolatedOn"
-          },
-          {
-            id: "isolationRemarks"
-          }
-        ]
-      }
-    ]
-  },
+  // TODO: Remove this block when Acquisition Event is confirmed to be removed entirely
+  // {
+  //   id: ACQUISITION_EVENT_COMPONENT_NAME,
+  //   labelKey: "acquisitionEvent",
+  //   maxGridSizeX: 2,
+  //   switchClassName: "enable-acquisition-event",
+  //   sections: [
+  //     {
+  //       id: "acquisition-event-reception-section",
+  //       labelKey: "reception",
+  //       maxGridSizeX: 2,
+  //       items: [
+  //         {
+  //           id: "group"
+  //         },
+  //         {
+  //           id: "receivedFrom"
+  //         },
+  //         {
+  //           id: "receivedDate"
+  //         },
+  //         {
+  //           id: "receptionRemarks"
+  //         }
+  //       ]
+  //     },
+  //     {
+  //       id: "acquisition-event-isolation-section",
+  //       labelKey: "isolation",
+  //       maxGridSizeX: 2,
+  //       items: [
+  //         {
+  //           id: "isolatedBy"
+  //         },
+  //         {
+  //           id: "isolatedOn"
+  //         },
+  //         {
+  //           id: "isolationRemarks"
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // },
   {
     id: PREPARATIONS_COMPONENT_NAME,
     labelKey: "preparations",


### PR DESCRIPTION
- Commented out logic to display Acquisition Event in Material Form Nav bar
- Commented out logic to display Acquisition Event in Material Sample edit
- Commented out logic to display Acquisition Event in Material Sample view
- Only commenting out for now instead of removing because the actual removal needs to be confirmed in another release