### PR TITLE
30727 Fixes for Controlled Vocabulary submenu

### DIFF
--- a/packages/dina-ui/components/button-bar/nav/nav.css
+++ b/packages/dina-ui/components/button-bar/nav/nav.css
@@ -8,8 +8,12 @@ body {
   margin-top: -5px;
 }
 
-.submenu > .dropdown-menu {
-  margin-left: -5px;
+.submenu > .dropend .dropdown-menu[data-bs-popper] {
+  top: 0;
+  right: auto;
+  left: 100%;
+  margin-top: 0;
+  margin-left: 0;
 }
 
 .submenu > button {

--- a/packages/dina-ui/components/button-bar/nav/nav.tsx
+++ b/packages/dina-ui/components/button-bar/nav/nav.tsx
@@ -235,9 +235,9 @@ function NavCollectionDropdown({ formatMessage }) {
           <DinaMessage id="collectingEventListTitle" />
         </NavDropdown.Item>
       </Link>
-      <Link href="/collection/collection-method/list" passHref={true}>
+      <Link href="/collection/collection/list" passHref={true}>
         <NavDropdown.Item>
-          <DinaMessage id="collectionMethodListTitle" />
+          <DinaMessage id="collectionListTitle" />
         </NavDropdown.Item>
       </Link>
       {/* Controlled Vocabulary submenu */}
@@ -251,9 +251,9 @@ function NavCollectionDropdown({ formatMessage }) {
         className="submenu"
         variant="light"
       >
-        <Link href="/collection/collection/list" passHref={true}>
+        <Link href="/collection/collection-method/list" passHref={true}>
           <NavDropdown.Item>
-            <DinaMessage id="collectionListTitle" />
+            <DinaMessage id="collectionMethodListTitle" />
           </NavDropdown.Item>
         </Link>
         <Link href="/collection/preparation-method/list" passHref={true}>

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -120,7 +120,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   collectionManagedAttributeListTitle: "Collection Module Managed Attributes",
   collectionMethodListTitle: "Collection Method",
   collectionMethodNameLabel: "Collection Method Name",
-  collectionSectionTitle: "Collections",
+  collectionSectionTitle: "Collection",
   collectionViewTitle: "Collection",
   collectorGroupAgentsLabel: "Collector Group Agents",
   collectorGroupListTitle: "Collector Group",


### PR DESCRIPTION
1. Renamed Collections dropdown to Collection
2. Moved Collection item back to main dropdown
3. Moved Collection Method to Controlled Vocabulary submenu