### PR TITLE
32018 Improvements to export view

### DIFF
--- a/packages/common-ui/lib/column-chooser/ColumnChooser.tsx
+++ b/packages/common-ui/lib/column-chooser/ColumnChooser.tsx
@@ -55,7 +55,7 @@ export function useColumnChooser({
     hideExportButton
   });
   const columnChooser = ColumnChooser(CustomMenu);
-  return { columnChooser, checkedColumnIds };
+  return { columnChooser, checkedColumnIds, CustomMenu };
 }
 
 interface UseCustomMenuProps extends UseColumnChooserProps {
@@ -69,7 +69,9 @@ function useCustomMenu({
   indexName,
   hideExportButton
 }: UseCustomMenuProps) {
-  const [searchedColumns, setSearchedColumns] = useState<any[]>(columns);
+  const [searchedColumns, setSearchedColumns] = useState<any[]>(
+    columns.filter((item) => item.id !== "selectColumn")
+  );
   const [loading, setLoading] = useState(false);
 
   const { formatMessage } = useIntl();

--- a/packages/common-ui/lib/column-chooser/ColumnChooser.tsx
+++ b/packages/common-ui/lib/column-chooser/ColumnChooser.tsx
@@ -69,9 +69,7 @@ function useCustomMenu({
   indexName,
   hideExportButton
 }: UseCustomMenuProps) {
-  const [searchedColumns, setSearchedColumns] = useState<any[]>(
-    columns.filter((item) => item.id !== "selectColumn")
-  );
+  const [searchedColumns, setSearchedColumns] = useState<any[]>(columns);
   const [loading, setLoading] = useState(false);
 
   const { formatMessage } = useIntl();

--- a/packages/common-ui/lib/column-chooser/ColumnChooser.tsx
+++ b/packages/common-ui/lib/column-chooser/ColumnChooser.tsx
@@ -100,7 +100,7 @@ function useCustomMenu({
           attributes: {
             source: "dina_material_sample_index",
             query: queryString,
-            columns: checkedColumnIds
+            columns: checkedColumnIds.filter((id) => id !== "selectColumn")
           }
         }
       },

--- a/packages/common-ui/lib/column-chooser/GroupedCheckboxWithLabel.tsx
+++ b/packages/common-ui/lib/column-chooser/GroupedCheckboxWithLabel.tsx
@@ -1,4 +1,4 @@
-import { startCase, uniq } from "lodash";
+import { startCase } from "lodash";
 import React, { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import { useLocalStorage } from "@rehooks/local-storage";
@@ -65,7 +65,7 @@ export function useGroupedCheckboxWithLabel({
   const [list, setList] = useState<CheckboxResource[]>(getResourcesWithId());
   const [checkedColumnIds, setCheckedColumnIds] = useLocalStorage<string[]>(
     `${indexName}_columnChooser`,
-    uniq([...list.map((resource) => resource.id ?? ""), "selectColumn"])
+    list.map((resource) => resource.id ?? "")
   );
   const [isCheckAll, setIsCheckAll] = useState<boolean>(
     checkedColumnIds.length === list.length
@@ -73,34 +73,29 @@ export function useGroupedCheckboxWithLabel({
 
   const handleSelectAll = (_e) => {
     setIsCheckAll(!isCheckAll);
-    setCheckedColumnIds(uniq([...list.map((li) => li.id), "selectColumn"]));
+    setCheckedColumnIds(list.map((li) => li.id));
     if (isCheckAll) {
-      setCheckedColumnIds(["selectColumn"]);
+      setCheckedColumnIds([]);
     }
   };
 
   const handleClick = (e) => {
     const { id, checked } = e.target;
     if (!checked) {
-      setCheckedColumnIds(
-        uniq([
-          ...checkedColumnIds.filter((item) => item !== id),
-          "selectColumn"
-        ])
-      );
+      setCheckedColumnIds(checkedColumnIds.filter((item) => item !== id));
       setIsCheckAll(false);
     } else {
       if ([...checkedColumnIds, id].length === list.length) {
         setIsCheckAll(true);
       }
-      setCheckedColumnIds(uniq([...checkedColumnIds, id, "selectColumn"]));
+      setCheckedColumnIds([...checkedColumnIds, id]);
     }
   };
 
   const groupedCheckBoxes = GroupedCheckboxes({
     handleSelectAll,
     isCheckAll,
-    list: list.filter((item) => item.id !== "selectColumn"),
+    list,
     handleClick,
     checkedColumnIds,
     isField

--- a/packages/common-ui/lib/column-chooser/GroupedCheckboxWithLabel.tsx
+++ b/packages/common-ui/lib/column-chooser/GroupedCheckboxWithLabel.tsx
@@ -29,12 +29,12 @@ export function Checkbox({
       ? formatMessage({ id: id as any })
       : startCase(id));
   return (
-    <div>
+    <div hidden={id === "selectColumn"}>
       <input
         id={id}
         type={"checkbox"}
         onChange={handleClick}
-        checked={isChecked}
+        checked={id === "selectColumn" ? true : isChecked}
         style={{
           marginRight: "0.3rem",
           height: "1.3rem",

--- a/packages/common-ui/lib/column-chooser/GroupedCheckboxWithLabel.tsx
+++ b/packages/common-ui/lib/column-chooser/GroupedCheckboxWithLabel.tsx
@@ -68,7 +68,8 @@ export function useGroupedCheckboxWithLabel({
     list.map((resource) => resource.id ?? "")
   );
   const [isCheckAll, setIsCheckAll] = useState<boolean>(
-    checkedColumnIds.length === list.length
+    checkedColumnIds.filter((id) => id !== "selectColumn").length ===
+      list.filter((resource) => resource.id !== "selectColumn").length
   );
 
   const handleSelectAll = (_e) => {
@@ -85,7 +86,12 @@ export function useGroupedCheckboxWithLabel({
       setCheckedColumnIds(checkedColumnIds.filter((item) => item !== id));
       setIsCheckAll(false);
     } else {
-      if ([...checkedColumnIds, id].length === list.length) {
+      if (
+        [...checkedColumnIds, id].filter(
+          (selectedId) => selectedId !== "selectColumn"
+        ).length ===
+        list.filter((resource) => resource.id !== "selectColumn").length
+      ) {
         setIsCheckAll(true);
       }
       setCheckedColumnIds([...checkedColumnIds, id]);

--- a/packages/common-ui/lib/list-page-layout/bulk-buttons.tsx
+++ b/packages/common-ui/lib/list-page-layout/bulk-buttons.tsx
@@ -117,6 +117,7 @@ export interface DataExportButtonProps {
   pathname: string;
   totalRecords: number;
   query: any;
+  indexName: string;
 }
 
 /**
@@ -129,7 +130,8 @@ export const DATA_EXPORT_SEARCH_RESULTS_KEY = "dataExportSearchResults";
 export function DataExportButton({
   pathname,
   totalRecords,
-  query
+  query,
+  indexName
 }: DataExportButtonProps) {
   const router = useRouter();
 
@@ -141,7 +143,7 @@ export function DataExportButton({
         writeStorage<any>(DATA_EXPORT_SEARCH_RESULTS_KEY, query);
         await router.push({
           pathname,
-          query: { totalRecords, hideTable: true }
+          query: { totalRecords, hideTable: true, indexName }
         });
       }}
     >

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -771,9 +771,8 @@ export function QueryPage<TData extends KitsuResource>({
 
   // Generate the key for the DINA form. It should only be generated once.
   const formKey = useMemo(() => uuidv4(), []);
-
   const { columnChooser, checkedColumnIds } = useColumnChooser({
-    columns: columnsResults,
+    columns: columnsResults.filter((column) => column.id !== "selectColumn"),
     indexName,
     hideExportButton: true
   });
@@ -823,6 +822,7 @@ export function QueryPage<TData extends KitsuResource>({
                       pathname={dataExportPath}
                       totalRecords={totalRecords}
                       query={elasticSearchQuery}
+                      indexName={indexName}
                     />
                   )}
                   {bulkSplitPath && (

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -772,7 +772,7 @@ export function QueryPage<TData extends KitsuResource>({
   // Generate the key for the DINA form. It should only be generated once.
   const formKey = useMemo(() => uuidv4(), []);
   const { columnChooser, checkedColumnIds } = useColumnChooser({
-    columns: columnsResults.filter((column) => column.id !== "selectColumn"),
+    columns: columnsResults,
     indexName,
     hideExportButton: true
   });

--- a/packages/dina-ui/pages/collection/material-sample/export.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/export.tsx
@@ -29,6 +29,7 @@ export default function MaterialSampleExportPage<
   const router = useRouter();
   const totalRecords = parseInt(router.query.totalRecords as string, 10);
   const hideTable: boolean | undefined = !!router.query.hideTable;
+  const indexName = String(router.query.indexName);
 
   const { formatMessage, formatNumber } = useIntl();
 
@@ -113,9 +114,9 @@ export default function MaterialSampleExportPage<
     }
   ];
 
-  const { columnChooser, checkedColumnIds } = useColumnChooser({
+  const { checkedColumnIds, CustomMenu } = useColumnChooser({
     columns,
-    indexName: "material_sample_export"
+    indexName
   });
 
   return (
@@ -136,7 +137,7 @@ export default function MaterialSampleExportPage<
             id="tableTotalCount"
             values={{ totalCount: formatNumber(totalRecords) }}
           />
-          {columnChooser}
+          <CustomMenu />
         </div>
 
         {!hideTable && (


### PR DESCRIPTION
- Column selection on Export page now uses selected columns from Material Sample list page
- Column selection menu now always visible on Export page, no longer needs Select Columns button
- Fixed bug related to selectColumn that caused Select All button to behave incorrectly
- Now no longer has Select Column option and Select All button works correctly