### PR TITLE
Bug #33260 - Managed Attribute text type with keyword numeric should …

### DIFF
--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
@@ -143,11 +143,13 @@ export default function QueryRowManagedAttributeSearch({
           "wildcard",
           "in",
           "notIn",
+          // Between is only used if the keyword numeric support is found.
+          managedAttributeConfig?.keywordNumericSupport ? "between" : undefined,
           "startsWith",
           "notEquals",
           "empty",
-          "notEmpty"
-        ];
+          "notEmpty",
+        ].filter(option => option !== undefined) as string[];
       default:
         return [];
     }

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch.tsx
@@ -97,6 +97,9 @@ export default function QueryRowManagedAttributeSearch({
     ? "PICK_LIST"
     : managedAttributeSelected?.vocabularyElementType ?? "";
 
+  console.log(JSON.stringify(managedAttributeState));
+  console.log(JSON.stringify(managedAttributeConfig));
+
   const supportedOperatorsForType: (type: string) => string[] = (type) => {
     switch (type) {
       case "INTEGER":
@@ -144,7 +147,8 @@ export default function QueryRowManagedAttributeSearch({
           "in",
           "notIn",
           // Between is only used if the keyword numeric support is found.
-          managedAttributeConfig?.keywordNumericSupport ? "between" : undefined,
+          // Hard-coded solution until properly fixed.
+          (managedAttributeConfig?.keywordNumericSupport || (managedAttributeSelected?.key === "barcode" && managedAttributeConfig?.dynamicField?.apiEndpoint === "objectstore-api/managed-attribute")) ? "between" : undefined,
           "startsWith",
           "notEquals",
           "empty",

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderManagedAttributeSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderManagedAttributeSearch.test.tsx
@@ -6,6 +6,7 @@ interface TestValueStructure {
   operators: string[];
   subTypes: (string | undefined)[];
   useKeywordMultiField: boolean;
+  useKeywordNumericField: boolean;
 }
 
 /**
@@ -25,6 +26,8 @@ describe("QueryBuilderManagedAttributeSearch", () => {
             case "in":
             case "notIn":
               return "stringValue1, stringValue2,stringValue3"
+            case "between":
+              return "{\\\"low\\\":\\\"stringValue1\\\",\\\"high\\\":\\\"stringValue3\\\"}";
             default:
               return "stringValue"
           }
@@ -34,13 +37,15 @@ describe("QueryBuilderManagedAttributeSearch", () => {
           "wildcard",
           "in",
           "notIn",
+          "between",
           "startsWith",
           "notEquals",
           "empty",
           "notEmpty"
         ],
         subTypes: [undefined],
-        useKeywordMultiField: true
+        useKeywordMultiField: true,
+        useKeywordNumericField: true
       },
       {
         type: "DATE",
@@ -63,7 +68,8 @@ describe("QueryBuilderManagedAttributeSearch", () => {
           "date_time",
           "date_time_optional_tz"
         ],
-        useKeywordMultiField: false
+        useKeywordMultiField: false,
+        useKeywordNumericField: false
       },
       {
         type: "INTEGER",
@@ -92,7 +98,8 @@ describe("QueryBuilderManagedAttributeSearch", () => {
           "notEmpty"
         ],
         subTypes: [undefined],
-        useKeywordMultiField: false
+        useKeywordMultiField: false,
+        useKeywordNumericField: false
       },
       {
         type: "DECIMAL",
@@ -121,7 +128,8 @@ describe("QueryBuilderManagedAttributeSearch", () => {
           "notEmpty"
         ],
         subTypes: [undefined],
-        useKeywordMultiField: false
+        useKeywordMultiField: false,
+        useKeywordNumericField: false
       },
       {
         type: "PICK_LIST",
@@ -136,14 +144,16 @@ describe("QueryBuilderManagedAttributeSearch", () => {
         },
         operators: ["equals", "notEquals", "in", "notIn", "empty", "notEmpty"],
         subTypes: [undefined],
-        useKeywordMultiField: true
+        useKeywordMultiField: true,
+        useKeywordNumericField: false
       },
       {
         type: "BOOL",
         testValue: () => "true",
         operators: ["equals", "empty", "notEmpty"],
         subTypes: [undefined],
-        useKeywordMultiField: true
+        useKeywordMultiField: true,
+        useKeywordNumericField: false
       }
     ];
 
@@ -184,8 +194,10 @@ describe("QueryBuilderManagedAttributeSearch", () => {
                       ).useKeywordMultiField,
                       optimizedPrefix: false,
                       containsSupport: false,
-                      endsWithSupport: false,
-                      keywordNumericSupport: false,
+                      endsWithSupport: false,                      
+                      keywordNumericSupport: (
+                        testValue as TestValueStructure
+                      ).useKeywordNumericField,
                       subType
                     }
                   })
@@ -236,7 +248,9 @@ describe("QueryBuilderManagedAttributeSearch", () => {
                       optimizedPrefix: false,
                       containsSupport: false,
                       endsWithSupport: false,
-                      keywordNumericSupport: false,
+                      keywordNumericSupport: (
+                        testValue as TestValueStructure
+                      ).useKeywordNumericField,
                       subType
                     }
                   })

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderManagedAttributeSearch.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/__snapshots__/QueryBuilderManagedAttributeSearch.test.tsx.snap
@@ -3629,6 +3629,17 @@ Object {
 }
 `;
 
+exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL function STRING based managed attribute tests Attribute level tests Using the between operator, undefined subtype 1`] = `
+Object {
+  "range": Object {
+    "data.attributes.managedAttributes.attributeName.keyword_numeric": Object {
+      "gte": "stringValue1",
+      "lte": "stringValue3",
+    },
+  },
+}
+`;
+
 exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL function STRING based managed attribute tests Attribute level tests Using the empty operator, undefined subtype 1`] = `
 Object {
   "bool": Object {
@@ -3801,6 +3812,33 @@ Object {
     "data.attributes.managedAttributes.attributeName.keyword": Object {
       "case_insensitive": true,
       "value": "*stringValue*",
+    },
+  },
+}
+`;
+
+exports[`QueryBuilderManagedAttributeSearch transformManagedAttributeToDSL function STRING based managed attribute tests Relationship level tests Using the between operator, undefined subtype 1`] = `
+Object {
+  "nested": Object {
+    "path": "included",
+    "query": Object {
+      "bool": Object {
+        "must": Array [
+          Object {
+            "range": Object {
+              "included.attributes.managedAttributes.attributeName.keyword_numeric": Object {
+                "gte": "stringValue1",
+                "lte": "stringValue3",
+              },
+            },
+          },
+          Object {
+            "term": Object {
+              "included.type": "collecting-event",
+            },
+          },
+        ],
+      },
     },
   },
 }


### PR DESCRIPTION
- Between operator will be displayed if keyword_numeric is available now.
- Added testing support for text based keywords (in managed attributes)