### PR TITLE
Support #30769 - Search on philip's lab group not working

### DIFF
--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchExport.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchExport.tsx
@@ -330,7 +330,9 @@ export function applyGroupFilters(elasticSearchQuery: any, groups: string[]) {
           ...(elasticSearchQuery?.query?.bool?.must ?? []),
           {
             [multipleGroups ? "terms" : "term"]: {
-              "data.attributes.group": multipleGroups ? groups : groups[0]
+              "data.attributes.group.keyword": multipleGroups
+                ? groups
+                : groups[0]
             }
           }
         ]

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/__snapshots__/QueryBuilderElasticSearchExport.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/__snapshots__/QueryBuilderElasticSearchExport.test.tsx.snap
@@ -167,7 +167,7 @@ Object {
         },
         Object {
           "terms": Object {
-            "data.attributes.group": Array [
+            "data.attributes.group.keyword": Array [
               "aafc",
               "cnc",
               "seqdb",
@@ -218,7 +218,7 @@ Object {
         },
         Object {
           "term": Object {
-            "data.attributes.group": "aafc",
+            "data.attributes.group.keyword": "aafc",
           },
         },
       ],


### PR DESCRIPTION
- Added ".keyword" to the group, the issue was the "-" in the group splitting it.
- Updated snapshot.