### PR TITLE
33915 Workbook upload delete failed import

### DIFF
--- a/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
+++ b/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
@@ -69,7 +69,9 @@ const MATERIAL_SAMPLE_FIELD_NAME_SYNONYMS = new Map<string, string>([
   ["hostremarks", "hostOrganism.remarks"],
   ["host remarks", "hostOrganism.remarks"],
   ["hostremark", "hostOrganism.remarks"],
-  ["host remark", "hostOrganism.remarks"]
+  ["host remark", "hostOrganism.remarks"],
+  ["collector's number", "collectingEvent.dwcRecordNumber"],
+  ["collector number", "collectingEvent.dwcRecordNumber"]
 ]);
 
 export type FieldOptionType = {

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -995,5 +995,6 @@ export const DINAUI_MESSAGES_ENGLISH = {
   duplicateResourcesFound:
     "Warning: duplicate resources found {duplicateResources}",
   field_row: "Row",
-  field_column: "Column"
+  field_column: "Column",
+  deleteFailedImport: "Delete Failed Import"
 };


### PR DESCRIPTION
- Added Delete Failed Import button on workbook upload progress page
- Users can press this button to delete the saved material samples for the failed upload job
- Also deletes linked collecting events