### PR TITLE
30234 Can't upload attachment in Project

### DIFF
--- a/packages/dina-ui/components/bulk-metadata/UploadingMetadataBulkEditor.tsx
+++ b/packages/dina-ui/components/bulk-metadata/UploadingMetadataBulkEditor.tsx
@@ -80,7 +80,7 @@ export function UploadingMetadataBulkEditor({
             id: agentId,
             type: "person"
           }
-        : null,
+        : undefined,
       bucket: group,
       dcType: objectUpload.dcType,
       fileIdentifier: objectUpload.id,

--- a/packages/dina-ui/components/object-store/metadata/MetadataUpload.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataUpload.tsx
@@ -70,13 +70,13 @@ export function MetadataUpload({ buttonBar }: MetadataUploadProps) {
       acCaption: objectUpload.originalFilename,
       acDigitizationDate: objectUpload.dateTimeDigitized
         ? moment(objectUpload.dateTimeDigitized).format()
-        : null,
+        : undefined,
       acMetadataCreator: agentId
         ? {
             id: agentId,
             type: "person"
           }
-        : null,
+        : undefined,
       bucket: group,
       dcType: objectUpload.dcType,
       fileIdentifier: objectUpload.id,

--- a/packages/dina-ui/components/object-store/metadata/MetadataUpload.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataUpload.tsx
@@ -70,7 +70,7 @@ export function MetadataUpload({ buttonBar }: MetadataUploadProps) {
       acCaption: objectUpload.originalFilename,
       acDigitizationDate: objectUpload.dateTimeDigitized
         ? moment(objectUpload.dateTimeDigitized).format()
-        : undefined,
+        : null,
       acMetadataCreator: agentId
         ? {
             id: agentId,

--- a/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
+++ b/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
@@ -27,7 +27,7 @@ export interface MetadataAttributes {
   acCaption?: string;
   dcFormat?: string;
   createdDate?: string;
-  acDigitizationDate?: string;
+  acDigitizationDate?: string | null;
   xmpMetadataDate?: string;
   acTags?: string[];
   originalFilename?: string;
@@ -46,9 +46,9 @@ export interface MetadataAttributes {
 
 export interface MetadataRelationships {
   acMetadataCreator?: Person | KitsuResource;
-  dcCreator?: Person | KitsuResource;
-  managedAttributes?: Record<string, string | undefined>;
-  derivatives?: PersistedResource<Derivative>[];
+  dcCreator?: Person | KitsuResource | null;
+  managedAttributes?: Record<string, string | null | undefined>;
+  derivatives?: PersistedResource<Derivative>[] | null;
 }
 
 export type Metadata = KitsuResource &

--- a/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
+++ b/packages/dina-ui/types/objectstore-api/resources/Metadata.ts
@@ -27,7 +27,7 @@ export interface MetadataAttributes {
   acCaption?: string;
   dcFormat?: string;
   createdDate?: string;
-  acDigitizationDate?: string | null;
+  acDigitizationDate?: string;
   xmpMetadataDate?: string;
   acTags?: string[];
   originalFilename?: string;
@@ -45,10 +45,10 @@ export interface MetadataAttributes {
 }
 
 export interface MetadataRelationships {
-  acMetadataCreator?: Person | KitsuResource | null;
-  dcCreator?: Person | KitsuResource | null;
-  managedAttributes?: Record<string, string | null | undefined>;
-  derivatives?: PersistedResource<Derivative>[] | null;
+  acMetadataCreator?: Person | KitsuResource;
+  dcCreator?: Person | KitsuResource;
+  managedAttributes?: Record<string, string | undefined>;
+  derivatives?: PersistedResource<Derivative>[];
 }
 
 export type Metadata = KitsuResource &


### PR DESCRIPTION
- Changed default value of acMetadataCreator from null to undefined when agentId not available
- Should no longer throw internal server error when agentId not available