### PR TITLE
33108 Allow to set name on export

### DIFF
--- a/packages/common-ui/lib/list-page-layout/DataExportListPageLayout.tsx
+++ b/packages/common-ui/lib/list-page-layout/DataExportListPageLayout.tsx
@@ -27,6 +27,7 @@ export function DataExportListPageLayout({
   };
   const TABLE_COLUMNS: ColumnDefinition<DataExport>[] = [
     "id",
+    "name",
     "status",
     "createdBy",
     dateCell("createdOn"),

--- a/packages/common-ui/lib/list-page-layout/DataExportListPageLayout.tsx
+++ b/packages/common-ui/lib/list-page-layout/DataExportListPageLayout.tsx
@@ -41,7 +41,7 @@ export function DataExportListPageLayout({
             className="btn btn-primary mt-2 bulk-edit-button"
             onClick={async () => {
               setLoading(true);
-              await downloadDataExport(apiClient, original?.id);
+              await downloadDataExport(apiClient, original?.id, original?.name);
               setLoading(false);
             }}
           >

--- a/packages/common-ui/lib/list-page-layout/bulk-buttons.tsx
+++ b/packages/common-ui/lib/list-page-layout/bulk-buttons.tsx
@@ -184,7 +184,6 @@ export function DataExportButton<TData extends KitsuResource>({
         await router.push({
           pathname,
           query: {
-            hideTable: true,
             uniqueName,
             indexName,
             entityLink

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -482,11 +482,11 @@ export function QueryPage<TData extends KitsuResource>({
     setElasticSearchQuery({ ...queryDSL });
 
     if (
-      isInitialQueryFinished.current == false ||
+      isInitialQueryFinished.current === false ||
       isActionTriggeredQuery.current
     ) {
       setLoading(true);
-      if (isInitialQueryFinished.current == false) {
+      if (isInitialQueryFinished.current === false) {
         isInitialQueryFinished.current = true;
       }
       // Fetch data using elastic search.
@@ -1061,7 +1061,6 @@ export function QueryPage<TData extends KitsuResource>({
                   setSelectedColumnSelectorIndexMapColumnsProxy
                 }
                 setLoadingIndexMapColumns={setLoadingIndexMapColumns}
-                hideExportButton={true}
                 columnSelectorDefaultColumns={columns}
                 // Column and data props
                 columns={columnsResults}

--- a/packages/common-ui/lib/table/QueryTable.tsx
+++ b/packages/common-ui/lib/table/QueryTable.tsx
@@ -387,7 +387,6 @@ export function QueryTable<TData extends KitsuResource>({
         // These props are needed for column selector
         setColumnSelector={setColumnSelector}
         uniqueName={path}
-        hideExportButton={true}
         className="-striped"
         columns={mappedColumns}
         data={(displayData as TData[]) ?? []}

--- a/packages/common-ui/lib/table/ReactTable.tsx
+++ b/packages/common-ui/lib/table/ReactTable.tsx
@@ -5,6 +5,7 @@ import {
   PaginationState,
   Row,
   SortingState,
+  Table,
   VisibilityState,
   flexRender,
   getCoreRowModel,
@@ -123,8 +124,9 @@ export interface ReactTableProps<TData> {
   // If true, index map columns are being loaded and processed from back end
   setLoadingIndexMapColumns?: React.Dispatch<React.SetStateAction<boolean>>;
 
-  // Hide column selector export button if true
-  hideExportButton?: boolean;
+  setReactTable?: React.Dispatch<
+    React.SetStateAction<Table<TData> | undefined>
+  >;
 
   // The default visible columns
   columnSelectorDefaultColumns?: any[];
@@ -180,8 +182,8 @@ export function ReactTable<TData>({
   setSelectedColumnSelectorIndexMapColumns,
   setLoadingIndexMapColumns,
   menuOnly,
-  hideExportButton,
-  columnSelectorDefaultColumns
+  columnSelectorDefaultColumns,
+  setReactTable
 }: ReactTableProps<TData>) {
   const { formatMessage } = useIntl();
   const [sorting, setSorting] = useState<SortingState>(sort ?? DEFAULT_SORT);
@@ -304,18 +306,20 @@ export function ReactTable<TData>({
         <ColumnSelector
           uniqueName={uniqueName}
           reactTable={table}
-          hideExportButton={hideExportButton}
           menuOnly={menuOnly}
           indexName={indexName}
           dynamicFieldMapping={dynamicFieldMapping}
           setColumnSelectorIndexMapColumns={setColumnSelectorIndexMapColumns}
           setLoadingIndexMapColumns={setLoadingIndexMapColumns}
           columnSelectorDefaultColumns={columnSelectorDefaultColumns}
-          setSelectedColumnSelectorIndexMapColumns={setSelectedColumnSelectorIndexMapColumns}
+          setSelectedColumnSelectorIndexMapColumns={
+            setSelectedColumnSelectorIndexMapColumns
+          }
         />
       );
       setColumnSelector?.(columnSelector);
     }
+    setReactTable?.(table);
   }, [table.getState().columnVisibility, table.getAllLeafColumns().length]);
 
   return !hideTable ? (

--- a/packages/dina-ui/types/dina-export-api/resources/DataExport.ts
+++ b/packages/dina-ui/types/dina-export-api/resources/DataExport.ts
@@ -1,6 +1,7 @@
 import { KitsuResource } from "kitsu";
 
 export type ExportStatus = "NEW" | "RUNNING" | "COMPLETED" | "ERROR";
+export type ExportType = "TABULAR_DATA" | "OBJECT_ARCHIVE";
 
 export interface DataExportAttributes {
   type: "data-export";
@@ -10,6 +11,8 @@ export interface DataExportAttributes {
   source?: string;
   query?: string;
   columns?: string[];
+  name?: string;
+  exportType?: ExportType;
 }
 
 export type DataExport = KitsuResource & DataExportAttributes;


### PR DESCRIPTION
- Refactored Export button from ColumnSelector menu to Export page
- Export button now in button bar of Export page
- Added "name" attribute to DataExport interface
- Added "exportType" attribute to DataExport interface
- Added "name" TextField to Export page, user can now enter name
- Clicking on Export button now sends request with "name" as part of payload
- The downloaded csv file will have "name" as file name
- Added "name" column to Data Exports list table