### PR TITLE
31992 Move Controlled Vocabulary out of Management menu

### DIFF
--- a/packages/dina-ui/components/button-bar/nav/nav.tsx
+++ b/packages/dina-ui/components/button-bar/nav/nav.tsx
@@ -104,6 +104,9 @@ export function Nav({ marginBottom = true }: NavProps) {
                 <NavObjectStoreDropdown formatMessage={formatMessage} />
                 <NavAgentDropdown formatMessage={formatMessage} />
                 <NavSequenceDropdown formatMessage={formatMessage} />
+                <NavControlledVocabularyDropdown
+                  formatMessage={formatMessage}
+                />
               </ReactNav>
 
               {/* Navigation menu right */}
@@ -210,13 +213,6 @@ function menuDisplayControl() {
 function NavCollectionDropdown({ formatMessage }) {
   const { show, showDropdown, hideDropdown, onKeyDown, onKeyDownLastItem } =
     menuDisplayControl();
-  const {
-    show: submenuShow,
-    showDropdown: submenuShowDropdown,
-    hideDropdown: submenuHideDropdown,
-    onKeyDown: submenuOnKeyDown,
-    onKeyDownLastItem: submenuOnKeyDownLastItem
-  } = menuDisplayControl();
   return (
     <NavDropdown
       title={formatMessage("collectionSectionTitle")}
@@ -241,37 +237,6 @@ function NavCollectionDropdown({ formatMessage }) {
           <DinaMessage id="collectionListTitle" />
         </NavDropdown.Item>
       </Link>
-      {/* Controlled Vocabulary submenu */}
-      <DropdownButton
-        title={formatMessage("controlledVocabularyTitle")}
-        drop={"end"}
-        onMouseOverCapture={submenuShowDropdown}
-        onKeyDown={submenuOnKeyDown}
-        onMouseLeave={submenuHideDropdown}
-        show={submenuShow}
-        className="submenu"
-        variant="light"
-        role="menuitem"
-      >
-        <Link href="/collection/collection-method/list" passHref={true}>
-          <NavDropdown.Item role="menuitem">
-            <DinaMessage id="collectionMethodListTitle" />
-          </NavDropdown.Item>
-        </Link>
-        <Link href="/collection/preparation-method/list" passHref={true}>
-          <NavDropdown.Item role="menuitem">
-            <DinaMessage id="title_preparationMethod" />
-          </NavDropdown.Item>
-        </Link>
-        <Link href="/collection/preparation-type/list" passHref={true}>
-          <NavDropdown.Item
-            onKeyDown={submenuOnKeyDownLastItem}
-            role="menuitem"
-          >
-            <DinaMessage id="preparationTypeListTitle" />
-          </NavDropdown.Item>
-        </Link>
-      </DropdownButton>
       <Link href="/collection/material-sample/list" passHref={true}>
         <NavDropdown.Item role="menuitem">
           <DinaMessage id="materialSampleListTitle" />
@@ -484,20 +449,24 @@ function NavSequenceDropdown({ formatMessage }) {
   );
 }
 
-function NavDinaManagementDropdown({ formatMessage }) {
+function NavControlledVocabularyDropdown({ formatMessage }) {
   const { show, showDropdown, hideDropdown, onKeyDown, onKeyDownLastItem } =
     menuDisplayControl();
   const { isAdmin } = useAccount();
   return (
     <NavDropdown
-      title={formatMessage("dinaManagementSectionTitle")}
+      title={formatMessage("controlledVocabularyTitle")}
       onMouseOver={showDropdown}
       onKeyDown={onKeyDown}
       onMouseLeave={hideDropdown}
       show={show}
-      className="float-right"
       role="menuitem"
     >
+      <Link href="/collection/collection-method/list" passHref={true}>
+        <NavDropdown.Item role="menuitem">
+          <DinaMessage id="collectionMethodListTitle" />
+        </NavDropdown.Item>
+      </Link>
       <Link href="/collection/extension/list" passHref={true}>
         <NavDropdown.Item role="menuitem">
           <DinaMessage id="fieldExtensions" />
@@ -519,6 +488,16 @@ function NavDinaManagementDropdown({ formatMessage }) {
         </NavDropdown.Item>
       </Link>
       {/* Permission page here. */}
+      <Link href="/collection/preparation-method/list" passHref={true}>
+        <NavDropdown.Item role="menuitem">
+          <DinaMessage id="title_preparationMethod" />
+        </NavDropdown.Item>
+      </Link>
+      <Link href="/collection/preparation-type/list" passHref={true}>
+        <NavDropdown.Item role="menuitem">
+          <DinaMessage id="preparationTypeListTitle" />
+        </NavDropdown.Item>
+      </Link>
       <Link href="/collection/protocol/list" passHref={true}>
         <NavDropdown.Item role="menuitem">
           <DinaMessage id="protocolListTitle" />
@@ -532,7 +511,24 @@ function NavDinaManagementDropdown({ formatMessage }) {
           <DinaMessage id="storageUnitTypeListTitle" />
         </NavDropdown.Item>
       </Link>
+    </NavDropdown>
+  );
+}
 
+function NavDinaManagementDropdown({ formatMessage }) {
+  const { show, showDropdown, hideDropdown, onKeyDown, onKeyDownLastItem } =
+    menuDisplayControl();
+  const { isAdmin } = useAccount();
+  return (
+    <NavDropdown
+      title={formatMessage("dinaManagementSectionTitle")}
+      onMouseOver={showDropdown}
+      onKeyDown={onKeyDown}
+      onMouseLeave={hideDropdown}
+      show={show}
+      className="float-right"
+      role="menuitem"
+    >
       {/* Admins only can view users. */}
       {isAdmin && (
         <Link

--- a/packages/dina-ui/pages/index.tsx
+++ b/packages/dina-ui/pages/index.tsx
@@ -72,8 +72,8 @@ export function Home() {
             </Card.Body>
           </Card>
 
-          {/* Split page into three sections */}
-          <Row lg={3} md={2} xs={1} className="mb-5">
+          {/* Split page into lg sections */}
+          <Row lg={4} md={2} xs={1} className="mb-5">
             {/* Collection Links */}
             <Col className="mb-4">
               <h2>
@@ -186,7 +186,7 @@ export function Home() {
               </h2>
 
               <Stack style={{ display: "inline-flex" }}>
-                <Link href="/organization/list">
+                <Link href="/organization/list" passHref={true}>
                   <a>
                     <DinaMessage id="organizationListTitle" />
                   </a>
@@ -279,6 +279,61 @@ export function Home() {
               </Stack>
             </Col>
 
+            {/* Controlled Vocabulary Links */}
+            <Col className="mb-4">
+              <h2>
+                <DinaMessage id="controlledVocabularyTitle" />
+              </h2>
+
+              <Stack style={{ display: "inline-flex" }}>
+                <Link href="/collection/collection-method/list">
+                  <a>
+                    <DinaMessage id="collectionMethodListTitle" />
+                  </a>
+                </Link>
+                <Link href="/collection/extension/list">
+                  <a>
+                    <DinaMessage id="fieldExtensions" />
+                  </a>
+                </Link>
+                <Link href="/collection/form-template/list">
+                  <a>
+                    <DinaMessage id="formTemplates" />
+                  </a>
+                </Link>
+                <Link href="/collection/institution/list">
+                  <a>
+                    <DinaMessage id="institutionListTitle" />
+                  </a>
+                </Link>
+                <Link href="/managed-attribute/list">
+                  <a>
+                    <DinaMessage id="managedAttributes" />
+                  </a>
+                </Link>
+                <Link href="/collection/preparation-method/list">
+                  <a>
+                    <DinaMessage id="title_preparationMethod" />
+                  </a>
+                </Link>
+                <Link href="/collection/preparation-type/list">
+                  <a>
+                    <DinaMessage id="preparationTypeListTitle" />
+                  </a>
+                </Link>
+                <Link href="/collection/protocol/list">
+                  <a>
+                    <DinaMessage id="protocolListTitle" />
+                  </a>
+                </Link>
+                <Link href="/collection/storage-unit-type/list">
+                  <a>
+                    <DinaMessage id="storageUnitTypeListTitle" />
+                  </a>
+                </Link>
+              </Stack>
+            </Col>
+
             {/* Management Links (Only visible to collection managers) */}
             {showManagementNavigation && (
               <Col className="mb-4">
@@ -287,37 +342,6 @@ export function Home() {
                 </h2>
 
                 <Stack style={{ display: "inline-flex" }}>
-                  <Link href="/collection/extension/list">
-                    <a>
-                      <DinaMessage id="fieldExtensions" />
-                    </a>
-                  </Link>
-                  <Link href="/collection/form-template/list">
-                    <a>
-                      <DinaMessage id="formTemplates" />
-                    </a>
-                  </Link>
-                  <Link href="/collection/institution/list">
-                    <a>
-                      <DinaMessage id="institutionListTitle" />
-                    </a>
-                  </Link>
-                  <Link href="/managed-attribute/list">
-                    <a>
-                      <DinaMessage id="managedAttributes" />
-                    </a>
-                  </Link>
-                  {/* Permissions link here */}
-                  <Link href="/collection/protocol/list">
-                    <a>
-                      <DinaMessage id="protocolListTitle" />
-                    </a>
-                  </Link>
-                  <Link href="/collection/storage-unit-type/list">
-                    <a>
-                      <DinaMessage id="storageUnitTypeListTitle" />
-                    </a>
-                  </Link>
                   {isAdmin && (
                     <Link href="/dina-user/list">
                       <a>


### PR DESCRIPTION
- Moved everything except for Users out of Management menu into new Controlled Vocabulary Menu
- Combined Controlled Vocabulary from Collection with new menu
- Added a Controlled Vocabulary section with list of links on the Home page to be consistent with other dropdown menus