### PR TITLE
29893 Form Template mandatory fields for all templates

### DIFF
--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -471,6 +471,7 @@ export function MaterialSampleForm({
                 <div className="row">
                   <div className="col-md-6">
                     <GroupSelectField
+                      disableTemplateCheckbox={true}
                       name="group"
                       enableStoredDefaultGroup={enableStoredDefaultGroup}
                     />

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleIdentifiersSection.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleIdentifiersSection.tsx
@@ -59,9 +59,11 @@ export function MaterialSampleIdentifiersSection({
           <CollectionSelectField
             name={`${namePrefix}collection`}
             customName="collection"
+            disableTemplateCheckbox={true}
           />
           <div className="d-flex">
             <TextField
+              disableTemplateCheckbox={true}
               name={`${namePrefix}materialSampleName`}
               inputProps={{ disabled: primaryIdDisabled }}
               customName="materialSampleName"

--- a/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
@@ -292,11 +292,11 @@ const formTemplate: PersistedResource<FormTemplate> = {
           name: "identifiers-section",
           visible: true,
           items: [
-            { defaultValue: undefined, name: "collection", visible: false },
+            { defaultValue: undefined, name: "collection", visible: true },
             {
               defaultValue: undefined,
               name: "materialSampleName",
-              visible: false
+              visible: true
             },
             {
               defaultValue: undefined,
@@ -1082,7 +1082,7 @@ describe("Form template edit page", () => {
                 {
                   defaultValue: "aafc",
                   name: "group",
-                  visible: false
+                  visible: true
                 },
                 {
                   defaultValue: undefined,
@@ -1115,11 +1115,11 @@ describe("Form template edit page", () => {
               name: "identifiers-section",
               visible: true,
               items: [
-                { defaultValue: undefined, name: "collection", visible: false },
+                { defaultValue: undefined, name: "collection", visible: true },
                 {
                   defaultValue: undefined,
                   name: "materialSampleName",
-                  visible: false
+                  visible: true
                 },
                 {
                   defaultValue: undefined,

--- a/packages/dina-ui/types/collection-api/resources/form-legends/MaterialSampleForm.ts
+++ b/packages/dina-ui/types/collection-api/resources/form-legends/MaterialSampleForm.ts
@@ -73,7 +73,7 @@ export const MATERIAL_SAMPLE_FORM_LEGEND: FormLegendComponentInformation[] = [
         id: "general-section",
         maxGridSizeX: 2,
         items: [
-          { id: "group" },
+          { id: "group", visible: true },
           {
             id: "tags"
           },
@@ -97,10 +97,12 @@ export const MATERIAL_SAMPLE_FORM_LEGEND: FormLegendComponentInformation[] = [
         maxGridSizeX: 2,
         items: [
           {
-            id: "collection"
+            id: "collection",
+            visible: true
           },
           {
-            id: "materialSampleName"
+            id: "materialSampleName",
+            visible: true
           },
           {
             id: "useNextSequence"


### PR DESCRIPTION
- Removed visibility check box for Group, Primary ID, Collection in Form Template
- These 3 fields should always be visible now