### PR TITLE
32220  Form Template support for Material Sample view page

### DIFF
--- a/packages/common-ui/lib/formik-connected/data-entry/DataEntryViewer.tsx
+++ b/packages/common-ui/lib/formik-connected/data-entry/DataEntryViewer.tsx
@@ -1,5 +1,11 @@
-import { DinaForm, processExtensionValuesLoading } from "common-ui";
+import {
+  DinaForm,
+  DinaFormSection,
+  FieldWrapper,
+  processExtensionValuesLoading
+} from "common-ui";
 import { DataEntry, DataEntryProps } from "./DataEntry";
+import { FIELD_EXTENSIONS_COMPONENT_NAME } from "../../../../dina-ui/types/collection-api";
 
 export interface DataEntryViewerProps extends DataEntryProps {
   extensionValues?: any;
@@ -19,14 +25,35 @@ export function DataEntryViewer({
     : processExtensionValuesLoading(extensionValues);
 
   return disableDinaForm ? (
-    <DataEntry
-      legend={legend}
-      name={name}
-      blockOptionsEndpoint={blockOptionsEndpoint}
-      readOnly={true}
-      width={"100%"}
-      blockOptionsFilter={blockOptionsFilter}
-    />
+    <DinaFormSection
+      componentName={FIELD_EXTENSIONS_COMPONENT_NAME}
+      sectionName="field-extension-section"
+    >
+      <FieldWrapper
+        disableLabelClick={true}
+        name={name}
+        hideLabel={true}
+        readOnlyRender={(_value, _form) => (
+          <DataEntry
+            legend={legend}
+            name={name}
+            blockOptionsEndpoint={blockOptionsEndpoint}
+            readOnly={true}
+            width={"100%"}
+            blockOptionsFilter={blockOptionsFilter}
+          />
+        )}
+      >
+        <DataEntry
+          legend={legend}
+          name={name}
+          blockOptionsEndpoint={blockOptionsEndpoint}
+          readOnly={true}
+          width={"100%"}
+          blockOptionsFilter={blockOptionsFilter}
+        />
+      </FieldWrapper>
+    </DinaFormSection>
   ) : (
     <DinaForm
       initialValues={{ extensionValues: processedExtensionValues }}

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -49,7 +49,10 @@ import {
 } from "../../../components";
 import { AttachmentReadOnlySection } from "../../../components/object-store/attachment-list/AttachmentReadOnlySection";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
-import { MaterialSample } from "../../../types/collection-api";
+import {
+  COLLECTING_EVENT_COMPONENT_NAME,
+  MaterialSample
+} from "../../../types/collection-api";
 import { GenerateLabelDropdownButton } from "../../../components/collection/material-sample/GenerateLabelDropdownButton";
 import { PersistedResource } from "kitsu";
 import { SplitMaterialSampleDropdownButton } from "../../../components/collection/material-sample/SplitMaterialSampleDropdownButton";
@@ -133,15 +136,8 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
       query: transactionQueryDSL
     }
   });
-  const {
-    navOrder,
-    setNavOrder,
-    sampleFormTemplate,
-    setSampleFormTemplateUUID,
-    visibleManagedAttributeKeys,
-    materialSampleInitialValues,
-    collectingEventInitialValues
-  } = useMaterialSampleFormTemplateSelectState({});
+  const { sampleFormTemplate, setSampleFormTemplateUUID } =
+    useMaterialSampleFormTemplateSelectState({});
 
   return (
     <div>
@@ -328,7 +324,11 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
                           />
                         </div>
                       )}
-                      <DinaForm initialValues={colEvent} readOnly={true}>
+                      <DinaForm
+                        initialValues={colEvent}
+                        readOnly={true}
+                        formTemplate={sampleFormTemplate}
+                      >
                         <CollectingEventFormLayout />
                       </DinaForm>
                     </FieldSet>

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -43,7 +43,9 @@ import {
   useCollectingEventQuery,
   useMaterialSampleQuery,
   withOrganismEditorValues,
-  TransactionMaterialDirectionSection
+  TransactionMaterialDirectionSection,
+  MaterialSampleFormTemplateSelect,
+  useMaterialSampleFormTemplateSelectState
 } from "../../../components";
 import { AttachmentReadOnlySection } from "../../../components/object-store/attachment-list/AttachmentReadOnlySection";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
@@ -131,12 +133,57 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
       query: transactionQueryDSL
     }
   });
+  const {
+    navOrder,
+    setNavOrder,
+    sampleFormTemplate,
+    setSampleFormTemplateUUID,
+    visibleManagedAttributeKeys,
+    materialSampleInitialValues,
+    collectingEventInitialValues
+  } = useMaterialSampleFormTemplateSelectState({});
 
   return (
     <div>
       {withResponse(materialSampleQuery, ({ data: materialSampleData }) => {
         const materialSample = withOrganismEditorValues(materialSampleData);
-        const buttonBar = buttonBarComponent(materialSample);
+        const buttonBar = id && (
+          <ButtonBar className="flex">
+            <BackButton
+              entityId={id}
+              entityLink="/collection/material-sample"
+              byPassView={true}
+              className="me-auto"
+            />
+            <div className="flex-grow-1 d-flex">
+              <div className="mx-auto">
+                <MaterialSampleFormTemplateSelect
+                  value={sampleFormTemplate}
+                  onChange={setSampleFormTemplateUUID}
+                />
+              </div>
+            </div>
+            <EditButton entityId={id} entityLink="collection/material-sample" />
+            <SplitMaterialSampleDropdownButton
+              ids={[id]}
+              disabled={!materialSample.materialSampleName}
+              materialSampleType={materialSample.materialSampleType}
+            />
+            <GenerateLabelDropdownButton materialSample={materialSample} />
+            <Link href={`/collection/material-sample/revisions?id=${id}`}>
+              <a className="btn btn-info ms-5">
+                <DinaMessage id="revisionsButtonText" />
+              </a>
+            </Link>
+            <DeleteButton
+              className="ms-5"
+              id={id}
+              options={{ apiBaseUrl: "/collection-api" }}
+              postDeleteRedirect="/collection/material-sample/list"
+              type="material-sample"
+            />
+          </ButtonBar>
+        );
         const hasPreparations = PREPARATION_FIELDS.some(
           (fieldName) => !isEmpty(materialSample[fieldName])
         );
@@ -170,6 +217,7 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
               <DinaForm<MaterialSample>
                 initialValues={materialSample}
                 readOnly={true}
+                formTemplate={sampleFormTemplate}
               >
                 {buttonBar}
                 <MaterialSampleStateWarning />
@@ -360,42 +408,6 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
       <Footer />
     </div>
   );
-
-  function buttonBarComponent(
-    materialSample: PersistedResource<MaterialSample>
-  ) {
-    return (
-      id && (
-        <ButtonBar className="flex">
-          <BackButton
-            entityId={id}
-            entityLink="/collection/material-sample"
-            byPassView={true}
-            className="me-auto"
-          />
-          <EditButton entityId={id} entityLink="collection/material-sample" />
-          <SplitMaterialSampleDropdownButton
-            ids={[id]}
-            disabled={!materialSample.materialSampleName}
-            materialSampleType={materialSample.materialSampleType}
-          />
-          <GenerateLabelDropdownButton materialSample={materialSample} />
-          <Link href={`/collection/material-sample/revisions?id=${id}`}>
-            <a className="btn btn-info ms-5">
-              <DinaMessage id="revisionsButtonText" />
-            </a>
-          </Link>
-          <DeleteButton
-            className="ms-5"
-            id={id}
-            options={{ apiBaseUrl: "/collection-api" }}
-            postDeleteRedirect="/collection/material-sample/list"
-            type="material-sample"
-          />
-        </ButtonBar>
-      )
-    );
-  }
 }
 
 export default withRouter(MaterialSampleViewPage);


### PR DESCRIPTION
- Added Form Template dropdown selection to view page button bar
- Only visibility applied, default values not used
- Selecting no Form Template displays all fields like edit page
- Direct Material Sample children section, Transaction section, along with other fields that cannot be hidden are always displayed