### PR TITLE
Support #32339 - Add existing storage unit search should not display …

### DIFF
--- a/packages/dina-ui/components/storage/BrowseStorageTree.tsx
+++ b/packages/dina-ui/components/storage/BrowseStorageTree.tsx
@@ -4,7 +4,6 @@ import {
   FormikButton,
   LoadingSpinner,
   MetaWithTotal,
-  Operation,
   rsql,
   useApiClient,
   useQuery,
@@ -27,6 +26,7 @@ import {
 export interface BrowseStorageTreeProps {
   onSelect?: (storageUnit: PersistedResource<StorageUnit>) => Promisable<void>;
   readOnly?: boolean;
+  parentStorageUnitUUID?: string;
 }
 
 /** Hierarchy of nodes UI to search for and find a Storage Unit. */
@@ -46,7 +46,12 @@ export function BrowseStorageTree(props: BrowseStorageTreeProps) {
         )}
         {":"}
       </div>
-      <StorageTreeList {...props} filter={filter} showPathInName={isFiltered} />
+      <StorageTreeList
+        {...props}
+        filter={filter}
+        showPathInName={isFiltered}
+        parentStorageUnitUUID={props.parentStorageUnitUUID}
+      />
     </div>
   );
 }
@@ -64,6 +69,8 @@ export interface StorageTreeListProps {
 
   /** Show the hierarchy path in the name. (Top-level only). */
   showPathInName?: boolean;
+
+  parentStorageUnitUUID?: string;
 }
 
 export function StorageTreeList({
@@ -72,7 +79,8 @@ export function StorageTreeList({
   parentId,
   disabled,
   filter,
-  showPathInName
+  showPathInName,
+  parentStorageUnitUUID
 }: StorageTreeListProps) {
   const limit = 100;
   const [pageNumber, setPageNumber] = useState(1);
@@ -160,8 +168,13 @@ export function StorageTreeList({
               showPathInName={showPathInName}
               storageUnit={unit as PersistedResource<StorageUnit>}
               onSelect={onSelect}
-              disabled={disabled}
+              disabled={
+                disabled || parentStorageUnitUUID
+                  ? unit.id === parentStorageUnitUUID
+                  : false
+              }
               checkForChildren={false}
+              parentStorageUnitUUID={parentStorageUnitUUID}
             />
           </div>
         ))}
@@ -186,8 +199,13 @@ export function StorageTreeList({
                   showPathInName={showPathInName}
                   storageUnit={unit}
                   onSelect={onSelect}
-                  disabled={disabled}
+                  disabled={
+                    disabled || parentStorageUnitUUID
+                      ? unit.id === parentStorageUnitUUID
+                      : false
+                  }
                   checkForChildren={true}
+                  parentStorageUnitUUID={parentStorageUnitUUID}
                 />
               </div>
             ))}
@@ -217,6 +235,8 @@ interface StorageUnitCollapserProps {
 
   /** If the storage unit has  */
   checkForChildren?: boolean;
+
+  parentStorageUnitUUID?: string;
 }
 
 function StorageUnitCollapser({
@@ -224,7 +244,8 @@ function StorageUnitCollapser({
   onSelect,
   disabled,
   showPathInName,
-  checkForChildren
+  checkForChildren,
+  parentStorageUnitUUID
 }: StorageUnitCollapserProps) {
   const [isOpen, setOpen] = useState(false);
   const { formatMessage } = useDinaIntl();
@@ -284,6 +305,7 @@ function StorageUnitCollapser({
             parentId={storageUnit.id}
             onSelect={onSelect}
             disabled={disabled}
+            parentStorageUnitUUID={parentStorageUnitUUID}
           />
         )}
       </div>

--- a/packages/dina-ui/components/storage/StorageFilter.tsx
+++ b/packages/dina-ui/components/storage/StorageFilter.tsx
@@ -10,10 +10,16 @@ import { DinaMessage } from "../../intl/dina-ui-intl";
 import { StorageUnitType } from "../../types/collection-api";
 
 export interface StorageFilterProps {
+  /**
+   * To prevent displaying itself in the search results, this UUID will be filtered from the 
+   * results.
+   */
+  parentStorageUnitUUID?: string;
+
   onChange: (newValue: FilterGroupModel | null) => void;
 }
 
-export function StorageFilter({ onChange }: StorageFilterProps) {
+export function StorageFilter({ onChange, parentStorageUnitUUID }: StorageFilterProps) {
   const [searchText, setSearchText] = useState<string>("");
   const [storageTypeFilter, setStorageTypeFilter] =
     useState<PersistedResource<StorageUnitType>>();
@@ -35,6 +41,19 @@ export function StorageFilter({ onChange }: StorageFilterProps) {
                 predicate: "IS" as const,
                 searchType: "PARTIAL_MATCH" as const,
                 value: searchText
+              }
+            ]
+          : []),
+        // Hide the parent storage unit, to prevent linking of itself.
+        ...(parentStorageUnitUUID
+          ? [
+              {
+                id: -432,
+                type: "FILTER_ROW" as const,
+                attribute: "uuid",
+                predicate: "IS NOT" as const,
+                searchType: "EXACT_MATCH" as const,
+                value: parentStorageUnitUUID
               }
             ]
           : []),

--- a/packages/dina-ui/components/storage/StorageLinker.tsx
+++ b/packages/dina-ui/components/storage/StorageLinker.tsx
@@ -30,6 +30,7 @@ export interface StorageLinkerProps {
   actionMode?: StorageActionMode;
   parentIdInURL?: string;
   createStorageMode?: boolean;
+  parentStorageUnitUUID?: string;
 }
 
 /** Multi-Tab Storage Assignment UI. */
@@ -39,7 +40,8 @@ export function StorageLinker({
   placeholder,
   actionMode,
   parentIdInURL,
-  createStorageMode
+  createStorageMode,
+  parentStorageUnitUUID
 }: StorageLinkerProps) {
   const [activeTab, setActiveTab] = useState(0);
   const { readOnly } = useDinaFormContext();
@@ -110,7 +112,10 @@ export function StorageLinker({
           >
             {!value?.id && (
               <TabPanel>
-                <StorageSearchSelector onChange={changeStorageAndResetTab} />
+                <StorageSearchSelector
+                  onChange={changeStorageAndResetTab}
+                  parentStorageUnitUUID={parentStorageUnitUUID}
+                />
               </TabPanel>
             )}
             {!value?.id && (
@@ -118,6 +123,7 @@ export function StorageLinker({
                 <BrowseStorageTree
                   onSelect={changeStorageAndResetTab}
                   readOnly={readOnly}
+                  parentStorageUnitUUID={parentStorageUnitUUID}
                 />
               </TabPanel>
             )}

--- a/packages/dina-ui/components/storage/StorageSearchSelector.tsx
+++ b/packages/dina-ui/components/storage/StorageSearchSelector.tsx
@@ -3,8 +3,7 @@ import {
   FilterGroupModel,
   FormikButton,
   QueryTable,
-  rsql,
-  useDinaFormContext
+  rsql
 } from "common-ui";
 import { KitsuResourceLink } from "kitsu";
 import Link from "next/link";
@@ -19,15 +18,21 @@ import {
 } from "./StorageUnitBreadCrumb";
 
 export interface StorageSearchSelectorProps {
+  /**
+   * To prevent displaying itself in the search results, this UUID will be filtered from the 
+   * results.
+   */
+  parentStorageUnitUUID?: string;
+
   onChange: (newValue: KitsuResourceLink) => Promisable<void>;
 }
 
 /** Table UI to search for and select a Storage Unit. */
 export function StorageSearchSelector({
-  onChange
+  onChange,
+  parentStorageUnitUUID
 }: StorageSearchSelectorProps) {
   const [filter, setFilter] = useState<FilterGroupModel | null>();
-  const { readOnly } = useDinaFormContext();
 
   const tableColumns: ColumnDefinition<StorageUnit>[] = [
     {
@@ -74,7 +79,7 @@ export function StorageSearchSelector({
           background-color: rgb(222, 252, 222) !important;
         }
       `}</style>
-      <StorageFilter onChange={setFilter} />
+      <StorageFilter onChange={setFilter} parentStorageUnitUUID={parentStorageUnitUUID} />
       <QueryTable
         columns={tableColumns}
         path="collection-api/storage-unit"

--- a/packages/dina-ui/components/storage/StorageUnitChildrenViewer.tsx
+++ b/packages/dina-ui/components/storage/StorageUnitChildrenViewer.tsx
@@ -128,6 +128,7 @@ export function StorageUnitChildrenViewer({
               actionMode="ADD_EXISTING_AS_CHILD"
               onChange={addExistingStorageUnitAsChild}
               createStorageMode={false}
+              parentStorageUnitUUID={storageUnit?.id}
             />
           )}
         </FieldSet>


### PR DESCRIPTION
- Storage Filter will now filter out the parent storage unit since it's not possible to link itself.
- Browse Storage Tree will now hide the "Select" button if it's being used for linking an existing parent storage unit.