### PR TITLE
31385 filter table doesn't align with the rest of the page

### DIFF
--- a/packages/common-ui/lib/filter-builder/FilterRow.tsx
+++ b/packages/common-ui/lib/filter-builder/FilterRow.tsx
@@ -97,7 +97,7 @@ export class FilterRow extends React.Component<FilterRowProps> {
     };
 
     return (
-      <div className="list-inline" style={{ display: "flex" }}>
+      <div className="list-inline" style={{ display: "flex-shrink" }}>
         <div className="list-inline-item" style={{ width: 320 }}>
           <Select<FilterAttributeOption>
             aria-label="Filter Attribute"


### PR DESCRIPTION
FilterRow components should now shrink with window width such that horizontal scrolling should no longer be necessary to see AND/OR buttons