### PR TITLE
Support #32813 - Autocomplete on material sample type not working

### DIFF
--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
@@ -1,7 +1,6 @@
 import { mountWithAppContext2 } from "common-ui/lib/test-util/mock-app-context";
 import { QueryBuilderAutoSuggestionTextSearchMemo } from "../QueryBuilderAutoSuggestionSearch";
 import { waitFor } from "@testing-library/react";
-import {fireEvent, screen} from '@testing-library/dom';
 
 const INDEX_NAME = "dina-material-sample-index";
 
@@ -76,6 +75,9 @@ const apiClientMock = {
 }
 
 describe("QueryBuilderAutoSuggestionSearch", () => {
+
+  beforeEach(jest.clearAllMocks);
+
   describe("QueryBuilderAutoSuggestionSearch Component", () => {
     it("Display field if match type is equals", async () => {
       // This test will just ensure the layout does not change unexpectedly.
@@ -172,10 +174,21 @@ describe("QueryBuilderAutoSuggestionSearch", () => {
       // Wait for the api call to be made.
       await waitFor(() => expect(mockAutoSuggestionRequest).toBeCalledTimes(1));
 
-      // Click on the textbox to make the dropdown options appear.
-      fireEvent.click(autoSuggestionComponent.getByRole("textbox"));
+      // Simulate focus, to display the suggestions dialog.
+      autoSuggestionComponent.getByRole("textbox").focus();
 
-      // Debugging: screen.logTestingPlaygroundURL();
+      // Wait for the component to update after focus change
+      await waitFor(() => expect(autoSuggestionComponent.getByRole("textbox")).toHaveFocus);
+
+      // Get each suggestion item and assert its content
+      const suggestions = autoSuggestionComponent.getAllByRole('option');
+      expect(suggestions.length).toBe(4); // Ensure there are 4 options
+
+      // Assert the text content of each suggestion
+      expect(suggestions[0].textContent).toBe('WHOLE_ORGANISM');
+      expect(suggestions[1].textContent).toBe('MIXED_ORGANISMS');
+      expect(suggestions[2].textContent).toBe('MOLECULAR_SAMPLE');
+      expect(suggestions[3].textContent).toBe('CULTURE_STRAIN');
     });
   });
 });

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
@@ -174,6 +174,28 @@ describe("QueryBuilderAutoSuggestionSearch", () => {
       // Wait for the api call to be made.
       await waitFor(() => expect(mockAutoSuggestionRequest).toBeCalledTimes(1));
 
+      // Ensure the API request was made correctly.
+      expect(mockAutoSuggestionRequest).toBeCalledWith(
+        "search-api/search-ws/search", // Search endpoint
+        {
+          aggs: {
+            term_aggregation: {
+              terms: {
+                field: "data.attributes.materialSampleType.keyword",
+                size: 100,
+              },
+            },
+          },
+          query: {
+            terms: {
+              "data.attributes.group": ["aafc", "cnc"],
+            },
+          },
+          size: 0,
+        },
+        {"params": {"indexName": "dina-material-sample-index"}}
+      );
+
       // Simulate focus, to display the suggestions dialog.
       autoSuggestionComponent.getByRole("textbox").focus();
 

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
@@ -1,0 +1,181 @@
+import { mountWithAppContext2 } from "common-ui/lib/test-util/mock-app-context";
+import { QueryBuilderAutoSuggestionTextSearchMemo } from "../QueryBuilderAutoSuggestionSearch";
+import { waitFor } from "@testing-library/react";
+import {fireEvent, screen} from '@testing-library/dom';
+
+const INDEX_NAME = "dina-material-sample-index";
+
+const CURRENT_FIELD_NAME = "data.attributes.materialSampleType";
+
+const INDEX_MAP = [
+  {
+    label: "materialSampleType",
+    value: "data.attributes.materialSampleType",
+    type: "text",
+    path: "data.attributes",
+    distinctTerm: true,
+    keywordMultiFieldSupport: true,
+    optimizedPrefix: false,
+    containsSupport: false,
+    endsWithSupport: false
+  }
+]
+
+const mockAutoSuggestionRequest = jest.fn<any, any>(async (path) => {
+  if (path === "search-api/search-ws/search") {
+    return {
+      data: {
+        took: 3,
+        timed_out: false,
+        _shards: {
+          failed: 0.0,
+          successful: 1.0,
+          total: 1.0,
+          skipped: 0.0
+        },
+        hits: {
+          total: {
+            relation: "eq",
+            value: 0
+          },
+          hits: []
+        },
+        aggregations: {
+          "sterms#term_aggregation": {
+            buckets: [
+              {
+                doc_count: 7,
+                key: "WHOLE_ORGANISM"
+              },
+              {
+                doc_count: 6,
+                key: "MIXED_ORGANISMS"
+              },
+              {
+                doc_count: 5,
+                key: "MOLECULAR_SAMPLE"
+              },
+              {
+                doc_count: 1,
+                key: "CULTURE_STRAIN"
+              }
+            ],
+            doc_count_error_upper_bound: 0,
+            sum_other_doc_count: 0
+          }
+        }
+      }
+    };
+  }
+});
+
+const apiClientMock = {
+  apiClient: {
+    axios: { post: mockAutoSuggestionRequest } as any
+  }
+}
+
+describe("QueryBuilderAutoSuggestionSearch", () => {
+  describe("QueryBuilderAutoSuggestionSearch Component", () => {
+    it("Display field if match type is equals", async () => {
+      // This test will just ensure the layout does not change unexpectedly.
+      // Any changes to the layout, the snapshots will need to be updated.
+      const autoSuggestionEquals = mountWithAppContext2(
+        <QueryBuilderAutoSuggestionTextSearchMemo
+          indexName={INDEX_NAME}
+          indexMap={INDEX_MAP}
+          currentFieldName={CURRENT_FIELD_NAME}
+          matchType="equals"
+          value="test"
+          setValue={jest.fn}
+        />,
+        { apiContext: apiClientMock }
+      );
+    
+      // Expect a snapshot with the date field being displayed.
+      expect(autoSuggestionEquals.asFragment()).toMatchSnapshot(
+        "Expect date field to be displayed since match type is equals"
+      );
+    
+      const autoSuggestionEmpty = mountWithAppContext2(
+        <QueryBuilderAutoSuggestionTextSearchMemo
+          indexName={INDEX_NAME}
+          indexMap={INDEX_MAP}
+          currentFieldName={CURRENT_FIELD_NAME}
+          matchType="empty"
+          value="test"
+          setValue={jest.fn}
+        />,
+        { apiContext: apiClientMock }
+      );
+    
+      // Expect a snapshot without the date field being displayed.
+      expect(autoSuggestionEmpty.asFragment()).toMatchSnapshot(
+        "Expect date field not to be displayed since the match type is not equals"
+      );
+    });
+
+    it("Display different placeholder on IN operators", async () => {
+      // This test will just ensure the layout does not change unexpectedly.
+      // Any changes to the layout, the snapshots will need to be updated.
+      const autoSuggestionIn = mountWithAppContext2(
+        <QueryBuilderAutoSuggestionTextSearchMemo
+          indexName={INDEX_NAME}
+          indexMap={INDEX_MAP}
+          currentFieldName={CURRENT_FIELD_NAME}
+          matchType="in"
+          value="test"
+          setValue={jest.fn}
+        />,
+        { apiContext: apiClientMock }
+      );
+    
+      // Expect a snapshot with a specific placeholder.
+      expect(autoSuggestionIn.asFragment()).toMatchSnapshot(
+        "Expect auto-suggestion field to be displayed with a different placeholder."
+      );
+    
+      const autoSuggestionNotIn = mountWithAppContext2(
+        <QueryBuilderAutoSuggestionTextSearchMemo
+          indexName={INDEX_NAME}
+          indexMap={INDEX_MAP}
+          currentFieldName={CURRENT_FIELD_NAME}
+          matchType="notIn"
+          value="test"
+          setValue={jest.fn}
+        />,
+        { apiContext: apiClientMock }
+      );
+    
+      // Expect a snapshot with a specific placeholder.
+      expect(autoSuggestionNotIn.asFragment()).toMatchSnapshot(
+        "Expect auto-suggestion field to be displayed with a different placeholder."
+      );
+    });
+
+    it("Display suggestions on equals or not equals operators", async () => {
+      const autoSuggestionComponent = mountWithAppContext2(
+        <QueryBuilderAutoSuggestionTextSearchMemo
+          indexName={INDEX_NAME}
+          indexMap={INDEX_MAP}
+          currentFieldName={CURRENT_FIELD_NAME}
+          matchType="equals"
+          value=""
+          setValue={jest.fn}
+        />,
+        { apiContext: apiClientMock }
+      );
+
+      // Wait for the auto-suggestion element to be loaded in.
+      await waitFor(() => expect(autoSuggestionComponent.findByRole("textbox")).not.toBeNull());
+
+      // Wait for the api call to be made.
+      await waitFor(() => expect(mockAutoSuggestionRequest).toBeCalledTimes(1));
+
+      // Click on the textbox to make the dropdown options appear.
+      fireEvent.click(autoSuggestionComponent.getByRole("textbox"));
+
+      // Debugging: screen.logTestingPlaygroundURL();
+    });
+  });
+});

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderBooleanSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderBooleanSearch.test.tsx
@@ -1,4 +1,4 @@
-import { mountWithAppContext } from "common-ui/lib/test-util/mock-app-context";
+import { mountWithAppContext2 } from "common-ui/lib/test-util/mock-app-context";
 import QueryBuilderBooleanSearch, {
   transformBooleanSearchToDSL
 } from "../QueryBuilderBooleanSearch";
@@ -8,7 +8,7 @@ describe("QueryBuilderBooleanSearch", () => {
     it("Display field if match type is equals", async () => {
       // This test will just ensure the layout does not change unexpectedly.
       // Any changes to the layout, the snapshots will need to be updated.
-      const boolSearchEquals = mountWithAppContext(
+      const boolSearchEquals = mountWithAppContext2(
         <QueryBuilderBooleanSearch
           matchType="equals"
           value="test"
@@ -17,13 +17,11 @@ describe("QueryBuilderBooleanSearch", () => {
       );
 
       // Expect a snapshot with the text field being displayed.
-      expect(
-        boolSearchEquals.find(QueryBuilderBooleanSearch).debug()
-      ).toMatchSnapshot(
+      expect(boolSearchEquals.asFragment()).toMatchSnapshot(
         "Expect boolean field to be displayed since match type is equals"
       );
 
-      const boolSearchEmpty = mountWithAppContext(
+      const boolSearchEmpty = mountWithAppContext2(
         <QueryBuilderBooleanSearch
           matchType="empty"
           value="test"
@@ -32,9 +30,7 @@ describe("QueryBuilderBooleanSearch", () => {
       );
 
       // Expect a snapshot without the text field being displayed.
-      expect(
-        boolSearchEmpty.find(QueryBuilderBooleanSearch).debug()
-      ).toMatchSnapshot(
+      expect(boolSearchEmpty.asFragment()).toMatchSnapshot(
         "Expect boolean field not to be displayed since the match type is not equals"
       );
     });

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderNumberSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderNumberSearch.test.tsx
@@ -1,4 +1,4 @@
-import { mountWithAppContext } from "common-ui/lib/test-util/mock-app-context";
+import { mountWithAppContext2 } from "common-ui/lib/test-util/mock-app-context";
 import QueryBuilderNumberSearch, {
   transformNumberSearchToDSL
 } from "../QueryBuilderNumberSearch";
@@ -8,7 +8,7 @@ describe("QueryBuilderNumberSearch", () => {
     it("Display field if match type is equals", async () => {
       // This test will just ensure the layout does not change unexpectedly.
       // Any changes to the layout, the snapshots will need to be updated.
-      const numberSearchEquals = mountWithAppContext(
+      const numberSearchEquals = mountWithAppContext2(
         <QueryBuilderNumberSearch
           matchType="equals"
           value="test"
@@ -17,13 +17,11 @@ describe("QueryBuilderNumberSearch", () => {
       );
 
       // Expect a snapshot with the number field being displayed.
-      expect(
-        numberSearchEquals.find(QueryBuilderNumberSearch).debug()
-      ).toMatchSnapshot(
+      expect(numberSearchEquals.asFragment()).toMatchSnapshot(
         "Expect number field to be displayed since match type is equals"
       );
 
-      const numberSearchEmpty = mountWithAppContext(
+      const numberSearchEmpty = mountWithAppContext2(
         <QueryBuilderNumberSearch
           matchType="empty"
           value="test"
@@ -32,9 +30,7 @@ describe("QueryBuilderNumberSearch", () => {
       );
 
       // Expect a snapshot without the number field being displayed.
-      expect(
-        numberSearchEmpty.find(QueryBuilderNumberSearch).debug()
-      ).toMatchSnapshot(
+      expect(numberSearchEmpty.asFragment()).toMatchSnapshot(
         "Expect number field not to be displayed since the match type is not equals"
       );
     });
@@ -42,7 +38,7 @@ describe("QueryBuilderNumberSearch", () => {
     it("Display different placeholder for in/not in operators", async () => {
       // This test will just ensure the layout does not change unexpectedly.
       // Any changes to the layout, the snapshots will need to be updated.
-      const numberSearchIn = mountWithAppContext(
+      const numberSearchIn = mountWithAppContext2(
         <QueryBuilderNumberSearch
           matchType="in"
           value="test"
@@ -51,13 +47,11 @@ describe("QueryBuilderNumberSearch", () => {
       );
 
       // Expect a snapshot with specific placeholder.
-      expect(
-        numberSearchIn.find(QueryBuilderNumberSearch).debug()
-      ).toMatchSnapshot(
+      expect(numberSearchIn.asFragment()).toMatchSnapshot(
         "Placeholder expected to be different for in operator."
       );
 
-      const numberSearchNotIn = mountWithAppContext(
+      const numberSearchNotIn = mountWithAppContext2(
         <QueryBuilderNumberSearch
           matchType="notIn"
           value="test"
@@ -66,9 +60,7 @@ describe("QueryBuilderNumberSearch", () => {
       );
 
       // Expect a snapshot with specific placeholder.
-      expect(
-        numberSearchNotIn.find(QueryBuilderNumberSearch).debug()
-      ).toMatchSnapshot(
+      expect(numberSearchNotIn.asFragment()).toMatchSnapshot(
         "Placeholder expected to be different for not in operator."
       );
     });

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderTextSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderTextSearch.test.tsx
@@ -1,4 +1,4 @@
-import { mountWithAppContext } from "common-ui/lib/test-util/mock-app-context";
+import { mountWithAppContext2 } from "common-ui/lib/test-util/mock-app-context";
 import QueryBuilderTextSearch, {
   transformTextSearchToDSL
 } from "../QueryBuilderTextSearch";
@@ -8,7 +8,7 @@ describe("QueryBuilderTextSearch", () => {
     it("Display field if match type is equals", async () => {
       // This test will just ensure the layout does not change unexpectedly.
       // Any changes to the layout, the snapshots will need to be updated.
-      const textSearchEquals = mountWithAppContext(
+      const textSearchEquals = mountWithAppContext2(
         <QueryBuilderTextSearch
           matchType="equals"
           value="test"
@@ -17,13 +17,11 @@ describe("QueryBuilderTextSearch", () => {
       );
 
       // Expect a snapshot with the text field being displayed.
-      expect(
-        textSearchEquals.find(QueryBuilderTextSearch).debug()
-      ).toMatchSnapshot(
+      expect(textSearchEquals.asFragment()).toMatchSnapshot(
         "Expect text field to be displayed since match type is equals"
       );
 
-      const textSearchEmpty = mountWithAppContext(
+      const textSearchEmpty = mountWithAppContext2(
         <QueryBuilderTextSearch
           matchType="empty"
           value="test"
@@ -32,9 +30,7 @@ describe("QueryBuilderTextSearch", () => {
       );
 
       // Expect a snapshot without the text field being displayed.
-      expect(
-        textSearchEmpty.find(QueryBuilderTextSearch).debug()
-      ).toMatchSnapshot(
+      expect(textSearchEmpty.asFragment()).toMatchSnapshot(
         "Expect text field not to be displayed since the match type is not equals"
       );
     });
@@ -42,7 +38,7 @@ describe("QueryBuilderTextSearch", () => {
     it("Display field if match type is in or not in", async () => {
       // This test will just ensure the layout does not change unexpectedly.
       // Any changes to the layout, the snapshots will need to be updated.
-      const textSearchIn = mountWithAppContext(
+      const textSearchIn = mountWithAppContext2(
         <QueryBuilderTextSearch
           matchType="in"
           value="test1, test2, test3"
@@ -51,13 +47,11 @@ describe("QueryBuilderTextSearch", () => {
       );
 
       // Expect a snapshot with the text field being with a different placeholder.
-      expect(
-        textSearchIn.find(QueryBuilderTextSearch).debug()
-      ).toMatchSnapshot(
+      expect(textSearchIn.asFragment()).toMatchSnapshot(
         "Expect text field to be displayed with a different placeholder."
       );
 
-      const textSearchNotIn = mountWithAppContext(
+      const textSearchNotIn = mountWithAppContext2(
         <QueryBuilderTextSearch
           matchType="notIn"
           value="test1, test2, test3"
@@ -66,9 +60,7 @@ describe("QueryBuilderTextSearch", () => {
       );
 
       // Expect a snapshot with the text field being with a different placeholder.
-      expect(
-        textSearchNotIn.find(QueryBuilderTextSearch).debug()
-      ).toMatchSnapshot(
+      expect(textSearchNotIn.asFragment()).toMatchSnapshot(
         "Expect text field to be displayed with a different placeholder."
       );
     });

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderAutoSuggestionSearch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderAutoSuggestionSearch.test.tsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QueryBuilderAutoSuggestionSearch QueryBuilderAutoSuggestionSearch Component Display different placeholder on IN operators: Expect auto-suggestion field to be displayed with a different placeholder. 1`] = `
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_in_placeholder"
+      type="text"
+      value="test"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`QueryBuilderAutoSuggestionSearch QueryBuilderAutoSuggestionSearch Component Display different placeholder on IN operators: Expect auto-suggestion field to be displayed with a different placeholder. 2`] = `
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_in_placeholder"
+      type="text"
+      value="test"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`QueryBuilderAutoSuggestionSearch QueryBuilderAutoSuggestionSearch Component Display field if match type is equals: Expect date field not to be displayed since the match type is not equals 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;
+
+exports[`QueryBuilderAutoSuggestionSearch QueryBuilderAutoSuggestionSearch Component Display field if match type is equals: Expect date field to be displayed since match type is equals 1`] = `
+<DocumentFragment>
+  <div>
+    <style>
+      
+          .autosuggest-container {
+            position: relative;
+            width: 100%;
+          }
+          .autosuggest .suggestions-container {
+            display: none;
+          }
+          .autosuggest .suggestions-container-open {
+            display: block;
+            position: absolute;
+            width: 100%;
+            z-index: 20;
+          }
+          .autosuggest .suggestion-highlighted { 
+            background-color: #ddd;
+            cursor: pointer;
+          }
+        
+    </style>
+    <div
+      class="autosuggest"
+    >
+      <div
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="react-autowhatever-1"
+        class="autosuggest-container"
+        role="combobox"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-controls="react-autowhatever-1"
+          autocomplete="none"
+          class="form-control"
+          placeholder="Type here to search."
+          type="text"
+          value="test"
+        />
+        <div
+          class="suggestions-container"
+          id="react-autowhatever-1"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderBooleanSearch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderBooleanSearch.test.tsx.snap
@@ -1,84 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`QueryBuilderBooleanSearch QueryBuilderBooleanSearch Component Display field if match type is equals: Expect boolean field not to be displayed since the match type is not equals 1`] = `"<QueryBuilderBooleanSearch matchType=\\"empty\\" value=\\"test\\" setValue={[Function: bound fn]} />"`;
+exports[`QueryBuilderBooleanSearch QueryBuilderBooleanSearch Component Display field if match type is equals: Expect boolean field not to be displayed since the match type is not equals 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;
 
 exports[`QueryBuilderBooleanSearch QueryBuilderBooleanSearch Component Display field if match type is equals: Expect boolean field to be displayed since match type is equals 1`] = `
-"<QueryBuilderBooleanSearch matchType=\\"equals\\" value=\\"test\\" setValue={[Function: bound fn]}>
-  <ForwardRef value={[undefined]} options={{...}} className=\\"flex-fill\\" onChange={[Function: onChange]}>
-    <Select options={{...}} className=\\"flex-fill\\" inputValue=\\"\\" menuIsOpen={false} onChange={[Function (anonymous)]} onInputChange={[Function (anonymous)]} onMenuClose={[Function (anonymous)]} onMenuOpen={[Function (anonymous)]} value={{...}} aria-live=\\"polite\\" backspaceRemovesValue={true} blurInputOnSelect={true} captureMenuScroll={false} closeMenuOnSelect={true} closeMenuOnScroll={false} components={{...}} controlShouldRenderValue={true} escapeClearsValue={false} filterOption={[Function (anonymous)]} formatGroupLabel={[Function: formatGroupLabel]} getOptionLabel={[Function: getOptionLabel]} getOptionValue={[Function: getOptionValue]} isDisabled={false} isLoading={false} isMulti={false} isRtl={false} isSearchable={true} isOptionDisabled={[Function: isOptionDisabled]} loadingMessage={[Function: loadingMessage]} maxMenuHeight={300} minMenuHeight={140} menuPlacement=\\"bottom\\" menuPosition=\\"absolute\\" menuShouldBlockScroll={false} menuShouldScrollIntoView={true} noOptionsMessage={[Function: noOptionsMessage]} openMenuOnFocus={false} openMenuOnClick={true} pageSize={5} placeholder=\\"Select...\\" screenReaderStatus={[Function: screenReaderStatus]} styles={{...}} tabIndex={0} tabSelectsValue={true}>
-      <SelectContainer clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} className=\\"flex-fill\\" innerProps={{...}} isDisabled={false} isFocused={false}>
-        <EmotionCssPropInternal css={{...}} className=\\"flex-fill\\" id={[undefined]} onKeyDown={[Function (anonymous)]} __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"div\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"SelectContainer\\">
-          <div className=\\"flex-fill css-b62m3t-container\\" id={[undefined]} onKeyDown={[Function (anonymous)]}>
-            <LiveRegion clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} id=\\"react-select-2-live-region\\" ariaSelection={{...}} focusedOption={{...}} focusedValue={{...}} isFocused={false} selectValue={{...}} focusableOptions={{...}}>
-              <A11yText id=\\"react-select-2-live-region\\">
-                <EmotionCssPropInternal css={{...}} id=\\"react-select-2-live-region\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"span\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"A11yText\\">
-                  <span id=\\"react-select-2-live-region\\" className=\\"css-1f43avz-a11yText-A11yText\\" />
-                </EmotionCssPropInternal>
-              </A11yText>
-              <A11yText aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\">
-                <EmotionCssPropInternal css={{...}} aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"span\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"A11yText\\">
-                  <span aria-live=\\"polite\\" aria-atomic=\\"false\\" aria-relevant=\\"additions text\\" className=\\"css-1f43avz-a11yText-A11yText\\" />
-                </EmotionCssPropInternal>
-              </A11yText>
-            </LiveRegion>
-            <Control clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} innerRef={[Function (anonymous)]} innerProps={{...}} isDisabled={false} isFocused={false} menuIsOpen={false}>
-              <EmotionCssPropInternal css={{...}} className=\\"\\" onMouseDown={[Function (anonymous)]} onTouchEnd={[Function (anonymous)]} __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"div\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"Control\\">
-                <div className=\\" css-1s2u09g-control\\" onMouseDown={[Function (anonymous)]} onTouchEnd={[Function (anonymous)]}>
-                  <ValueContainer clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} isDisabled={false}>
-                    <EmotionCssPropInternal css={{...}} className=\\"\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"div\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"ValueContainer\\">
-                      <div className=\\" css-319lph-ValueContainer\\">
-                        <Placeholder clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} isDisabled={false} isFocused={false} innerProps={{...}}>
-                          <EmotionCssPropInternal css={{...}} className=\\"\\" id=\\"react-select-2-placeholder\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"div\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"Placeholder\\">
-                            <div className=\\" css-14el2xx-placeholder\\" id=\\"react-select-2-placeholder\\">
-                              Select...
-                            </div>
-                          </EmotionCssPropInternal>
-                        </Placeholder>
-                        <Input clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} autoCapitalize=\\"none\\" autoComplete=\\"off\\" autoCorrect=\\"off\\" id=\\"react-select-2-input\\" innerRef={[Function (anonymous)]} isDisabled={false} isHidden={false} onBlur={[Function (anonymous)]} onChange={[Function (anonymous)]} onFocus={[Function (anonymous)]} spellCheck=\\"false\\" tabIndex={0} form={[undefined]} type=\\"text\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-expanded={false} aria-haspopup={true} aria-controls=\\"react-select-2-listbox\\" aria-owns=\\"react-select-2-listbox\\" aria-errormessage={[undefined]} aria-invalid={[undefined]} aria-label={[undefined]} aria-labelledby={[undefined]} role=\\"combobox\\" aria-describedby=\\"react-select-2-placeholder\\">
-                          <EmotionCssPropInternal className=\\"\\" css={{...}} data-value=\\"\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"div\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"Input\\">
-                            <div className=\\" css-6j8wv5-Input\\" data-value=\\"\\">
-                              <input className=\\"\\" style={{...}} disabled={false} autoCapitalize=\\"none\\" autoComplete=\\"off\\" autoCorrect=\\"off\\" id=\\"react-select-2-input\\" onBlur={[Function (anonymous)]} onChange={[Function (anonymous)]} onFocus={[Function (anonymous)]} spellCheck=\\"false\\" tabIndex={0} form={[undefined]} type=\\"text\\" value=\\"\\" aria-autocomplete=\\"list\\" aria-expanded={false} aria-haspopup={true} aria-controls=\\"react-select-2-listbox\\" aria-owns=\\"react-select-2-listbox\\" aria-errormessage={[undefined]} aria-invalid={[undefined]} aria-label={[undefined]} aria-labelledby={[undefined]} role=\\"combobox\\" aria-describedby=\\"react-select-2-placeholder\\" />
-                            </div>
-                          </EmotionCssPropInternal>
-                        </Input>
-                      </div>
-                    </EmotionCssPropInternal>
-                  </ValueContainer>
-                  <IndicatorsContainer clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} isDisabled={false}>
-                    <EmotionCssPropInternal css={{...}} className=\\"\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"div\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"IndicatorsContainer\\">
-                      <div className=\\" css-1hb7zxy-IndicatorsContainer\\">
-                        <IndicatorSeparator clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} isDisabled={false} isFocused={false}>
-                          <EmotionCssPropInternal css={{...}} className=\\"\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"span\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"IndicatorSeparator\\">
-                            <span className=\\" css-1okebmr-indicatorSeparator\\" />
-                          </EmotionCssPropInternal>
-                        </IndicatorSeparator>
-                        <DropdownIndicator clearValue={[Function (anonymous)]} cx={[Function (anonymous)]} getStyles={[Function (anonymous)]} getValue={[Function (anonymous)]} hasValue={false} isMulti={false} isRtl={false} options={{...}} selectOption={[Function (anonymous)]} selectProps={{...}} setValue={[Function (anonymous)]} theme={{...}} innerProps={{...}} isDisabled={false} isFocused={false}>
-                          <EmotionCssPropInternal css={{...}} className=\\"\\" onMouseDown={[Function (anonymous)]} onTouchEnd={[Function (anonymous)]} aria-hidden=\\"true\\" __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"div\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"DropdownIndicator\\">
-                            <div className=\\" css-tlfecz-indicatorContainer\\" onMouseDown={[Function (anonymous)]} onTouchEnd={[Function (anonymous)]} aria-hidden=\\"true\\">
-                              <DownChevron>
-                                <Svg size={20}>
-                                  <EmotionCssPropInternal height={20} width={20} viewBox=\\"0 0 20 20\\" aria-hidden=\\"true\\" focusable=\\"false\\" css={{...}} __EMOTION_TYPE_PLEASE_DO_NOT_USE__=\\"svg\\" __EMOTION_LABEL_PLEASE_DO_NOT_USE__=\\"Svg\\">
-                                    <svg height={20} width={20} viewBox=\\"0 0 20 20\\" aria-hidden=\\"true\\" focusable=\\"false\\" className=\\"css-tj5bde-Svg\\">
-                                      <path d=\\"M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z\\" />
-                                    </svg>
-                                  </EmotionCssPropInternal>
-                                </Svg>
-                              </DownChevron>
-                            </div>
-                          </EmotionCssPropInternal>
-                        </DropdownIndicator>
-                      </div>
-                    </EmotionCssPropInternal>
-                  </IndicatorsContainer>
-                </div>
-              </EmotionCssPropInternal>
-            </Control>
+<DocumentFragment>
+  <div>
+    <div
+      class="flex-fill css-b62m3t-container"
+    >
+      <span
+        class="css-1f43avz-a11yText-A11yText"
+        id="react-select-2-live-region"
+      />
+      <span
+        aria-atomic="false"
+        aria-live="polite"
+        aria-relevant="additions text"
+        class="css-1f43avz-a11yText-A11yText"
+      />
+      <div
+        class=" css-1s2u09g-control"
+      >
+        <div
+          class=" css-319lph-ValueContainer"
+        >
+          <div
+            class=" css-14el2xx-placeholder"
+            id="react-select-2-placeholder"
+          >
+            Select...
           </div>
-        </EmotionCssPropInternal>
-      </SelectContainer>
-    </Select>
-  </ForwardRef>
-</QueryBuilderBooleanSearch>"
+          <div
+            class=" css-6j8wv5-Input"
+            data-value=""
+          >
+            <input
+              aria-autocomplete="list"
+              aria-controls="react-select-2-listbox"
+              aria-describedby="react-select-2-placeholder"
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-owns="react-select-2-listbox"
+              autocapitalize="none"
+              autocomplete="off"
+              autocorrect="off"
+              class=""
+              id="react-select-2-input"
+              role="combobox"
+              spellcheck="false"
+              style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+              tabindex="0"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class=" css-1hb7zxy-IndicatorsContainer"
+        >
+          <span
+            class=" css-1okebmr-indicatorSeparator"
+          />
+          <div
+            aria-hidden="true"
+            class=" css-tlfecz-indicatorContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-tj5bde-Svg"
+              focusable="false"
+              height="20"
+              viewBox="0 0 20 20"
+              width="20"
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`QueryBuilderBooleanSearch transformBooleanSearchToDSL function Edge cases If no field value is provided, nothing should be generated. 1`] = `Object {}`;

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderNumberSearch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderNumberSearch.test.tsx.snap
@@ -1,23 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`QueryBuilderNumberSearch QueryBuilderNumberSearch Component Display different placeholder for in/not in operators: Placeholder expected to be different for in operator. 1`] = `
-"<QueryBuilderNumberSearch matchType=\\"in\\" value=\\"test\\" setValue={[Function: bound fn]}>
-  <input type=\\"text\\" value=\\"test\\" onChange={[Function: onChange]} className=\\"form-control\\" placeholder=\\"queryBuilder_value_in_placeholder\\" />
-</QueryBuilderNumberSearch>"
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_in_placeholder"
+      type="text"
+      value="test"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`QueryBuilderNumberSearch QueryBuilderNumberSearch Component Display different placeholder for in/not in operators: Placeholder expected to be different for not in operator. 1`] = `
-"<QueryBuilderNumberSearch matchType=\\"notIn\\" value=\\"test\\" setValue={[Function: bound fn]}>
-  <input type=\\"text\\" value=\\"test\\" onChange={[Function: onChange]} className=\\"form-control\\" placeholder=\\"queryBuilder_value_in_placeholder\\" />
-</QueryBuilderNumberSearch>"
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_in_placeholder"
+      type="text"
+      value="test"
+    />
+  </div>
+</DocumentFragment>
 `;
 
-exports[`QueryBuilderNumberSearch QueryBuilderNumberSearch Component Display field if match type is equals: Expect number field not to be displayed since the match type is not equals 1`] = `"<QueryBuilderNumberSearch matchType=\\"empty\\" value=\\"test\\" setValue={[Function: bound fn]} />"`;
+exports[`QueryBuilderNumberSearch QueryBuilderNumberSearch Component Display field if match type is equals: Expect number field not to be displayed since the match type is not equals 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;
 
 exports[`QueryBuilderNumberSearch QueryBuilderNumberSearch Component Display field if match type is equals: Expect number field to be displayed since match type is equals 1`] = `
-"<QueryBuilderNumberSearch matchType=\\"equals\\" value=\\"test\\" setValue={[Function: bound fn]}>
-  <input type=\\"number\\" value=\\"test\\" onChange={[Function: onChange]} className=\\"form-control\\" placeholder=\\"queryBuilder_value_number_placeholder\\" />
-</QueryBuilderNumberSearch>"
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_number_placeholder"
+      type="number"
+      value="test"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`QueryBuilderNumberSearch transformNumberSearchToDSL function Edge cases If no field value is provided, nothing should be generated. 1`] = `Object {}`;

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderTextSearch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderTextSearch.test.tsx.snap
@@ -1,23 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`QueryBuilderTextSearch QueryBuilderTextSearch Component Display field if match type is equals: Expect text field not to be displayed since the match type is not equals 1`] = `"<QueryRowTextSearch matchType=\\"empty\\" value=\\"test\\" setValue={[Function: bound fn]} />"`;
+exports[`QueryBuilderTextSearch QueryBuilderTextSearch Component Display field if match type is equals: Expect text field not to be displayed since the match type is not equals 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;
 
 exports[`QueryBuilderTextSearch QueryBuilderTextSearch Component Display field if match type is equals: Expect text field to be displayed since match type is equals 1`] = `
-"<QueryRowTextSearch matchType=\\"equals\\" value=\\"test\\" setValue={[Function: bound fn]}>
-  <input type=\\"text\\" value=\\"test\\" onChange={[Function: onChange]} className=\\"form-control\\" placeholder=\\"queryBuilder_value_text_placeholder\\" />
-</QueryRowTextSearch>"
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_text_placeholder"
+      type="text"
+      value="test"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`QueryBuilderTextSearch QueryBuilderTextSearch Component Display field if match type is in or not in: Expect text field to be displayed with a different placeholder. 1`] = `
-"<QueryRowTextSearch matchType=\\"in\\" value=\\"test1, test2, test3\\" setValue={[Function: bound fn]}>
-  <input type=\\"text\\" value=\\"test1, test2, test3\\" onChange={[Function: onChange]} className=\\"form-control\\" placeholder=\\"queryBuilder_value_in_placeholder\\" />
-</QueryRowTextSearch>"
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_in_placeholder"
+      type="text"
+      value="test1, test2, test3"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`QueryBuilderTextSearch QueryBuilderTextSearch Component Display field if match type is in or not in: Expect text field to be displayed with a different placeholder. 2`] = `
-"<QueryRowTextSearch matchType=\\"notIn\\" value=\\"test1, test2, test3\\" setValue={[Function: bound fn]}>
-  <input type=\\"text\\" value=\\"test1, test2, test3\\" onChange={[Function: onChange]} className=\\"form-control\\" placeholder=\\"queryBuilder_value_in_placeholder\\" />
-</QueryRowTextSearch>"
+<DocumentFragment>
+  <div>
+    <input
+      class="form-control"
+      placeholder="queryBuilder_value_in_placeholder"
+      type="text"
+      value="test1, test2, test3"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`QueryBuilderTextSearch transformTextSearchToDSL function ContainsText (Infix) operation Normal field 1`] = `


### PR DESCRIPTION
- Migrated the Boolean and Number Query Search tests to use "React-testing-library" instead of enzyme.
- Started working on the new Auto Suggestion Query tests, with mocks to the elastic search request/response.