### PR TITLE
Support #32343 - Add existing storage unit RSQL not working with dash…

### DIFF
--- a/packages/common-ui/lib/filter-builder/FilterBuilder.tsx
+++ b/packages/common-ui/lib/filter-builder/FilterBuilder.tsx
@@ -14,7 +14,18 @@ export type FilterAttribute = string | FilterAttributeConfig;
 export interface FilterAttributeConfig {
   name: string;
   label?: string;
+
+  /**
+   * If enabled, ranges will be split into greater than and less than parts.
+   * 
+   * Can be combined with allowList option as well.
+   */
   allowRange?: boolean;
+
+  /**
+   * If enabled, any commas will be automatically inserted into a IN query.
+   */
+  allowList?: boolean;
 
   /** Only needed for date or dropdown filters. */
   type?: FilterAttributeType;

--- a/packages/common-ui/lib/filter-builder/__tests__/rsql.test.ts
+++ b/packages/common-ui/lib/filter-builder/__tests__/rsql.test.ts
@@ -141,6 +141,7 @@ describe("rsql conversion", () => {
         {
           attribute: {
             allowRange: true,
+            allowList: true,
             label: "Number",
             name: "number"
           },
@@ -160,12 +161,39 @@ describe("rsql conversion", () => {
     expect(rsqlFilter).toEqual("number=in=(10,90),number=ge=30;number=le=50");
   });
 
+  it("Allows a list but no range filter.", () => {
+    const model: FilterGroupModel = {
+      children: [
+        {
+          attribute: {
+            allowRange: false,
+            allowList: true,
+            label: "Number",
+            name: "number"
+          },
+          id: 1,
+          predicate: "IS",
+          searchType: "PARTIAL_MATCH",
+          type: "FILTER_ROW",
+          value: "10,30-50,90"
+        }
+      ],
+      id: 6,
+      operator: "AND",
+      type: "FILTER_GROUP"
+    };
+
+    const rsqlFilter = rsql(model);
+    expect(rsqlFilter).toEqual("number=in=(10,30-50,90)");
+  });
+
   it("Allows a NOT list and range filter.", () => {
     const model: FilterGroupModel = {
       children: [
         {
           attribute: {
             allowRange: true,
+            allowList: true,
             label: "Number",
             name: "number"
           },
@@ -192,7 +220,7 @@ describe("rsql conversion", () => {
       children: [
         {
           attribute: {
-            allowRange: true,
+            allowList: true,
             label: "Number",
             name: "number"
           },

--- a/packages/dina-ui/components/storage/StorageFilter.tsx
+++ b/packages/dina-ui/components/storage/StorageFilter.tsx
@@ -71,7 +71,8 @@ export function StorageFilter({ onChange }: StorageFilterProps) {
                 searchType: "EXACT_MATCH" as const,
                 value: groupNames.join(","),
                 attribute: {
-                  allowRange: true,
+                  allowRange: false,
+                  allowList: true,
                   name: "group"
                 }
               }

--- a/packages/dina-ui/components/storage/__tests__/StorageUnitChildrenViewer.test.tsx
+++ b/packages/dina-ui/components/storage/__tests__/StorageUnitChildrenViewer.test.tsx
@@ -70,7 +70,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           }
         case "hierarchy,storageUnitType":
           switch (params?.filter?.rsql) {
-            case "group=in=(aafc,cnc)":
+            case "group=in=(aafc,cnc,overy-lab)":
             case "":
               // The searchable table results:
               return {
@@ -214,7 +214,7 @@ describe("StorageUnitChildrenViewer component", () => {
       <DinaForm initialValues={{}} readOnly={true}>
         <StorageUnitChildrenViewer storageUnit={storageUnitX} />,
       </DinaForm>,
-      { apiContext }
+      { apiContext, accountContext: { groupNames: ["aafc", "cnc", "overy-lab"] } }
     );
 
     wrapper.find("button.add-existing-as-child").simulate("click");


### PR DESCRIPTION
- Added new option in the RSQL builder to allowLists. (Can be combined with the allowRange option)
- Added a new test case in the rsql.test.ts for allowing lists but no ranges.
- The groupNames now has the allowRange off.
- Updated the Storage Unit Children Viewer test with a group containing a dash.