### PR TITLE
32753 Reset arrow on column headers when search is reset

### DIFF
--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -752,7 +752,7 @@ export function QueryPage<TData extends KitsuResource>({
   }, [totalColumns]);
 
   const resolvedReactTableProps: Partial<ReactTableProps<TData>> = {
-    defaultSorted: sortingRules,
+    sort: sortingRules,
     columnVisibility,
     ...computedReactTableProps
   };
@@ -1058,7 +1058,7 @@ export function QueryPage<TData extends KitsuResource>({
                   viewMode && selectedResources?.length ? false : true
                 }
                 onSortingChange={onSortChange}
-                defaultSorted={sortingRules}
+                sort={sortingRules}
                 // Table customization props
                 {...resolvedReactTableProps}
                 className="-striped react-table-overflow"

--- a/packages/common-ui/lib/table/QueryTable.tsx
+++ b/packages/common-ui/lib/table/QueryTable.tsx
@@ -392,7 +392,7 @@ export function QueryTable<TData extends KitsuResource>({
         className="-striped"
         columns={mappedColumns}
         data={(displayData as TData[]) ?? []}
-        defaultSorted={sortingRules}
+        sort={sortingRules}
         loading={loadingProp || queryIsLoading}
         enableFilters={enableFilters}
         defaultColumnFilters={columnFilters}

--- a/packages/common-ui/lib/table/ReactTable.tsx
+++ b/packages/common-ui/lib/table/ReactTable.tsx
@@ -41,7 +41,7 @@ export interface ReactTableProps<TData> {
   enableSorting?: boolean;
   enableMultiSort?: boolean;
   manualSorting?: boolean;
-  defaultSorted?: SortingState;
+  sort?: SortingState;
   onSortingChange?: (sorting: SortingState) => void;
   // Filtering
   enableFilters?: boolean;
@@ -129,6 +129,13 @@ export interface ReactTableProps<TData> {
   columnSelectorDefaultColumns?: any[];
 }
 
+const DEFAULT_SORT: SortingState = [
+  {
+    id: "createdOn",
+    desc: true
+  }
+];
+
 export function ReactTable<TData>({
   data,
   onRowMove,
@@ -148,7 +155,7 @@ export function ReactTable<TData>({
   onDataChanged,
   enableEditing,
   pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
-  defaultSorted,
+  sort,
   onSortingChange,
   manualSorting = false,
   defaultExpanded,
@@ -176,7 +183,7 @@ export function ReactTable<TData>({
   columnSelectorDefaultColumns
 }: ReactTableProps<TData>) {
   const { formatMessage } = useIntl();
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>(sort ?? DEFAULT_SORT);
   const [columnFilters, setColumnFilters] =
     useState<ColumnFiltersState>(defaultColumnFilters);
   const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({
@@ -233,7 +240,7 @@ export function ReactTable<TData>({
     ...(enableSorting && { getSortedRowModel: getSortedRowModel() }),
     ...(enableFilters && { getFilteredRowModel: getFilteredRowModel() }),
     initialState: {
-      sorting: defaultSorted,
+      sorting: sort ?? sorting,
       pagination: { pageIndex, pageSize },
       ...(defaultExpanded && {
         expanded: defaultExpanded
@@ -249,7 +256,7 @@ export function ReactTable<TData>({
         getExpandedRowModel: getExpandedRowModel()
       }),
     state: {
-      sorting,
+      sorting: sort ?? sorting,
       ...(columnVisibility && { columnVisibility }),
       ...(enableFilters && columnFilters && { columnFilters }),
       ...(manualPagination && {
@@ -329,10 +336,9 @@ export function ReactTable<TData>({
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
               {headerGroup.headers.map((header) => {
-                const defaultSortRule = defaultSorted?.find(
+                const defaultSortRule = sort?.find(
                   (sortRule) => sortRule.id === header.id
                 );
-
                 return (
                   <th
                     key={header.id}

--- a/packages/dina-ui/components/collection/material-sample/SamplesView.tsx
+++ b/packages/dina-ui/components/collection/material-sample/SamplesView.tsx
@@ -103,7 +103,7 @@ export function SamplesView({ samples, fieldSetId }: SamplesViewProps) {
         columns={CHILD_SAMPLES_COLUMNS}
         className="-striped react-table-overflow"
         data={samples ?? []}
-        defaultSorted={sortingRules}
+        sort={sortingRules}
         showPagination={shouldShowPagination}
       />
     </FieldSet>

--- a/packages/dina-ui/components/collection/material-sample/ScheduledActionsField.tsx
+++ b/packages/dina-ui/components/collection/material-sample/ScheduledActionsField.tsx
@@ -192,7 +192,7 @@ export function ScheduledActionsField({
                 {hasActions && (
                   <ReactTable<ScheduledAction>
                     columns={actionColumns}
-                    defaultSorted={[{ id: "date", desc: true }]}
+                    sort={[{ id: "date", desc: true }]}
                     data={scheduledActions}
                     showPagination={false}
                     className="-striped mb-2"

--- a/packages/dina-ui/components/revisions/RevisionsPageLayout.tsx
+++ b/packages/dina-ui/components/revisions/RevisionsPageLayout.tsx
@@ -164,7 +164,7 @@ export function RevisionsPageLayout({
                 </div>
               );
             },
-            defaultSorted: [],
+            sort: [],
             // Revisions are not sortable, they are pre-sorted by commit datetime.
             enableSorting: false,
             className: "no-hover-highlight"

--- a/packages/dina-ui/components/seqdb/ngs-index/NgsIndexField.tsx
+++ b/packages/dina-ui/components/seqdb/ngs-index/NgsIndexField.tsx
@@ -157,7 +157,7 @@ export function NgsIndexField({
                 {hasNgsIndexs && (
                   <ReactTable<NgsIndex>
                     columns={ngsIndexColumns}
-                    defaultSorted={[{ id: "date", desc: true }]}
+                    sort={[{ id: "date", desc: true }]}
                     data={ngsIndexes}
                     showPagination={false}
                     className="-striped mb-2"


### PR DESCRIPTION
- Fix incorrect use of states, now use state passed to ReactTable from QueryPage
- Fall back to ReactTable internal state otherwise
- Clicking on QueryPage reset should now correctly reset the sort indicators on column headers
- Refactored state names