### PR TITLE
Support #32196 - Form template not working

### DIFF
--- a/packages/common-ui/lib/formik-connected/data-entry/DataEntryUtils.tsx
+++ b/packages/common-ui/lib/formik-connected/data-entry/DataEntryUtils.tsx
@@ -1,48 +1,108 @@
 /**
- * Process Extension Values from back-end into nested arrays for front-end
+ * Process Extension Values from back-end into nested arrays for front-end (formik) to use
+ * 
+ * @param {Object} initExtensionValues - The initial extension values loaded from the back-end.
+ * @returns {Object|undefined} The processed extension values for front-end use, or undefined if input is not provided.
  */
 export function processExtensionValuesLoading(initExtensionValues) {
+  // If not loaded from the API leave it undefined.
   if (!initExtensionValues) {
     return undefined;
   }
+
+  // Recursive function to check for the presence of .select property.
+  function hasSelectProperty(obj) {
+    if (typeof obj === 'object') {
+      if (obj.hasOwnProperty('select')) {
+        return true;
+      }
+      for (const key in obj) {
+        if (hasSelectProperty(obj[key])) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // Check if initExtensionValues or any nested objects contain a '.select' property.
+  if (hasSelectProperty(initExtensionValues)) {
+    return initExtensionValues;
+  }
+
+  // Initialize an object to store the processed extension values.
   const processedExtensionValues = {};
+
+  // Iterate through the keys of initExtensionValues (data blocks).
   Object.keys(initExtensionValues).forEach((blockKey) => {
+    // Create a nested object for each data block.
     processedExtensionValues[blockKey] = {};
     processedExtensionValues[blockKey].rows = {};
+
+    // Iterate through the keys of the data block (extension fields).
     Object.keys(initExtensionValues[blockKey]).forEach((extensionKey) => {
+
+      // Check if the key is not "rows" (a special case).
       if (extensionKey !== "rows") {
+
+        // Create an extension field object with 'type' and 'value'.
         const extensionField = {
           type: extensionKey,
           value: initExtensionValues[blockKey][extensionKey]
         };
+
+        // Store the extension field in the 'rows' property.
         processedExtensionValues[blockKey].rows[extensionKey] = extensionField;
       }
     });
+
+    // Set the 'select' property in the processed data to match the blockKey.
     processedExtensionValues[blockKey].select = blockKey;
   });
+
+  // Return the processed extension values for front-end use.
   return processedExtensionValues;
 }
 
 /**
- * Process Extension Values from front-end into nested maps for back-end
+ * Process extension values and store the processed data in the input object.
+ * 
+ * This will convert the formik extension values into a format for the API to understand.
+ * 
+ * @param {Object} submittedExtensionValues - The input data to process and store.
+ * @returns {Object} The processed extension values.
  */
 export function processExtensionValuesSaving(submittedExtensionValues: any) {
+  // Create an empty object to store the processed data.
   const processedExtensionValues = {};
+
+  // Loop through the keys of the submittedExtensionValues object.
   Object.keys(submittedExtensionValues).forEach((dataBlockKey) => {
+    // Extract the 'select' and 'rows' properties from the current dataBlock.
     const fieldKey = submittedExtensionValues[dataBlockKey]?.select;
     const extensionFieldsRows = submittedExtensionValues[dataBlockKey]?.rows;
+
+    // If the processedExtensionValues object doesn't have a property with the fieldKey,
+    // create an empty object for it.
     if (!processedExtensionValues[fieldKey]) {
       processedExtensionValues[fieldKey] = {};
     }
 
+    // Loop through the keys of the extensionFieldsRows object.
     Object.keys(extensionFieldsRows).forEach((rowKey) => {
+      // Extract the 'type' and 'value' properties from the current row.
       const type = extensionFieldsRows[rowKey]?.type;
       const value = extensionFieldsRows[rowKey]?.value;
+
+      // Add a new property to the processedExtensionValues object, under the fieldKey,
+      // where the property name is the 'type' and the value is the 'value'.
       processedExtensionValues[fieldKey] = {
         ...processedExtensionValues[fieldKey],
         [type]: value
       };
     });
   });
+
+  // Return the processedExtensionValues object with the rearranged data.
   return processedExtensionValues;
 }

--- a/packages/common-ui/lib/formik-connected/data-entry/DataEntryViewer.tsx
+++ b/packages/common-ui/lib/formik-connected/data-entry/DataEntryViewer.tsx
@@ -1,11 +1,7 @@
 import {
   DinaForm,
-  LoadingSpinner,
-  processExtensionValuesLoading,
-  useQuery
+  processExtensionValuesLoading
 } from "common-ui";
-import { useState } from "react";
-import { FieldExtension } from "../../../../dina-ui/types/collection-api/resources/FieldExtension";
 import { DataEntry, DataEntryProps } from "./DataEntry";
 
 export interface DataEntryViewerProps extends DataEntryProps {

--- a/packages/dina-ui/components/collection/collecting-event/CollectingEventFormLayout.tsx
+++ b/packages/dina-ui/components/collection/collecting-event/CollectingEventFormLayout.tsx
@@ -1004,7 +1004,7 @@ export function CollectingEventFormLayout({
         >
           <DataEntryField
             legend={<DinaMessage id="collectingEventFieldExtensions" />}
-            name="extensionValuesForm"
+            name="extensionValues"
             readOnly={readOnly}
             isTemplate={isTemplate}
             blockOptionsEndpoint={`collection-api/extension`}

--- a/packages/dina-ui/components/collection/collecting-event/useCollectingEvent.tsx
+++ b/packages/dina-ui/components/collection/collecting-event/useCollectingEvent.tsx
@@ -83,10 +83,7 @@ export function useCollectingEventQuery(id?: string | null) {
 
         // Process loaded back-end data into data structure that Forkmiks can use
         if (data.extensionValues) {
-          data.extensionValuesForm = processExtensionValuesLoading(
-            data.extensionValues
-          );
-          delete data.extensionValues;
+          data.extensionValues = processExtensionValuesLoading(data.extensionValues);
         }
       }
     }
@@ -265,12 +262,12 @@ export function useCollectingEventSave({
     ) {
       submittedValues.dwcVerbatimCoordinateSystem = null;
     }
-    if (submittedValues.extensionValuesForm) {
+
+    if (submittedValues.extensionValues) {
       submittedValues.extensionValues = processExtensionValuesSaving(
-        submittedValues.extensionValuesForm
+        submittedValues.extensionValues
       );
     }
-    delete submittedValues.extensionValuesForm;
 
     const [savedCollectingEvent] = await save<CollectingEvent>(
       [

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -325,7 +325,7 @@ export function MaterialSampleForm({
         >
           <DataEntryField
             legend={<DinaMessage id="materialSampleFieldExtensions" />}
-            name="extensionValuesForm"
+            name="extensionValues"
             readOnly={readOnly}
             isTemplate={isTemplate}
             id={id}

--- a/packages/dina-ui/components/collection/material-sample/useMaterialSample.tsx
+++ b/packages/dina-ui/components/collection/material-sample/useMaterialSample.tsx
@@ -103,12 +103,9 @@ export function useMaterialSampleQuery(id?: string | null) {
           }
         }
 
-        // Process loaded back-end data into data structure that Forkmiks can use
+        // Process loaded back-end data into data structure that Formik can use
         if (data.extensionValues) {
-          data.extensionValuesForm = processExtensionValuesLoading(
-            data.extensionValues
-          );
-          delete data.extensionValues;
+          data.extensionValues = processExtensionValuesLoading(data.extensionValues);
         }
 
         // Convert to separated list
@@ -487,12 +484,11 @@ export function useMaterialSampleSave({
       };
     }
 
-    if (submittedValues.extensionValuesForm) {
+    if (submittedValues.extensionValues) {
       submittedValues.extensionValues = processExtensionValuesSaving(
-        submittedValues.extensionValuesForm
+        submittedValues.extensionValues
       );
     }
-    delete submittedValues.extensionValuesForm;
 
     /** Input to submit to the back-end API. */
     const materialSampleInput: InputResource<MaterialSample> = {

--- a/packages/dina-ui/components/revisions/revision-row-configs/collectingevent-revision-config.tsx
+++ b/packages/dina-ui/components/revisions/revision-row-configs/collectingevent-revision-config.tsx
@@ -136,7 +136,7 @@ export const COLLECTING_EVENT_REVISION_ROW_CONFIG: RevisionRowConfig<CollectingE
         <DataEntryViewer
           extensionValues={value}
           legend={<></>}
-          name={"extensionValuesForm"}
+          name={"extensionValues"}
           blockOptionsEndpoint={`collection-api/extension`}
           blockOptionsFilter={{
             "extension.fields.dinaComponent": "COLLECTING_EVENT"

--- a/packages/dina-ui/components/revisions/revision-row-configs/material-sample-revision-configs.tsx
+++ b/packages/dina-ui/components/revisions/revision-row-configs/material-sample-revision-configs.tsx
@@ -243,7 +243,7 @@ export const MATERIAL_SAMPLE_REVISION_ROW_CONFIG: RevisionRowConfig<MaterialSamp
         <DataEntryViewer
           extensionValues={value}
           legend={<></>}
-          name={"extensionValuesForm"}
+          name={"extensionValues"}
           blockOptionsEndpoint={`collection-api/extension`}
           blockOptionsFilter={{
             "extension.fields.dinaComponent": "MATERIAL_SAMPLE"

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -306,7 +306,7 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
                   <ScheduledActionsField />
                 )}
                 <DataEntryViewer
-                  name={"extensionValuesForm"}
+                  name={"extensionValues"}
                   legend={<DinaMessage id="materialSampleFieldExtensions" />}
                   extensionValues={materialSample.extensionValues}
                   disableDinaForm={true}

--- a/packages/dina-ui/types/collection-api/resources/CollectingEvent.ts
+++ b/packages/dina-ui/types/collection-api/resources/CollectingEvent.ts
@@ -62,7 +62,6 @@ export interface CollectingEventAttributes {
 
   selectedSections?: string[];
   extensionValues?: any;
-  extensionValuesForm?: any;
   protocol?: Protocol;
 }
 

--- a/packages/dina-ui/types/collection-api/resources/MaterialSample.ts
+++ b/packages/dina-ui/types/collection-api/resources/MaterialSample.ts
@@ -74,7 +74,6 @@ export interface MaterialSampleAttributes {
   isRestricted?: boolean;
   restrictionRemarks?: string | null;
   extensionValues?: any;
-  extensionValuesForm?: any;
   version?: string;
 }
 


### PR DESCRIPTION
- Added comments to the DataEntryUtils.
- Added a check to the processExtensionValuesLoading to see if it has already been processed, if so don't re-process it.
-  Changed all "extensionValuesForm" back to "extensionValues" since it was causing issues with the form templates - added the check in processExtensionValuesLoading to prevent it from redoing it multiple times.