### PR TITLE
31602 Label barcode payload should use uuid instead of name

### DIFF
--- a/packages/dina-ui/components/collection/material-sample/GenerateLabelDropdownButton.tsx
+++ b/packages/dina-ui/components/collection/material-sample/GenerateLabelDropdownButton.tsx
@@ -12,6 +12,7 @@ import { useApiClient } from "../../../../common-ui/lib/api-client/ApiClientCont
 interface ReportTemplateOption {
   label: string;
   value: string;
+  includesBarcode: boolean;
 }
 
 type CustomMenuProps = {
@@ -46,10 +47,13 @@ export function GenerateLabelDropdownButton({
     },
     {
       onSuccess: async ({ data }) => {
-        const generatedOptions = data.map((template) => ({
-          label: template?.name ?? "",
-          value: template?.id ?? ""
-        }));
+        const generatedOptions: ReportTemplateOption[] = data.map(
+          (template) => ({
+            label: template?.name ?? "",
+            value: template?.id ?? "",
+            includesBarcode: template.includesBarcode
+          })
+        );
         setReportTemplateOptions(generatedOptions);
 
         // If options are available, just set the first one automatically.
@@ -80,7 +84,9 @@ export function GenerateLabelDropdownButton({
               {
                 barcode: {
                   id: materialSample.barcode ?? "",
-                  content: materialSample.materialSampleName ?? ""
+                  content: reportTemplate.includesBarcode
+                    ? materialSample.id
+                    : ""
                 },
                 data: {
                   attributes: materialSample


### PR DESCRIPTION
- Barcode now produces sample's uuid instead of name
- Barcode only included in label if template includesBarcode field is true