### PR TITLE
Support #33339 - UI Crash when delete a filter

### DIFF
--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchValidator.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchValidator.tsx
@@ -17,6 +17,15 @@ export function isValidationResult(object: any): object is ValidationResult {
   return 'errorMessage' in object;
 }
 
+/**
+ * Given a query tree, this function will return all the validation errors present. An empty array
+ * if no validation errors exist.
+ * 
+ * @param queryTree The current query tree to test for errors.
+ * @param config Query builder configuration
+ * @param formatMessage Instance of the formatMessage for translation of error messages.
+ * @returns ValidationError array, can be an empty array if no errors found.
+ */
 export function getElasticSearchValidationResults(
   queryTree: ImmutableTree,
   config: Config,
@@ -24,7 +33,7 @@ export function getElasticSearchValidationResults(
 ): ValidationError[] {
   const results = elasticSearchFormatValidator(queryTree, config, formatMessage);
 
-  if (isValidationResult(results)) {
+  if (results === true || isValidationResult(results)) {
     return results === true ? [] : [results];
   } else {
     // Filter out "true" values and return only ValidationError objects:

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/QueryBuilderElasticSearchValidator.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/QueryBuilderElasticSearchValidator.test.tsx
@@ -1,0 +1,133 @@
+import { ImmutableTree, JsonTree, Utils } from "react-awesome-query-builder";
+import { ESIndexMapping } from "../../../types";
+import { generateBuilderConfig } from "../../useQueryBuilderConfig";
+import { getElasticSearchValidationResults } from "../QueryBuilderElasticSearchValidator";
+
+const mockFormatMessage = jest.fn((message) => message.id);
+
+const testIndexMap: ESIndexMapping[] = [
+  {
+    label: "startEventDateTime", 
+    value: "collectingEvent.startEventDateTime", 
+    type: "date", 
+    path: "attributes", 
+    parentName: "collectingEvent", 
+    parentType: "collecting-event", 
+    parentPath: "included", 
+    keywordMultiFieldSupport: true, 
+    keywordNumericSupport: false, 
+    optimizedPrefix: false, 
+    containsSupport: false, 
+    endsWithSupport: false,
+    distinctTerm: false
+  }
+];
+
+describe("QueryBuilderElasticSearchValidator functionality", () => {
+  describe("getElasticSearchValidationResults", () => {
+
+    test("Given empty query tree, return no validation errors", async () => {
+      const validationErrors = getElasticSearchValidationResults(
+          Utils.loadTree(
+            {
+              id: "8c6dc2c8-4070-48ce-b700-13a931f9ebaf",
+              type: "group",
+              children1: [
+                {}
+              ],
+              properties: {
+                conjunction: "AND"
+              }
+            } as JsonTree
+          ),
+          generateBuilderConfig(
+            testIndexMap,
+            "dina-material-sample-index",
+            mockFormatMessage,
+            []
+          ),
+          mockFormatMessage
+      );
+
+      // Should be an empty array.
+      expect(validationErrors.length).toBe(0);
+    });
+
+    test("Valid date given, no validation errors should be present", async () => {
+      const validationErrors = getElasticSearchValidationResults(
+          Utils.loadTree(
+            {
+              id: "8c6dc2c8-4070-48ce-b700-13a931f9ebaf",
+              type: "group",
+              children1: [
+                {
+                  type: "rule",
+                  properties: {
+                    field: "collectingEvent.startEventDateTime",
+                    value: [ "1998-05-19" ],
+                    operator: "equals", // No longer supported prefix.
+                    valueSrc: [],
+                    valueType: [],
+                    valueError: []
+                  }
+                }
+              ],
+              properties: {
+                conjunction: "AND"
+              }
+            } as JsonTree
+          ),
+          generateBuilderConfig(
+            testIndexMap,
+            "dina-material-sample-index",
+            mockFormatMessage,
+            []
+          ),
+          mockFormatMessage
+      );
+
+      // One validation error should be present.
+      expect(validationErrors.length).toBe(0);
+    });
+
+    test("Invalid date given, validation error should be present", async () => {
+      const validationErrors = getElasticSearchValidationResults(
+          Utils.loadTree(
+            {
+              id: "8c6dc2c8-4070-48ce-b700-13a931f9ebaf",
+              type: "group",
+              children1: [
+                {
+                  type: "rule",
+                  properties: {
+                    field: "collectingEvent.startEventDateTime",
+                    value: [ "today" ],
+                    operator: "equals", // No longer supported prefix.
+                    valueSrc: [],
+                    valueType: [],
+                    valueError: []
+                  }
+                }
+              ],
+              properties: {
+                conjunction: "AND"
+              }
+            } as JsonTree
+          ),
+          generateBuilderConfig(
+            testIndexMap,
+            "dina-material-sample-index",
+            mockFormatMessage,
+            []
+          ),
+          mockFormatMessage
+      );
+
+      // One validation error should be present.
+      expect(validationErrors.length).toBe(1);
+      expect(validationErrors[0].fieldName).toEqual("field_startEventDateTime");
+      expect(mockFormatMessage).toHaveBeenLastCalledWith({"id": "dateMustBeFormattedYyyyMmDd"});
+    });
+
+  });
+});


### PR DESCRIPTION
- Fixed the error.
- Added test coverage for the QueryBuilderElasticSearchValidator for an empty query tree.
- Added test coverage for date validation.