### PR TITLE
Support #33028 - Improve the Saved Search Deletion Dialog

### DIFF
--- a/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
+++ b/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
@@ -509,7 +509,12 @@ export function SavedSearch({
       openModal(
         <AreYouSureModal
           actionMessage={<DinaMessage id="removeSavedSearch" />}
-          messageBody={<DinaMessage id="areYouSureRemoveSavedSearch" values={{savedSearchName: savedSearchName}} />}
+          messageBody={
+            <>
+              <strong><DinaMessage id="areYouSureRemoveSavedSearch"/></strong><br/>
+              "{savedSearchName}"
+            </>
+          }
           onYesButtonClicked={deleteSearch}
         />
       );

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -722,7 +722,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
     "Remove Managed Attribute Value: {attributeNames}",
   removeOrganism: "Remove Organism",
   removeSavedSearch: "Remove Saved Search",
-  areYouSureRemoveSavedSearch: "Are you sure you want to remove: \"{savedSearchName}\"?",
+  areYouSureRemoveSavedSearch: "Are you sure you want to remove:",
   removeThisElement: "Remove This {typeName}",
   removeThisPlaceLabel: " Remove this Place",
   requiredField: "Required field",


### PR DESCRIPTION
- Moved the saved search name to it's own line
- Applied bold to the "Are you sure you want to delete:" part with the name unbolded