### PR TITLE
Bug #32371 - Elastic search query should not have empty sort objects

### DIFF
--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchExport.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchExport.tsx
@@ -265,7 +265,7 @@ export function applySortingRules<TData extends KitsuResource>(
     );
 
     // Add all of the queries to the existing elastic search query.
-    if (sortingQueries.length !== 0) {
+    if (!isEmpty(sortingQueries)) {
       return {
         ...elasticSearchQuery,
         sort: sortingQueries

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/__snapshots__/QueryBuilderElasticSearchExport.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/__snapshots__/QueryBuilderElasticSearchExport.test.tsx.snap
@@ -448,7 +448,6 @@ Object {
       ],
     },
   },
-  "sort": Object {},
 }
 `;
 

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -115,11 +115,13 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
   const transactionElasticQuery = useElasticSearchQuery({
     indexName: "dina_loan_transaction_index",
     queryDSL: {
-      _source: [
-        "data.id",
-        "data.attributes.materialDirection",
-        "data.attributes.transactionNumber"
-      ],
+      _source: {
+        includes: [
+          "data.id",
+          "data.attributes.materialDirection",
+          "data.attributes.transactionNumber"
+        ]
+      },
       size: 1,
       sort: {
         "data.attributes.openedDate": {


### PR DESCRIPTION
- Using the isEmpty lodash function instead to detect empty objects.
- Found a _source filtering without the includes, added it.