### PR TITLE
Support #32335 - Add existing storage unit group rsql is incorrect

### DIFF
--- a/packages/dina-ui/components/storage/StorageFilter.tsx
+++ b/packages/dina-ui/components/storage/StorageFilter.tsx
@@ -63,16 +63,19 @@ export function StorageFilter({ onChange }: StorageFilterProps) {
             ]
           : []),
         ...(groupNames
-          ? groupNames.map((group, index) => {
-              return {
-                id: -index,
+          ? [
+              {
+                id: -1234,
                 type: "FILTER_ROW" as const,
-                attribute: "group",
                 predicate: "IS" as const,
                 searchType: "EXACT_MATCH" as const,
-                value: group
-              };
-            })
+                value: groupNames.join(","),
+                attribute: {
+                  allowRange: true,
+                  name: "group"
+                }
+              }
+            ]
           : [])
       ]
     });

--- a/packages/dina-ui/components/storage/__tests__/BrowseStorageTree.test.tsx
+++ b/packages/dina-ui/components/storage/__tests__/BrowseStorageTree.test.tsx
@@ -77,7 +77,7 @@ const mockGet = jest.fn<any, any>(async (path, params = {}) => {
     case "collection-api/storage-unit":
       if (
         params.filter?.parentStorageUnit === null ||
-        params.filter?.rsql === "group==aafc;group==cnc"
+        params.filter?.rsql === "group=in=(aafc,cnc)"
       ) {
         // Top-level units:
         return { data: [STORAGE_A], meta: { totalResourceCount: 1 } };
@@ -158,7 +158,7 @@ describe("BrowseStorageTree component", () => {
     // With no filter, gets the top-level units:
     expect(mockGet).lastCalledWith("collection-api/storage-unit", {
       filter: {
-        rsql: "group==aafc;group==cnc"
+        rsql: "group=in=(aafc,cnc)"
       },
       include: "storageUnitChildren,storageUnitType",
       page: {
@@ -179,7 +179,7 @@ describe("BrowseStorageTree component", () => {
     // With a filter, gets units from any level matching the search text:
     expect(mockGet).lastCalledWith("collection-api/storage-unit", {
       filter: {
-        rsql: "name==*test-search-text*;group==aafc;group==cnc"
+        rsql: "name==*test-search-text*;group=in=(aafc,cnc)"
       },
       include: "storageUnitChildren,storageUnitType",
       page: {

--- a/packages/dina-ui/components/storage/__tests__/StorageUnitChildrenViewer.test.tsx
+++ b/packages/dina-ui/components/storage/__tests__/StorageUnitChildrenViewer.test.tsx
@@ -70,7 +70,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           }
         case "hierarchy,storageUnitType":
           switch (params?.filter?.rsql) {
-            case "group==aafc;group==cnc":
+            case "group=in=(aafc,cnc)":
             case "":
               // The searchable table results:
               return {


### PR DESCRIPTION
- Changed filter to generate an IN with all of the options instead.
- Updated the test for the new RSQL being generated.