### PR TITLE
33941 Workbook upload avoid autoselect when more than 1 option

### DIFF
--- a/packages/dina-ui/components/workbook/column-mapping/useColumnMapping.tsx
+++ b/packages/dina-ui/components/workbook/column-mapping/useColumnMapping.tsx
@@ -523,14 +523,14 @@ export function useColumnMapping() {
         } else {
           map.push({
             targetField: fieldPath,
-            skipped: fieldPath === undefined,
+            skipped: false,
             columnHeader
           });
         }
       } else {
         map.push({
           targetField: fieldPath,
-          skipped: fieldPath === undefined,
+          skipped: false,
           columnHeader
         });
       }


### PR DESCRIPTION
- Now no longer auto selects collector's display name if there is a column header with "display name"