### PR TITLE
30476 manage-attributes view page

### DIFF
--- a/packages/dina-ui/components/page-layouts/ViewPageLayout.tsx
+++ b/packages/dina-ui/components/page-layouts/ViewPageLayout.tsx
@@ -36,6 +36,7 @@ export type ViewPageLayoutProps<T extends KitsuResource> =
     queryOptions?: QueryOptions<T, unknown>;
     form: (formProps: ResourceFormProps<T>) => ReactNode;
     entityLink: string;
+    customBackButton?: JSX.Element;
     type: string;
     apiBaseUrl: string;
 
@@ -85,6 +86,7 @@ export function ViewPageLayout<T extends KitsuResource>({
   customQueryHook,
   queryOptions,
   entityLink,
+  customBackButton,
   type,
   apiBaseUrl,
   nameField = "name",
@@ -146,12 +148,16 @@ export function ViewPageLayout<T extends KitsuResource>({
             <>
               <Head title={title} />
               <ButtonBar className="gap-2">
-                <BackButton
-                  entityId={id}
-                  className="me-auto"
-                  entityLink={entityLink}
-                  byPassView={true}
-                />
+                {customBackButton ? (
+                  customBackButton
+                ) : (
+                  <BackButton
+                    entityId={id}
+                    className="me-auto"
+                    entityLink={entityLink}
+                    byPassView={true}
+                  />
+                )}
                 {canEdit &&
                   (editButton?.(formProps) ?? (
                     <EditButton entityId={id} entityLink={entityLink} />

--- a/packages/dina-ui/pages/collection/managed-attribute/edit.tsx
+++ b/packages/dina-ui/pages/collection/managed-attribute/edit.tsx
@@ -1,12 +1,13 @@
 import { SelectField, useQuery, withResponse } from "common-ui";
 import { WithRouterProps } from "next/dist/client/with-router";
+import Link from "next/link";
 import { withRouter } from "next/router";
 import {
   Footer,
   Head,
-  Nav,
   ManagedAttributeForm,
-  ManagedAttributeFormProps
+  ManagedAttributeFormProps,
+  Nav
 } from "../../../components";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import {
@@ -36,11 +37,26 @@ export function ManagedAttributesEditPage({ router }: WithRouterProps) {
     value: dataType
   }));
 
+  const backButton =
+    id === undefined ? (
+      <Link href="/managed-attribute/list?step=0">
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToList" />
+        </a>
+      </Link>
+    ) : (
+      <Link href={`/collection/managed-attribute/view?id=${id}`}>
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToList" />
+        </a>
+      </Link>
+    );
+
   const formProps: ManagedAttributeFormProps = {
     router,
-    postSaveRedirect: "/managed-attribute/list?step=0",
+    postSaveRedirect: "/collection/managed-attribute",
     apiBaseUrl: "/collection-api",
-    listHref: "/managed-attribute/list?step=0",
+    backButton,
     componentField: (
       <SelectField
         className="col-md-6"

--- a/packages/dina-ui/pages/collection/managed-attribute/view.tsx
+++ b/packages/dina-ui/pages/collection/managed-attribute/view.tsx
@@ -1,0 +1,52 @@
+import { DinaForm, SelectField } from "common-ui";
+import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
+import {
+  CollectionModuleType,
+  COLLECTION_MODULE_TYPES,
+  COLLECTION_MODULE_TYPE_LABELS
+} from "../../../types/collection-api/resources/ManagedAttribute";
+import { ManagedAttribute } from "../../../types/objectstore-api";
+import {
+  ManagedAttributeFormLayout,
+  ViewPageLayout
+} from "../../../components";
+import Link from "next/link";
+
+export default function ManagedAttributesViewPage() {
+  const { formatMessage } = useDinaIntl();
+  const ATTRIBUTE_COMPONENT_OPTIONS: {
+    label: string;
+    value: CollectionModuleType;
+  }[] = COLLECTION_MODULE_TYPES.map((dataType) => ({
+    label: formatMessage(COLLECTION_MODULE_TYPE_LABELS[dataType] as any),
+    value: dataType
+  }));
+  const componentField = (
+    <SelectField
+      className="col-md-6"
+      name="managedAttributeComponent"
+      options={ATTRIBUTE_COMPONENT_OPTIONS}
+    />
+  );
+  const backButton = (
+    <Link href="/managed-attribute/list?step=0">
+      <a className="back-button my-auto me-auto">
+        <DinaMessage id="backToList" />
+      </a>
+    </Link>
+  );
+  return (
+    <ViewPageLayout<ManagedAttribute>
+      form={(props) => (
+        <DinaForm<ManagedAttribute> {...props}>
+          <ManagedAttributeFormLayout componentField={componentField} />
+        </DinaForm>
+      )}
+      query={(id) => ({ path: `collection-api/managed-attribute/${id}` })}
+      entityLink="/collection/managed-attribute"
+      customBackButton={backButton}
+      type="managed-attribute"
+      apiBaseUrl="/collection-api"
+    />
+  );
+}

--- a/packages/dina-ui/pages/loan-transaction/managed-attribute/edit.tsx
+++ b/packages/dina-ui/pages/loan-transaction/managed-attribute/edit.tsx
@@ -1,5 +1,6 @@
 import { useQuery, withResponse } from "common-ui";
 import { WithRouterProps } from "next/dist/client/with-router";
+import Link from "next/link";
 import { withRouter } from "next/router";
 import {
   Footer,
@@ -23,11 +24,26 @@ export function ManagedAttributesEditPage({ router }: WithRouterProps) {
     { disabled: id === undefined }
   );
 
+  const backButton =
+    id === undefined ? (
+      <Link href="/managed-attribute/list?step=2">
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToList" />
+        </a>
+      </Link>
+    ) : (
+      <Link href={`/loan-transaction/managed-attribute/view?id=${id}`}>
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToReadOnlyPage" />
+        </a>
+      </Link>
+    );
+
   const formProps: ManagedAttributeFormProps = {
     router,
     postSaveRedirect: "/managed-attribute/list?step=2",
     apiBaseUrl: "/loan-transaction-api",
-    listHref: "/managed-attribute/list?step=2"
+    backButton
   };
 
   return (

--- a/packages/dina-ui/pages/loan-transaction/managed-attribute/view.tsx
+++ b/packages/dina-ui/pages/loan-transaction/managed-attribute/view.tsx
@@ -1,0 +1,32 @@
+import { DinaForm } from "common-ui";
+import {
+  ManagedAttributeFormLayout,
+  ViewPageLayout
+} from "../../../components";
+import { ManagedAttribute } from "../../../types/objectstore-api";
+import Link from "next/link";
+import { DinaMessage } from "../../../../dina-ui/intl/dina-ui-intl";
+
+export default function ManagedAttributesViewPage() {
+  const backButton = (
+    <Link href="/managed-attribute/list?step=2">
+      <a className="back-button my-auto me-auto">
+        <DinaMessage id="backToList" />
+      </a>
+    </Link>
+  );
+  return (
+    <ViewPageLayout<ManagedAttribute>
+      form={(props) => (
+        <DinaForm<ManagedAttribute> {...props}>
+          <ManagedAttributeFormLayout />
+        </DinaForm>
+      )}
+      query={(id) => ({ path: `loan-transaction-api/managed-attribute/${id}` })}
+      entityLink="/loan-transaction/managed-attribute"
+      customBackButton={backButton}
+      type="managed-attribute"
+      apiBaseUrl="/loan-transaction-api"
+    />
+  );
+}

--- a/packages/dina-ui/pages/managed-attribute/list.tsx
+++ b/packages/dina-ui/pages/managed-attribute/list.tsx
@@ -90,7 +90,7 @@ function CollectionAttributeListView() {
   >[] = [
     {
       Cell: ({ original: { id, name } }) => (
-        <Link href={`/collection/managed-attribute/edit?id=${id}`}>
+        <Link href={`/collection/managed-attribute/view?id=${id}`}>
           <a>{name}</a>
         </Link>
       ),
@@ -164,9 +164,7 @@ function ObjectStoreAttributeListView() {
     [
       {
         Cell: ({ original: { id, name } }) => (
-          <Link
-            href={`/object-store/managedAttributesView/detailsView?id=${id}`}
-          >
+          <Link href={`/object-store/managed-attribute/view?id=${id}`}>
             <a>{name}</a>
           </Link>
         ),
@@ -206,7 +204,7 @@ function ObjectStoreAttributeListView() {
       </h3>
 
       {/* Quick create menu */}
-      <CreateNewSection href="/object-store/managedAttributesView/detailsView" />
+      <CreateNewSection href="/object-store/managed-attribute/edit" />
 
       <ListPageLayout
         filterAttributes={OBJECT_STORE_ATTRIBUTES_FILTER_ATTRIBUTES}
@@ -227,7 +225,7 @@ function TransactionAttributeListView() {
     [
       {
         Cell: ({ original: { id, name } }) => (
-          <Link href={`/loan-transaction/managed-attribute/edit?id=${id}`}>
+          <Link href={`/loan-transaction/managed-attribute/view?id=${id}`}>
             <a>{name}</a>
           </Link>
         ),

--- a/packages/dina-ui/pages/object-store/managed-attribute/edit.tsx
+++ b/packages/dina-ui/pages/object-store/managed-attribute/edit.tsx
@@ -2,7 +2,6 @@
 import {
   ButtonBar,
   DateField,
-  DeleteButton,
   DinaForm,
   DinaFormOnSubmit,
   SelectField,
@@ -12,6 +11,7 @@ import {
   useQuery,
   withResponse
 } from "common-ui";
+import { fromPairs, toPairs } from "lodash";
 import { WithRouterProps } from "next/dist/client/with-router";
 import Link from "next/link";
 import { NextRouter, withRouter } from "next/router";
@@ -23,14 +23,14 @@ import {
   ManagedAttributeType,
   MANAGED_ATTRIBUTE_TYPE_OPTIONS
 } from "../../../types/objectstore-api/resources/ManagedAttribute";
-import { fromPairs, toPairs } from "lodash";
 
 interface ManagedAttributeFormProps {
   profile?: ManagedAttribute;
   router: NextRouter;
+  backButton: JSX.Element;
 }
 
-export function ManagedAttributesDetailsPage({ router }: WithRouterProps) {
+export function ManagedAttributesEditPage({ router }: WithRouterProps) {
   const { formatMessage } = useDinaIntl();
   const { id } = router.query;
   const title = id ? "editManagedAttributeTitle" : "addManagedAttributeTitle";
@@ -41,6 +41,21 @@ export function ManagedAttributesDetailsPage({ router }: WithRouterProps) {
     },
     { disabled: id === undefined }
   );
+
+  const backButton =
+    id === undefined ? (
+      <Link href="/managed-attribute/list?step=1">
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToList" />
+        </a>
+      </Link>
+    ) : (
+      <Link href={`/object-store/managed-attribute/view?id=${id}`}>
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToReadOnlyPage" />
+        </a>
+      </Link>
+    );
 
   return (
     <div>
@@ -54,7 +69,11 @@ export function ManagedAttributesDetailsPage({ router }: WithRouterProps) {
               <DinaMessage id="editManagedAttributeTitle" />
             </h1>
             {withResponse(query, ({ data }) => (
-              <ManagedAttributeForm profile={data} router={router} />
+              <ManagedAttributeForm
+                profile={data}
+                router={router}
+                backButton={backButton}
+              />
             ))}
           </div>
         ) : (
@@ -63,7 +82,7 @@ export function ManagedAttributesDetailsPage({ router }: WithRouterProps) {
               <DinaMessage id="addManagedAttributeTitle" />
             </h1>
             <br />
-            <ManagedAttributeForm router={router} />
+            <ManagedAttributeForm router={router} backButton={backButton} />
           </div>
         )}
       </main>
@@ -72,7 +91,11 @@ export function ManagedAttributesDetailsPage({ router }: WithRouterProps) {
   );
 }
 
-function ManagedAttributeForm({ profile, router }: ManagedAttributeFormProps) {
+function ManagedAttributeForm({
+  profile,
+  router,
+  backButton
+}: ManagedAttributeFormProps) {
   const { formatMessage } = useDinaIntl();
 
   const id = profile?.id;
@@ -156,19 +179,8 @@ function ManagedAttributeForm({ profile, router }: ManagedAttributeFormProps) {
   return (
     <DinaForm initialValues={initialValues} onSubmit={onSubmit}>
       <ButtonBar>
+        {backButton}
         <SubmitButton />
-        <Link href="/managed-attribute/list?step=1">
-          <a className="btn btn-dark">
-            <DinaMessage id="cancelButtonText" />
-          </a>
-        </Link>
-        <DeleteButton
-          className="ms-5"
-          id={id}
-          options={{ apiBaseUrl: "/objectstore-api" }}
-          postDeleteRedirect="/managed-attribute/list?step=1"
-          type="managed-attribute"
-        />
       </ButtonBar>
       <div className="row">
         <TextField
@@ -216,4 +228,4 @@ function ManagedAttributeForm({ profile, router }: ManagedAttributeFormProps) {
   );
 }
 
-export default withRouter(ManagedAttributesDetailsPage);
+export default withRouter(ManagedAttributesEditPage);

--- a/packages/dina-ui/pages/object-store/managed-attribute/view.tsx
+++ b/packages/dina-ui/pages/object-store/managed-attribute/view.tsx
@@ -1,0 +1,32 @@
+import { DinaForm } from "common-ui";
+import {
+  ManagedAttributeFormLayout,
+  ViewPageLayout
+} from "../../../components";
+import { ManagedAttribute } from "../../../types/objectstore-api";
+import Link from "next/link";
+import { DinaMessage } from "../../../../dina-ui/intl/dina-ui-intl";
+
+export default function ManagedAttributesViewPage() {
+  const backButton = (
+    <Link href="/managed-attribute/list?step=1">
+      <a className="back-button my-auto me-auto">
+        <DinaMessage id="backToList" />
+      </a>
+    </Link>
+  );
+  return (
+    <ViewPageLayout<ManagedAttribute>
+      form={(props) => (
+        <DinaForm<ManagedAttribute> {...props}>
+          <ManagedAttributeFormLayout />
+        </DinaForm>
+      )}
+      query={(id) => ({ path: `objectstore-api/managed-attribute/${id}` })}
+      entityLink="/object-store/managed-attribute"
+      customBackButton={backButton}
+      type="managed-attribute"
+      apiBaseUrl="objectstore-api/"
+    />
+  );
+}


### PR DESCRIPTION
1.  moved some code to managed-attribute folder for consistency
2. Add view page for 3 types of managed-attributed
3. Change the navigation rule from edit to view page or to list page consistent as how other modules do.
4. Move delete button from edit page to view page for object-store managed-attribute, which is consistent with other modules.