### PR TITLE
Support #32332 - Material sample children not loading

### DIFF
--- a/packages/common-ui/lib/custom-query-view/CustomQueryPageView.tsx
+++ b/packages/common-ui/lib/custom-query-view/CustomQueryPageView.tsx
@@ -54,14 +54,6 @@ export interface CustomQueryPageViewProps<TData extends KitsuResource>
   titleKey?: keyof typeof DINAUI_MESSAGES_ENGLISH;
 
   /**
-   * This key is used for generating the local storage key so the option can be saved in the users
-   * local storage.
-   *
-   * If no key is provided, local storage for saving the option will be disabled.
-   */
-  localStorageKey?: string;
-
-  /**
    * If options are provided, a dropdown menu to the right of the legend title will be displayed
    * to allow the user to choose the query thats being displayed.
    *
@@ -72,12 +64,11 @@ export interface CustomQueryPageViewProps<TData extends KitsuResource>
 
 export function CustomQueryPageView<TData extends KitsuResource>({
   titleKey,
-  localStorageKey,
   customQueryOptions,
   ...queryPageProps
 }: CustomQueryPageViewProps<TData>) {
-  const CUSTOM_QUERY_PAGE_LOCAL_STORAGE_KEY = localStorageKey
-    ? localStorageKey + "-custom-query-page-option"
+  const CUSTOM_QUERY_PAGE_LOCAL_STORAGE_KEY = queryPageProps.uniqueName
+    ? queryPageProps.uniqueName + "-custom-query-page-option"
     : null;
 
   const { formatMessage, locale } = useDinaIntl();
@@ -163,6 +154,7 @@ export function CustomQueryPageView<TData extends KitsuResource>({
         <>
           <QueryPage<TData>
             {...queryPageProps}
+            enableColumnChooser={false}
             customViewQuery={customQuerySelected.customQuery}
             customViewFields={customQuerySelected.customViewFields ?? []}
             customViewElasticSearchQuery={

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -92,6 +92,15 @@ export interface QueryPageProps<TData extends KitsuResource> {
   indexName: string;
 
   /**
+   * Used for generating the local storage keys. Every instance of the QueryPage should have it's
+   * own unique name.
+   * 
+   * In special cases where you want the sorting, pagination, column selection and other features
+   * to remain the same across tables, it can share the same name.
+   */
+  uniqueName: string;
+
+  /**
    * This is used to indicate to the QueryBuilder all the possible places for dynamic fields to
    * be searched against. It will also define the path and data component if required.
    *
@@ -237,6 +246,7 @@ const GROUP_STORAGE_KEY = "groupStorage";
  */
 export function QueryPage<TData extends KitsuResource>({
   indexName,
+  uniqueName,
   dynamicFieldMapping,
   columns,
   bulkDeleteButtonProps,
@@ -273,14 +283,14 @@ export function QueryPage<TData extends KitsuResource>({
   const [totalRecords, setTotalRecords] = useState<number>(0);
 
   // User applied sorting rules for elastic search to use.
-  const localStorageLastUsedSortKey = indexName + "-last-used-sort";
+  const localStorageLastUsedSortKey = uniqueName + "-last-used-sort";
   const [sortingRules, setSortingRules] = useLocalStorage<ColumnSort[]>(
     localStorageLastUsedSortKey,
     defaultSort ?? DEFAULT_SORT
   );
 
   // The pagination size.
-  const localStorageLastUsedPageSizeKey = indexName + "-last-used-page-size";
+  const localStorageLastUsedPageSizeKey = uniqueName + "-last-used-page-size";
   const [pageSize, setPageSize] = useLocalStorage<number>(
     localStorageLastUsedPageSizeKey,
     defaultPageSize ?? DEFAULT_PAGE_SIZE
@@ -288,7 +298,7 @@ export function QueryPage<TData extends KitsuResource>({
 
   // The pagination offset.
   const localStorageLastUsedPageOffsetKey =
-    indexName + "-last-used-page-offset";
+    uniqueName + "-last-used-page-offset";
   const [pageOffset, setPageOffset] = useLocalStorage<number>(
     localStorageLastUsedPageOffsetKey,
     0
@@ -685,8 +695,8 @@ export function QueryPage<TData extends KitsuResource>({
     ...columns
   ];
 
-  const localStorageLastUsedKey = indexName + "-last-used-tree";
-  const localStorageLastUsedTreeKey = indexName + "-saved-search-changed";
+  const localStorageLastUsedKey = uniqueName + "-last-used-tree";
+  const localStorageLastUsedTreeKey = uniqueName + "-saved-search-changed";
 
   /**
    * Reset the search filters to a blank state. Errors are also cleared since a new filter is being
@@ -792,7 +802,7 @@ export function QueryPage<TData extends KitsuResource>({
   const formKey = useMemo(() => uuidv4(), []);
   const { columnChooser, checkedColumnIds } = useColumnChooser({
     columns: columnsResults,
-    localStorageKey: indexName,
+    localStorageKey: uniqueName,
     hideExportButton: true
   });
 

--- a/packages/dina-ui/components/project/ProjectFormLayout.tsx
+++ b/packages/dina-ui/components/project/ProjectFormLayout.tsx
@@ -84,6 +84,7 @@ export function ProjectFormLayout() {
       {readOnly && (
         <CustomQueryPageView
           titleKey="attachedMaterialSamples"
+          uniqueName="attached-material-samples-project"
           columns={ELASTIC_SEARCH_COLUMN}
           indexName={"dina_material_sample_index"}
           viewMode={readOnly}

--- a/packages/dina-ui/components/seqdb/ngs-workflow/NgsSampleSelectionStep.tsx
+++ b/packages/dina-ui/components/seqdb/ngs-workflow/NgsSampleSelectionStep.tsx
@@ -272,6 +272,7 @@ export function NgsSampleSelectionStep({
       )}
       <QueryPage<any>
         indexName={"dina_material_sample_index"}
+        uniqueName="ngs-material-sample-selection-step"
         columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
         selectionMode={editMode}
         selectionResources={selectedResources}

--- a/packages/dina-ui/components/seqdb/pcr-workflow/SangerSampleSelectionStep.tsx
+++ b/packages/dina-ui/components/seqdb/pcr-workflow/SangerSampleSelectionStep.tsx
@@ -277,6 +277,7 @@ export function SangerSampleSelectionStep({
       )}
       <QueryPage<any>
         indexName={"dina_material_sample_index"}
+        uniqueName="pcr-material-sample-selection-step"
         columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
         selectionMode={editMode}
         selectionResources={selectedResources}

--- a/packages/dina-ui/components/transaction/MaterialSampleTransactionList.tsx
+++ b/packages/dina-ui/components/transaction/MaterialSampleTransactionList.tsx
@@ -16,6 +16,7 @@ export function MaterialSampleTransactionList({ transactionQueryDSL }) {
   return (
     <QueryPage
       indexName="dina_loan_transaction_index"
+      uniqueName="loan-transaction-material-samples"
       customViewElasticSearchQuery={transactionQueryDSL}
       customViewFields={[]}
       viewMode={true}

--- a/packages/dina-ui/pages/collection/assemblage/edit.tsx
+++ b/packages/dina-ui/pages/collection/assemblage/edit.tsx
@@ -241,6 +241,7 @@ export function AssemblageFormLayout() {
       {readOnly && (
         <CustomQueryPageView
           titleKey="attachedMaterialSamples"
+          uniqueName="attached-material-samples-assemblages"
           columns={ELASTIC_SEARCH_COLUMN}
           indexName={"dina_material_sample_index"}
           viewMode={readOnly}

--- a/packages/dina-ui/pages/collection/material-sample/list.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/list.tsx
@@ -301,6 +301,7 @@ export default function MaterialSampleListPage() {
         <QueryPage
           rowStyling={rowStyling}
           indexName={"dina_material_sample_index"}
+          uniqueName="material-sample-list"
           dynamicFieldMapping={{
             fields: [
               // Managed Attributes

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -209,7 +209,7 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
                 <CustomQueryPageView
                   indexName="dina_material_sample_index"
                   columns={ELASTIC_SEARCH_COLUMN_CHILDREN_VIEW}
-                  localStorageKey="material-sample-children"
+                  uniqueName="material-sample-children"
                   customQueryOptions={[
                     {
                       value: "materialSampleChildren",

--- a/packages/dina-ui/pages/loan-transaction/transaction/edit.tsx
+++ b/packages/dina-ui/pages/loan-transaction/transaction/edit.tsx
@@ -398,6 +398,7 @@ export function TransactionFormLayout({
         <div className="mb-3">
           <QueryPage<MaterialSample>
             indexName={"dina_material_sample_index"}
+            uniqueName="transaction-edit-material-sample"
             columns={ELASTIC_SEARCH_COLUMN}
             selectionMode={!readOnly}
             selectionResources={

--- a/packages/dina-ui/pages/loan-transaction/transaction/list.tsx
+++ b/packages/dina-ui/pages/loan-transaction/transaction/list.tsx
@@ -69,6 +69,7 @@ export default function TransactionListPage() {
         </ButtonBar>
         <QueryPage
           indexName={"dina_loan_transaction_index"}
+          uniqueName="transaction-list-material-samples"
           columns={TRANSACTION_TABLE_COLUMNS}
           dynamicFieldMapping={{
             fields: [

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -176,6 +176,7 @@ export default function MetadataListPage() {
             <SplitPagePanel>
               <QueryPage
                 indexName={"dina_object_store_index"}
+                uniqueName="object-store-list"
                 dynamicFieldMapping={{
                   fields: [
                     {

--- a/packages/dina-ui/pages/object-store/object/view.tsx
+++ b/packages/dina-ui/pages/object-store/object/view.tsx
@@ -116,6 +116,7 @@ export default function MetadataViewPage() {
                     {customViewQuery && (
                       <CustomQueryPageView
                         titleKey="attachedMaterialSamples"
+                        uniqueName="attached-material-samples-object-store"
                         columns={ELASTIC_SEARCH_COLUMN}
                         indexName={"dina_material_sample_index"}
                         viewMode={customViewQuery ? true : false}


### PR DESCRIPTION
- Custom Views now have column selection turned off (not supported yet anyway)
- Instead of using indexName for local storage, each QueryPage will now have a uniqueName so the settings can be stored per table.