### PR TITLE
33842 Add host organism to workbook upload

### DIFF
--- a/packages/dina-ui/components/workbook/column-mapping/useColumnMapping.tsx
+++ b/packages/dina-ui/components/workbook/column-mapping/useColumnMapping.tsx
@@ -473,8 +473,8 @@ export function useColumnMapping() {
           const k = keyArr[i];
           label =
             label === undefined
-              ? formatMessage(k as any).trim() || k.toUpperCase()
-              : label + (formatMessage(k as any).trim() || k.toUpperCase());
+              ? formatMessage(k as any).trim() || startCase(k)
+              : label + (formatMessage(k as any).trim() || startCase(k));
           if (i < keyArr.length - 1) {
             label = label + ".";
           }

--- a/packages/dina-ui/components/workbook/utils/FieldMappingConfig.ts
+++ b/packages/dina-ui/components/workbook/utils/FieldMappingConfig.ts
@@ -45,6 +45,13 @@ const FieldMappingConfig: FieldMappingConfigType = {
     publiclyReleasable: { dataType: WorkbookDataTypeEnum.BOOLEAN },
     useNextSequence: { dataType: WorkbookDataTypeEnum.BOOLEAN },
     isRestricted: { dataType: WorkbookDataTypeEnum.BOOLEAN },
+    hostOrganism: {
+      dataType: WorkbookDataTypeEnum.OBJECT,
+      attributes: {
+        name: { dataType: WorkbookDataTypeEnum.STRING },
+        remarks: { dataType: WorkbookDataTypeEnum.STRING }
+      }
+    },
     collection: {
       dataType: WorkbookDataTypeEnum.OBJECT,
       relationshipConfig: {

--- a/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
+++ b/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
@@ -65,7 +65,9 @@ const MATERIAL_SAMPLE_FIELD_NAME_SYNONYMS = new Map<string, string>([
   ["attachment", "attachment.name"],
   ["attachments", "attachment.name"],
   ["hostorganism", "hostOrganism.name"],
-  ["host organism", "hostOrganism.name"]
+  ["host organism", "hostOrganism.name"],
+  ["hostremarks", "hostOrganism.remarks"],
+  ["host remarks", "hostOrganism.remarks"]
 ]);
 
 export type FieldOptionType = {

--- a/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
+++ b/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
@@ -67,7 +67,9 @@ const MATERIAL_SAMPLE_FIELD_NAME_SYNONYMS = new Map<string, string>([
   ["hostorganism", "hostOrganism.name"],
   ["host organism", "hostOrganism.name"],
   ["hostremarks", "hostOrganism.remarks"],
-  ["host remarks", "hostOrganism.remarks"]
+  ["host remarks", "hostOrganism.remarks"],
+  ["hostremark", "hostOrganism.remarks"],
+  ["host remark", "hostOrganism.remarks"]
 ]);
 
 export type FieldOptionType = {

--- a/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
+++ b/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
@@ -63,7 +63,9 @@ const MATERIAL_SAMPLE_FIELD_NAME_SYNONYMS = new Map<string, string>([
   ["collectors", "collectingEvent.collectors.displayName"],
   ["collector", "collectingEvent.collectors.displayName"],
   ["attachment", "attachment.name"],
-  ["attachments", "attachment.name"]
+  ["attachments", "attachment.name"],
+  ["hostorganism", "hostOrganism.name"],
+  ["host organism", "hostOrganism.name"]
 ]);
 
 export type FieldOptionType = {

--- a/packages/dina-ui/types/collection-api/resources/MaterialSample.ts
+++ b/packages/dina-ui/types/collection-api/resources/MaterialSample.ts
@@ -109,7 +109,6 @@ export interface MaterialSampleRelationships {
   storageUnit?: StorageUnit;
   projects?: Project[];
   assemblages?: Assemblage[];
-  organism?: Organism[];
 }
 
 interface MaterialSampleChildren extends MaterialSample {

--- a/packages/dina-ui/types/collection-api/resources/MaterialSample.ts
+++ b/packages/dina-ui/types/collection-api/resources/MaterialSample.ts
@@ -109,6 +109,7 @@ export interface MaterialSampleRelationships {
   storageUnit?: StorageUnit;
   projects?: Project[];
   assemblages?: Assemblage[];
+  organism?: Organism[];
 }
 
 interface MaterialSampleChildren extends MaterialSample {


### PR DESCRIPTION
- Added hostOrganism with attributes name and remarks to FieldMappingConfig
- Can now add hostOrganism.name and hostOrganism.remarks columns in workbook upload
- Can also use "host organism" or "hostorganism" for instead of hostOrganism.name
- Fixed bug where grouping name in the select field did not have a space between host organism