### PR TITLE
Support #32030 - CI Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         # jq -cM ...: This part will split it into 6 groups. The last group will probably not have enough to fill the full group.
       - id: set-test-chunks
         name: split tests into chunks
-        run: echo "test-chunks=$(npx jest --listTests | shuf | awk NF | jq -R . | jq -s . | jq -cM '[_nwise(length / 5 | floor)]')" >> $GITHUB_OUTPUT
+        run: echo "test-chunks=$(npx jest --listTests | shuf | awk NF | jq -R . | jq -s . | jq -cM '[_nwise(length / 7 | floor)]')" >> $GITHUB_OUTPUT
 
       - id: set-test-chunk-ids
         name: Set Chunk IDs
@@ -33,10 +33,11 @@ jobs:
 
   test-chunk:
     runs-on: ubuntu-latest
-    name: Run tests (Chunk ${{ matrix.chunk }})
+    name: run tests (Chunk ${{ matrix.chunk }})
     needs:
       - setup
     strategy:
+      fail-fast: false
       matrix:
         chunk: ${{ fromJson(needs.setup.outputs['test-chunk-ids']) }}
     steps:
@@ -55,7 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - setup
-      - test-chunk
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         # awk NF: Remove additional empty lines.
         # jq -R .: Convert each line to a JSON string.
         # jq -s .: Combine them all into a single JSON array.
-        # jq -cM ...: This part will split it into 6 groups. The last group will probably not have enough to fill the full group.
+        # jq -cM ...: This part will split it into 8 groups. The last group will probably not have enough to fill the full group.
       - id: set-test-chunks
         name: split tests into chunks
         run: echo "test-chunks=$(npx jest --listTests | shuf | awk NF | jq -R . | jq -s . | jq -cM '[_nwise(length / 7 | floor)]')" >> $GITHUB_OUTPUT

--- a/packages/common-ui/lib/formik-connected/__tests__/CheckBoxField.test.tsx
+++ b/packages/common-ui/lib/formik-connected/__tests__/CheckBoxField.test.tsx
@@ -11,7 +11,7 @@ describe("CheckBoxField component", () => {
       </DinaForm>
     );
     expect(wrapper.find("label").text()).toEqual("Test Object Test Field");
-    expect((wrapper.find("input").instance() as any).checked).toEqual(true);
+    expect((wrapper.find("input").instance() as any).checked).toEqual(false);
   });
 
   it("Changes the field's value.", () => {

--- a/packages/common-ui/lib/formik-connected/__tests__/CheckBoxField.test.tsx
+++ b/packages/common-ui/lib/formik-connected/__tests__/CheckBoxField.test.tsx
@@ -11,7 +11,7 @@ describe("CheckBoxField component", () => {
       </DinaForm>
     );
     expect(wrapper.find("label").text()).toEqual("Test Object Test Field");
-    expect((wrapper.find("input").instance() as any).checked).toEqual(false);
+    expect((wrapper.find("input").instance() as any).checked).toEqual(true);
   });
 
   it("Changes the field's value.", () => {


### PR DESCRIPTION
- Bumped up to 8 test chunk runners (0 based number, changed to 7)
- Testing fail-fast set to false.
- Build step no longer depends on the test-chunks finishing.
- Broke a test on purpose for testing.