### PR TITLE
Bug #32940 - Issue with managed attribute saved search with last saved search or default searches

### DIFF
--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
@@ -17,7 +17,6 @@ import QueryBuilderTextSearch, {
 } from "./QueryBuilderTextSearch";
 import { get } from "lodash";
 import { PersistedResource } from "kitsu";
-import { format } from "path/posix";
 
 interface QueryRowTextSearchProps {
   /**
@@ -80,14 +79,15 @@ export default function QueryRowManagedAttributeSearch({
     if (setValue) {
       setValue(JSON.stringify(managedAttributeState));
     }
-  }, [managedAttributeState, setValue]);
+  }, [managedAttributeState]);
 
   // Convert a value from Query Builder into the Managed Attribute State in this component.
+  // Dependent on the managedAttributeConfig to indicate when it's changed.
   useEffect(() => {
     if (value) {
       setManagedAttributeState(JSON.parse(value));
     }
-  }, [value]);
+  }, [managedAttributeConfig]);
 
   const managedAttributeSelected =
     managedAttributeState.selectedManagedAttribute;

--- a/packages/common-ui/lib/list-page/reload-last-search/useLastSavedSearch.tsx
+++ b/packages/common-ui/lib/list-page/reload-last-search/useLastSavedSearch.tsx
@@ -16,6 +16,11 @@ interface UseLastSavedSearchProps {
   >;
 
   /**
+   * Search has been loaded in.
+   */
+  setDefaultLoadedIn: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /**
    * For the last loaded search, we will actually perform the search by calling this callback
    * function.
    */
@@ -38,6 +43,7 @@ interface UseLastSavedSearchReturn {
 
 export function useLastSavedSearch({
   setQueryBuilderTree,
+  setDefaultLoadedIn,
   setSubmittedQueryBuilderTree,
   performSubmit,
   uniqueName
@@ -57,6 +63,7 @@ export function useLastSavedSearch({
       setSubmittedQueryBuilderTree(
         Utils.loadTree(localStorageQueryTree as JsonTree)
       );
+      setDefaultLoadedIn(true);
     } else {
       // Nothing to load in, mark as loaded.
       setQueryLoaded(true);

--- a/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
+++ b/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
@@ -457,12 +457,8 @@ export function SavedSearch({
       // Ask the user if they sure they want to delete the saved search.
       openModal(
         <AreYouSureModal
-          actionMessage={
-            <>
-              <DinaMessage id="removeSavedSearch" />{" "}
-              {`${savedSearchName ?? ""}`}{" "}
-            </>
-          }
+          actionMessage={<DinaMessage id="removeSavedSearch" />}
+          messageBody={<DinaMessage id="areYouSureRemoveSavedSearch" values={{savedSearchName: savedSearchName}} />}
           onYesButtonClicked={deleteSearch}
         />
       );

--- a/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
+++ b/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
@@ -141,6 +141,7 @@ export function SavedSearch({
   useLastSavedSearch({
     setQueryBuilderTree,
     setSubmittedQueryBuilderTree,
+    setDefaultLoadedIn,
     performSubmit,
     uniqueName
   });
@@ -191,7 +192,7 @@ export function SavedSearch({
   // When a new saved search is selected.
   useEffect(() => {
     if (!selectedSavedSearch || !userPreferences) return;
-
+    setQueryError(undefined);
     loadSavedSearch(selectedSavedSearch);
   }, [selectedSavedSearch, lastSelected]);
 

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -722,6 +722,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
     "Remove Managed Attribute Value: {attributeNames}",
   removeOrganism: "Remove Organism",
   removeSavedSearch: "Remove Saved Search",
+  areYouSureRemoveSavedSearch: "Are you sure you want to remove: \"{savedSearchName}\"?",
   removeThisElement: "Remove This {typeName}",
   removeThisPlaceLabel: " Remove this Place",
   requiredField: "Required field",


### PR DESCRIPTION
- Default loaded in state is now set to true when last loaded has been already loaded in, default search will be skipped now.
- Query error is cleared when a new search is selected and redetermined.