### PR TITLE
29998 Hover tooltip for Add Person in Modal not visible

### DIFF
--- a/packages/common-ui/lib/tooltip/Tooltip.tsx
+++ b/packages/common-ui/lib/tooltip/Tooltip.tsx
@@ -115,6 +115,7 @@ export function Tooltip({
         }
         placement={placement}
         trigger={["focus", "hover"]}
+        zIndex={3001}
       >
         <span>
           {visibleElement ? (


### PR DESCRIPTION
- Hovering over tooltip correctly shows tooltip bubble over modal now