### PR TITLE
31324 Regression in download functionality

### DIFF
--- a/packages/dina-ui/components/object-store/file-view/FileView.tsx
+++ b/packages/dina-ui/components/object-store/file-view/FileView.tsx
@@ -85,8 +85,12 @@ export function FileView({
         const response = await fetchObjectBlob(path);
         const url = window?.URL?.createObjectURL(response.data);
         const link = document?.createElement("a");
+        const content: string = response.headers["content-disposition"];
+        const filename = content
+          .slice(content.indexOf("filename=") + "filename=".length)
+          .replaceAll('"', "");
         link.href = url;
-        link?.setAttribute("download", path); // or any other extension
+        link?.setAttribute("download", filename); // or any other extension
         document?.body?.appendChild(link);
         link?.click();
         window?.URL?.revokeObjectURL(url);


### PR DESCRIPTION
- Fixed Original download file name to use originalFilename
- Thumbnail name should also be consistent with what it was previously