### PR TITLE
Support #31988 - Managed attributes and field extensions should have …

### DIFF
--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderFieldExtensionSearch.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderFieldExtensionSearch.tsx
@@ -121,6 +121,7 @@ export default function QueryRowFieldExtensionSearch({
   const operatorOptions = [
     "exactMatch",
     "partialMatch",
+    "startsWith",
     "notEquals",
     "empty",
     "notEmpty"
@@ -303,10 +304,10 @@ export function transformFieldExtensionToDSL({
     value: fieldExtensionSearchValue.searchValue,
     fieldInfo: {
       ...fieldInfo,
-      distinctTerm:
-        fieldExtensionSearchValue.selectedOperator !== "partialMatch",
-      keywordMultiFieldSupport:
-        fieldExtensionSearchValue.selectedOperator === "partialMatch"
+      distinctTerm: false,
+
+      // All field extensions have keyword support.
+      keywordMultiFieldSupport: true
     } as ESIndexMapping
   });
 }

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
@@ -63,9 +63,6 @@ export default function QueryRowManagedAttributeSearch({
 }: QueryRowTextSearchProps) {
   const { formatMessage } = useIntl();
 
-  const [managedAttributeSearchValue, setManagedAttributeSearchValue] =
-    useState<string>("");
-
   const [managedAttributeState, setManagedAttributeState] =
     useState<ManagedAttributeSearchStates>(() =>
       value
@@ -131,7 +128,14 @@ export default function QueryRowManagedAttributeSearch({
       case "BOOL":
         return ["equals", "empty", "notEmpty"];
       case "STRING":
-        return ["exactMatch", "partialMatch", "notEquals", "empty", "notEmpty"];
+        return [
+          "exactMatch",
+          "partialMatch",
+          "startsWith",
+          "notEquals",
+          "empty",
+          "notEmpty"
+        ];
       default:
         return [];
     }
@@ -152,6 +156,14 @@ export default function QueryRowManagedAttributeSearch({
 
   // Determine the value input to display based on the type.
   const supportedValueForType = (type: string) => {
+    // If the operator is "empty" or "not empty", do not display anything.
+    if (
+      managedAttributeState.selectedOperator === "empty" ||
+      managedAttributeState.selectedOperator === "notEmpty"
+    ) {
+      return <></>;
+    }
+
     const commonProps = {
       matchType: managedAttributeState.selectedOperator,
       value: managedAttributeState.searchValue,
@@ -330,8 +342,10 @@ export function transformManagedAttributeToDSL({
     value: managedAttributeSearchValue.searchValue,
     fieldInfo: {
       ...fieldInfo,
-      distinctTerm:
-        managedAttributeSearchValue.selectedOperator !== "partialMatch"
+      distinctTerm: false,
+
+      // All managed attributes have keyword support.
+      keywordMultiFieldSupport: true
     } as ESIndexMapping
   };
 

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderFieldExtensionSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderFieldExtensionSearch.test.tsx
@@ -5,6 +5,7 @@ describe("QueryBuilderManagedAttributeSearch", () => {
     const operators = [
       "exactMatch",
       "partialMatch",
+      "startsWith",
       "notEquals",
       "empty",
       "notEmpty"

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderManagedAttributeSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderManagedAttributeSearch.test.tsx
@@ -23,6 +23,7 @@ describe("QueryBuilderManagedAttributeSearch", () => {
         operators: [
           "exactMatch",
           "partialMatch",
+          "startsWith",
           "notEquals",
           "empty",
           "notEmpty"

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderFieldExtensionSearch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderFieldExtensionSearch.test.tsx.snap
@@ -30,7 +30,7 @@ Object {
 exports[`QueryBuilderManagedAttributeSearch transformFieldExtensionToDSL function Attribute level tests Using the exactMatch operator. 1`] = `
 Object {
   "term": Object {
-    "data.attributes.extensionValues.extension.field": "test123",
+    "data.attributes.extensionValues.extension.field.keyword": "test123",
   },
 }
 `;
@@ -59,7 +59,7 @@ Object {
       Object {
         "bool": Object {
           "must_not": Object {
-            "term": Object {
+            "match": Object {
               "data.attributes.extensionValues.extension.field": "test123",
             },
           },
@@ -82,6 +82,14 @@ Object {
 exports[`QueryBuilderManagedAttributeSearch transformFieldExtensionToDSL function Attribute level tests Using the partialMatch operator. 1`] = `
 Object {
   "match": Object {
+    "data.attributes.extensionValues.extension.field": "test123",
+  },
+}
+`;
+
+exports[`QueryBuilderManagedAttributeSearch transformFieldExtensionToDSL function Attribute level tests Using the startsWith operator. 1`] = `
+Object {
+  "prefix": Object {
     "data.attributes.extensionValues.extension.field": "test123",
   },
 }
@@ -166,7 +174,7 @@ Object {
         "must": Array [
           Object {
             "term": Object {
-              "included.attributes.extensionValues.extension.field": "test123",
+              "included.attributes.extensionValues.extension.field.keyword": "test123",
             },
           },
           Object {
@@ -225,7 +233,7 @@ Object {
                 },
               },
               "must_not": Object {
-                "term": Object {
+                "match": Object {
                   "included.attributes.extensionValues.extension.field": "test123",
                 },
               },
@@ -275,6 +283,30 @@ Object {
         "must": Array [
           Object {
             "match": Object {
+              "included.attributes.extensionValues.extension.field": "test123",
+            },
+          },
+          Object {
+            "term": Object {
+              "included.type": "collecting-event",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`QueryBuilderManagedAttributeSearch transformFieldExtensionToDSL function Relationship level tests Using the startsWith operator. 1`] = `
+Object {
+  "nested": Object {
+    "path": "included",
+    "query": Object {
+      "bool": Object {
+        "must": Array [
+          Object {
+            "prefix": Object {
               "included.attributes.extensionValues.extension.field": "test123",
             },
           },

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderManagedAttributeSearch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderManagedAttributeSearch.test.tsx.snap
@@ -29,8 +29,8 @@ Object {
 
 exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL function BOOL based managed attribute tests Attribute level with operator equals 1`] = `
 Object {
-  "term": Object {
-    "data.attributes.managedAttributes.attributeName.keyword": "true",
+  "match": Object {
+    "data.attributes.managedAttributes.attributeName": "true",
   },
 }
 `;
@@ -130,8 +130,8 @@ Object {
       "bool": Object {
         "must": Array [
           Object {
-            "term": Object {
-              "included.attributes.managedAttributes.attributeName.keyword": "true",
+            "match": Object {
+              "included.attributes.managedAttributes.attributeName": "true",
             },
           },
           Object {
@@ -1282,8 +1282,8 @@ Object {
 
 exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL function PICK_LIST based managed attribute tests Attribute level with operator equals 1`] = `
 Object {
-  "term": Object {
-    "data.attributes.managedAttributes.attributeName.keyword": "3.5",
+  "match": Object {
+    "data.attributes.managedAttributes.attributeName": "3.5",
   },
 }
 `;
@@ -1312,8 +1312,8 @@ Object {
       Object {
         "bool": Object {
           "must_not": Object {
-            "term": Object {
-              "data.attributes.managedAttributes.attributeName.keyword": "3.5",
+            "match": Object {
+              "data.attributes.managedAttributes.attributeName": "3.5",
             },
           },
         },
@@ -1410,8 +1410,8 @@ Object {
       "bool": Object {
         "must": Array [
           Object {
-            "term": Object {
-              "included.attributes.managedAttributes.attributeName.keyword": "3.5",
+            "match": Object {
+              "included.attributes.managedAttributes.attributeName": "3.5",
             },
           },
           Object {
@@ -1470,8 +1470,8 @@ Object {
                 },
               },
               "must_not": Object {
-                "term": Object {
-                  "included.attributes.managedAttributes.attributeName.keyword": "3.5",
+                "match": Object {
+                  "included.attributes.managedAttributes.attributeName": "3.5",
                 },
               },
             },
@@ -1570,8 +1570,8 @@ Object {
       Object {
         "bool": Object {
           "must_not": Object {
-            "term": Object {
-              "data.attributes.managedAttributes.attributeName.keyword": "stringValue",
+            "match": Object {
+              "data.attributes.managedAttributes.attributeName": "stringValue",
             },
           },
         },
@@ -1594,6 +1594,14 @@ exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL funct
 Object {
   "match": Object {
     "data.attributes.managedAttributes.attributeName": "stringValue",
+  },
+}
+`;
+
+exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL function STRING based managed attribute tests Attribute level with operator startsWith 1`] = `
+Object {
+  "prefix": Object {
+    "data.attributes.managedAttributes.attributeName": "stringvalue",
   },
 }
 `;
@@ -1736,8 +1744,8 @@ Object {
                 },
               },
               "must_not": Object {
-                "term": Object {
-                  "included.attributes.managedAttributes.attributeName.keyword": "stringValue",
+                "match": Object {
+                  "included.attributes.managedAttributes.attributeName": "stringValue",
                 },
               },
             },
@@ -1787,6 +1795,30 @@ Object {
           Object {
             "match": Object {
               "included.attributes.managedAttributes.attributeName": "stringValue",
+            },
+          },
+          Object {
+            "term": Object {
+              "included.type": "collecting-event",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL function STRING based managed attribute tests Relationship level with operator startsWith 1`] = `
+Object {
+  "nested": Object {
+    "path": "included",
+    "query": Object {
+      "bool": Object {
+        "must": Array [
+          Object {
+            "prefix": Object {
+              "included.attributes.managedAttributes.attributeName": "stringvalue",
             },
           },
           Object {


### PR DESCRIPTION
- Added "Starts with" support for both managed attributes and field extensions.
- Fixed an issue with "Exact match" and "Not equals" search not working in some cases.
- For pick lists, "Empty" and "Not Empty" no longer display the value anymore to be consistent with the other types.
- Updated snapshots to reflect changes.