### PR TITLE
Support #32197 - Simplify query builder

### DIFF
--- a/packages/common-ui/common-ui-style.scss
+++ b/packages/common-ui/common-ui-style.scss
@@ -168,17 +168,23 @@ input[type="number"]::-webkit-outer-spin-button {
   top: 0px !important;
 }
 
+// Hide the query builder line if only one item is in the group (toggled by hide--line)
+.group--children.hide--line > .group-or-rule-container > .group-or-rule::before {
+  border-color: transparent !important;
+}
+
 /* 
  * Toggle Group Styles
  */
 .toggleGroup {
   position: relative;
   background: white;
-  border: 2px solid #dadada;
+  border: 2px solid #cccccc;
   border-radius: 10px;
   padding: 3px;
   float: left;
-  top: 5px;
+  top: 7px;
+  margin-left: 1px;
 }
 
 .toggleButton:last-child {
@@ -193,6 +199,11 @@ input[type="number"]::-webkit-outer-spin-button {
   border: none;
   box-shadow: none !important;
   transition: background 0.3s, color 0.3s;
+}
+
+.toggleButton > span {
+  position: relative;
+  top: 2px;
 }
 
 .activeToggle {

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-core-components/QueryConjunctionSwitch.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-core-components/QueryConjunctionSwitch.tsx
@@ -4,13 +4,15 @@ import Button from "react-bootstrap/Button";
 interface QueryConjunctionSwitchProps {
   currentConjunction?: string;
   setConjunction?: (conjunction: string) => void;
+  disabled?: boolean;
 }
 
 export function QueryConjunctionSwitch({
   currentConjunction,
-  setConjunction
+  setConjunction,
+  disabled
 }: QueryConjunctionSwitchProps) {
-  return (
+  return !disabled ? (
     <>
       <div className="toggleGroup">
         <Button
@@ -21,7 +23,9 @@ export function QueryConjunctionSwitch({
           }
           onClick={(_) => setConjunction?.("AND")}
         >
-          <DinaMessage id="queryBuilder_conjunction_and" />
+          <span>
+            <DinaMessage id="queryBuilder_conjunction_and" />
+          </span>
         </Button>
         <Button
           className={
@@ -31,9 +35,11 @@ export function QueryConjunctionSwitch({
           }
           onClick={(_) => setConjunction?.("OR")}
         >
-          <DinaMessage id="queryBuilder_conjunction_or" />
+          <span>
+            <DinaMessage id="queryBuilder_conjunction_or" />
+          </span>
         </Button>
       </div>
     </>
-  );
+  ) : (<></>);
 }

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-core-components/__tests__/__snapshots__/QueryConjunctionSwitch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-core-components/__tests__/__snapshots__/QueryConjunctionSwitch.test.tsx.snap
@@ -5,20 +5,24 @@ exports[`QueryConjunctionSwitch component Snapshot Test 1`] = `
   <div className=\\"toggleGroup\\">
     <Button className=\\"toggleButton activeToggle\\" onClick={[Function: onClick]} variant=\\"primary\\" active={false} disabled={false}>
       <button onClick={[Function: onClick]} disabled={false} type=\\"button\\" className=\\"toggleButton activeToggle btn btn-primary\\">
-        <FormattedMessage id=\\"queryBuilder_conjunction_and\\">
-          <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_and\\">
-             
+        <span>
+          <FormattedMessage id=\\"queryBuilder_conjunction_and\\">
+            <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_and\\">
+               
+            </FormattedMessage>
           </FormattedMessage>
-        </FormattedMessage>
+        </span>
       </button>
     </Button>
     <Button className=\\"toggleButton\\" onClick={[Function: onClick]} variant=\\"primary\\" active={false} disabled={false}>
       <button onClick={[Function: onClick]} disabled={false} type=\\"button\\" className=\\"toggleButton btn btn-primary\\">
-        <FormattedMessage id=\\"queryBuilder_conjunction_or\\">
-          <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_or\\">
-             
+        <span>
+          <FormattedMessage id=\\"queryBuilder_conjunction_or\\">
+            <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_or\\">
+               
+            </FormattedMessage>
           </FormattedMessage>
-        </FormattedMessage>
+        </span>
       </button>
     </Button>
   </div>
@@ -30,20 +34,24 @@ exports[`QueryConjunctionSwitch component Snapshot Test 2`] = `
   <div className=\\"toggleGroup\\">
     <Button className=\\"toggleButton\\" onClick={[Function: onClick]} variant=\\"primary\\" active={false} disabled={false}>
       <button onClick={[Function: onClick]} disabled={false} type=\\"button\\" className=\\"toggleButton btn btn-primary\\">
-        <FormattedMessage id=\\"queryBuilder_conjunction_and\\">
-          <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_and\\">
-             
+        <span>
+          <FormattedMessage id=\\"queryBuilder_conjunction_and\\">
+            <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_and\\">
+               
+            </FormattedMessage>
           </FormattedMessage>
-        </FormattedMessage>
+        </span>
       </button>
     </Button>
     <Button className=\\"toggleButton activeToggle\\" onClick={[Function: onClick]} variant=\\"primary\\" active={false} disabled={false}>
       <button onClick={[Function: onClick]} disabled={false} type=\\"button\\" className=\\"toggleButton activeToggle btn btn-primary\\">
-        <FormattedMessage id=\\"queryBuilder_conjunction_or\\">
-          <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_or\\">
-             
+        <span>
+          <FormattedMessage id=\\"queryBuilder_conjunction_or\\">
+            <FormattedMessage defaultMessage=\\" \\" id=\\"queryBuilder_conjunction_or\\">
+               
+            </FormattedMessage>
           </FormattedMessage>
-        </FormattedMessage>
+        </span>
       </button>
     </Button>
   </div>

--- a/packages/common-ui/lib/list-page/query-builder/useQueryBuilderConfig.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/useQueryBuilderConfig.tsx
@@ -633,6 +633,7 @@ function generateBuilderConfig(
       <QueryConjunctionSwitch
         currentConjunction={conjunctionProps?.selectedConjunction}
         setConjunction={conjunctionProps?.setConjunction}
+        disabled={conjunctionProps?.disabled}
       />
     )
   };


### PR DESCRIPTION
- If only one rule is inside of a group (including the root group) it will now no longer display the conjunction switch, the line will also be removed until more than one rule is there.
- Moved the position and color of the toggle group slightly so it aligns with the line.
- Toggle switch text is now centered vertically with the button.