### PR TITLE
34066 Display managed attributes tooltips in object store view

### DIFF
--- a/packages/common-ui/lib/field-header/FieldHeader.tsx
+++ b/packages/common-ui/lib/field-header/FieldHeader.tsx
@@ -22,6 +22,9 @@ export interface FieldNameProps {
 
   /** Optional link text, should be used when adding a link. */
   tooltipLinkText?: string;
+
+  /** Optional flag to make label of the field StartCase. */
+  startCaseLabel?: boolean;
 }
 
 /** Get the field label and tooltip given the camelCase field key. */
@@ -34,7 +37,8 @@ export function useFieldLabels() {
     tooltipImage,
     tooltipImageAlt,
     tooltipLink,
-    tooltipLinkText
+    tooltipLinkText,
+    startCaseLabel = true
   }: FieldNameProps) {
     const messageKey = `field_${name}`;
     const tooltipKey = tooltipOverride
@@ -55,7 +59,9 @@ export function useFieldLabels() {
 
     const fieldLabel = messages[messageKey]
       ? formatMessage({ id: messageKey as any })
-      : startCase(name);
+      : startCaseLabel
+      ? startCase(name)
+      : name;
 
     return { tooltip, fieldLabel };
   }
@@ -75,7 +81,8 @@ export function FieldHeader({
   tooltipImage,
   tooltipImageAlt,
   tooltipLink,
-  tooltipLinkText
+  tooltipLinkText,
+  startCaseLabel
 }: FieldNameProps) {
   const { getFieldLabel } = useFieldLabels();
   const { fieldLabel, tooltip } = getFieldLabel({
@@ -84,7 +91,8 @@ export function FieldHeader({
     tooltipImage,
     tooltipImageAlt,
     tooltipLink,
-    tooltipLinkText
+    tooltipLinkText,
+    startCaseLabel
   });
 
   return (

--- a/packages/common-ui/lib/formik-connected/FieldWrapper.tsx
+++ b/packages/common-ui/lib/formik-connected/FieldWrapper.tsx
@@ -73,6 +73,9 @@ export interface FieldWrapperProps {
   children?:
     | JSX.Element
     | ((renderProps: FieldWrapperRenderProps) => JSX.Element);
+
+  /** Optional flag to make label of the field StartCase. */
+  startCaseLabel?: boolean;
 }
 
 export interface FieldWrapperRenderProps {
@@ -171,7 +174,8 @@ function LabelWrapper({
     tooltipImageAlt,
     tooltipLink,
     tooltipLinkText,
-    disableTemplateCheckbox
+    disableTemplateCheckbox,
+    startCaseLabel
   },
   fieldSpyProps: {
     field: { value },
@@ -195,6 +199,7 @@ function LabelWrapper({
       tooltipImageAlt={tooltipImageAlt}
       tooltipLink={tooltipLink}
       tooltipLinkText={tooltipLinkText}
+      startCaseLabel={startCaseLabel}
     />
   );
 

--- a/packages/common-ui/lib/formik-connected/__tests__/__snapshots__/AutoSuggestTextField.test.tsx.snap
+++ b/packages/common-ui/lib/formik-connected/__tests__/__snapshots__/AutoSuggestTextField.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`AutoSuggestTextField Snapshot test 1`] = `
                   <label className=\\"examplePersonNameField-field mb-2 w-100 mb-3\\" htmlFor={[undefined]}>
                     <div className=\\"field-label label-col mb-2\\" style={[undefined]}>
                       <strong>
-                        <FieldHeader name=\\"examplePersonNameField\\" customName={[undefined]} tooltipOverride={[undefined]} tooltipImage={[undefined]} tooltipImageAlt={[undefined]} tooltipLink={[undefined]} tooltipLinkText={[undefined]}>
+                        <FieldHeader name=\\"examplePersonNameField\\" customName={[undefined]} tooltipOverride={[undefined]} tooltipImage={[undefined]} tooltipImageAlt={[undefined]} tooltipLink={[undefined]} tooltipLinkText={[undefined]} startCaseLabel={[undefined]}>
                           <div className=\\"examplePersonNameField-field-header\\">
                             Example Person Name Field
                           </div>

--- a/packages/common-ui/lib/resource-select/ResourceSelect.tsx
+++ b/packages/common-ui/lib/resource-select/ResourceSelect.tsx
@@ -351,7 +351,7 @@ export function ResourceSelect<TData extends KitsuResource>({
         "&:hover": { borderColor: "rgb(148, 26, 37)" }
       })
     }),
-    menu: (base) => ({ ...base, zIndex: 1050 }),
+    menu: (base) => ({ ...base, zIndex: 9001 }),
     // Make the menu's height fit the resource options and the action options:
     menuList: (base) => ({ ...base, maxHeight: "400px" }),
     group: (base, gProps) => ({

--- a/packages/dina-ui/components/managed-attributes/ManagedAttributeField.tsx
+++ b/packages/dina-ui/components/managed-attributes/ManagedAttributeField.tsx
@@ -33,22 +33,11 @@ export function ManagedAttributeFieldWithLabel(
   const { locale, formatMessage } = useDinaIntl();
   const attributeKey = attribute.key;
   const attributePath = `${valuesPath}.${attributeKey}`;
-  const multiDescription =
-    attribute?.multilingualDescription?.descriptions?.find(
-      (description) => description.lang === locale
-    )?.desc;
-  const unit = attribute?.unit;
-
-  const unitMessage = formatMessage("dataUnit");
-
-  const tooltipText = unit
-    ? `${multiDescription}\n${unitMessage}${unit}`
-    : multiDescription;
-
-  const fallbackTooltipText =
-    attribute?.multilingualDescription?.descriptions?.find(
-      (description) => description.lang !== locale
-    )?.desc;
+  const tooltipText = getManagedAttributeTooltipText(
+    attribute,
+    locale,
+    formatMessage
+  );
 
   return (
     <label
@@ -59,9 +48,7 @@ export function ManagedAttributeFieldWithLabel(
       <div className="mb-2 d-flex align-items-center">
         <strong className="me-auto">
           {attribute.name ?? attributeKey}
-          <Tooltip
-            directText={tooltipText ?? fallbackTooltipText ?? attribute.name}
-          />
+          <Tooltip directText={tooltipText} />
         </strong>
         {!readOnly && (
           <FormikButton
@@ -79,6 +66,30 @@ export function ManagedAttributeFieldWithLabel(
       <ManagedAttributeField {...props} />
     </label>
   );
+}
+
+export function getManagedAttributeTooltipText(
+  attribute: PersistedResource<ManagedAttribute>,
+  locale: string,
+  formatMessage: any
+) {
+  const multiDescription =
+    attribute?.multilingualDescription?.descriptions?.find(
+      (description) => description.lang === locale
+    )?.desc;
+  const unit = attribute?.unit;
+
+  const unitMessage = formatMessage("dataUnit");
+
+  const tooltipText = unit
+    ? `${multiDescription}\n${unitMessage}${unit}`
+    : multiDescription;
+
+  const fallbackTooltipText =
+    attribute?.multilingualDescription?.descriptions?.find(
+      (description) => description.lang !== locale
+    )?.desc;
+  return tooltipText ?? fallbackTooltipText ?? attribute.name;
 }
 
 /** Formik-connected field for a single Managed Attribute. No surrounding label tag. */

--- a/packages/dina-ui/components/managed-attributes/ManagedAttributesViewer.tsx
+++ b/packages/dina-ui/components/managed-attributes/ManagedAttributesViewer.tsx
@@ -1,8 +1,17 @@
-import { DinaForm, FieldView, useApiClient, useIsMounted } from "common-ui";
+import {
+  DinaForm,
+  FieldView,
+  LabelView,
+  Tooltip,
+  useApiClient,
+  useIsMounted
+} from "common-ui";
 import { toPairs } from "lodash";
 import { ManagedAttribute } from "../../types/collection-api";
 import { useEffect, useState } from "react";
-import { DinaMessage } from "../../intl/dina-ui-intl";
+import { DinaMessage, useDinaIntl } from "../../intl/dina-ui-intl";
+import { get } from "http";
+import { getManagedAttributeTooltipText } from "./ManagedAttributeField";
 
 export interface ManagedAttributesViewerProps {
   /**
@@ -17,9 +26,10 @@ export function ManagedAttributesViewer({
   values,
   managedAttributeApiPath
 }: ManagedAttributesViewerProps) {
+  const { locale, formatMessage } = useDinaIntl();
   const { apiClient } = useApiClient();
   const [allAttrKeyNameMap, setAllAttrKeyNameMap] = useState<{
-    [key: string]: string;
+    [key: string]: Record<string, string>;
   }>({});
   const isMounted = useIsMounted();
   // Call API to fetch all ManagedAttributes
@@ -27,16 +37,20 @@ export function ManagedAttributesViewer({
     async function fetchAllManagedAttributes() {
       try {
         const { data } = await apiClient.get<ManagedAttribute[]>(
-          `${managedAttributeApiPath}?fields=key,name`,
+          `${managedAttributeApiPath}?fields=key,name,multilingualDescription`,
           {}
         );
         const attrKeyNameMap = data.reduce(
           (accu, obj) => ({
             ...accu,
-            [obj.key]: obj.name
+            [obj.key]: {
+              name: obj.name,
+              multilingualDescription: obj.multilingualDescription
+            }
           }),
-          {} as { [key: string]: string }
+          {} as { [key: string]: {} }
         );
+
         if (isMounted.current) {
           setAllAttrKeyNameMap(attrKeyNameMap);
         }
@@ -47,7 +61,6 @@ export function ManagedAttributesViewer({
     }
     fetchAllManagedAttributes();
   }, []);
-
   const managedAttributeValues = (
     values
       ? toPairs(values).map(([key, mav]) => ({
@@ -58,7 +71,9 @@ export function ManagedAttributesViewer({
   )
     .map((item) => ({
       ...item,
-      name: allAttrKeyNameMap[item.key]
+      name: allAttrKeyNameMap[item.key]?.name,
+      multilingualDescription:
+        allAttrKeyNameMap[item.key]?.multilingualDescription
     }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   const managedAttributesInitialValues = managedAttributeValues?.reduce(
@@ -70,12 +85,19 @@ export function ManagedAttributesViewer({
       {managedAttributeValues?.length ? (
         <div className="row">
           {managedAttributeValues?.map((mav) => {
+            const tooltipText = getManagedAttributeTooltipText(
+              mav as any,
+              locale,
+              formatMessage
+            );
             return (
               <FieldView
                 className="col-6"
-                label={mav.name}
+                customName={mav.name}
                 name={`${mav.key}`}
                 key={mav.key}
+                tooltipOverride={tooltipText}
+                startCaseLabel={false}
               />
             );
           })}


### PR DESCRIPTION
- Now displays tooltip for object store managed attributes in object/view page
- Tooltip should corresponding to locale