### PR TITLE
Support #34095 - New pagination options look awkward on selection mode

### DIFF
--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -1097,6 +1097,7 @@ export function QueryPage<TData extends KitsuResource>({
                   rowStyling={rowStyling}
                   showPagination={true}
                   showPaginationTop={true}
+                  smallPaginationButtons={selectionMode}
                 />
               )}
               <div className="mt-2">
@@ -1147,6 +1148,7 @@ export function QueryPage<TData extends KitsuResource>({
                     enableSorting={!enableDnd}
                     showPagination={!enableDnd}
                     manualPagination={true}
+                    smallPaginationButtons={true}
                   />
                 </div>
               </>

--- a/packages/common-ui/lib/table/Pagination.tsx
+++ b/packages/common-ui/lib/table/Pagination.tsx
@@ -10,17 +10,20 @@ import {
   FaAngleLeft,
   FaAngleRight
 } from "react-icons/fa";
+import classNames from "classnames";
 
 export function Pagination<TData>({
   table,
   pageSizeOptions,
   isTop,
-  displayFirstAndLastOptions
+  displayFirstAndLastOptions,
+  smallPaginationButtons
 }: {
   table: Table<TData>;
   pageSizeOptions: number[];
   isTop: boolean;
   displayFirstAndLastOptions: boolean;
+  smallPaginationButtons: boolean;
 }) {
   const { formatMessage } = useIntl();
   const [selectOptions, setSelectOptions] = useState<
@@ -34,9 +37,11 @@ export function Pagination<TData>({
 
   return (
     <div
-      className={
-        "-pagination" + (isTop ? " -pagination-top" : " -pagination-bottom")
-      }
+      className={classNames(
+        "-pagination",
+        isTop ? " -pagination-top" : " -pagination-bottom",
+        smallPaginationButtons && "-pagination-small"
+      )}
       data-testid="pagination"
     >
       {displayFirstAndLastOptions && (
@@ -47,8 +52,14 @@ export function Pagination<TData>({
             onClick={() => table.firstPage()}
             disabled={!table.getCanPreviousPage()}
           >
-            <FaAngleDoubleLeft className="me-2 -pagination-icon" />
-            {formatMessage({ id: "first" })}
+            <FaAngleDoubleLeft
+              className={
+                smallPaginationButtons
+                  ? "-pagination-icon"
+                  : "me-2 -pagination-icon"
+              }
+            />
+            {!smallPaginationButtons && formatMessage({ id: "first" })}
           </button>
         </div>
       )}
@@ -59,8 +70,14 @@ export function Pagination<TData>({
           onClick={() => table.previousPage()}
           disabled={!table.getCanPreviousPage()}
         >
-          <FaAngleLeft className="me-2 -pagination-icon" />
-          {formatMessage({ id: "previous" })}
+          <FaAngleLeft
+            className={
+              smallPaginationButtons
+                ? "-pagination-icon"
+                : "me-2 -pagination-icon"
+            }
+          />
+          {!smallPaginationButtons && formatMessage({ id: "previous" })}
         </button>
       </div>
       <div className="-center">
@@ -142,8 +159,14 @@ export function Pagination<TData>({
           onClick={() => table.nextPage()}
           disabled={!table.getCanNextPage()}
         >
-          {formatMessage({ id: "next" })}
-          <FaAngleRight className="ms-2 -pagination-icon" />
+          {!smallPaginationButtons && formatMessage({ id: "next" })}
+          <FaAngleRight
+            className={
+              smallPaginationButtons
+                ? "-pagination-icon"
+                : "ms-2 -pagination-icon"
+            }
+          />
         </button>
       </div>
       {displayFirstAndLastOptions && (
@@ -154,8 +177,14 @@ export function Pagination<TData>({
             onClick={() => table.lastPage()}
             disabled={!table.getCanNextPage()}
           >
-            {formatMessage({ id: "last" })}
-            <FaAngleDoubleRight className="ms-2 -pagination-icon" />
+            {!smallPaginationButtons && formatMessage({ id: "last" })}
+            <FaAngleDoubleRight
+              className={
+                smallPaginationButtons
+                  ? "-pagination-icon"
+                  : "ms-2 -pagination-icon"
+              }
+            />
           </button>
         </div>
       )}

--- a/packages/common-ui/lib/table/ReactTable.tsx
+++ b/packages/common-ui/lib/table/ReactTable.tsx
@@ -59,6 +59,8 @@ export interface ReactTableProps<TData> {
   showPagination?: boolean;
   // Show pagination on the top
   showPaginationTop?: boolean;
+  // Display pagination with the icons only. Perfect for small tables.
+  smallPaginationButtons?: boolean;
   pageSizeOptions?: number[];
   defaultExpanded?: ExpandedState;
   // A function to render the SubComponent in the expanded area.
@@ -97,6 +99,7 @@ export function ReactTable<TData>({
   showPagination = false,
   showPaginationTop = false,
   manualPagination = false,
+  smallPaginationButtons = false,
   pageSize: initPageSize,
   pageCount,
   page,
@@ -255,6 +258,7 @@ export function ReactTable<TData>({
             displayFirstAndLastOptions={
               enableSorting && !!sort && sort?.length > 0
             }
+            smallPaginationButtons={smallPaginationButtons}
           />
         </div>
       )}
@@ -398,6 +402,7 @@ export function ReactTable<TData>({
             displayFirstAndLastOptions={
               enableSorting && !!sort && sort?.length > 0
             }
+            smallPaginationButtons={smallPaginationButtons}
           />
         </div>
       )}

--- a/packages/common-ui/lib/table/react-table.css
+++ b/packages/common-ui/lib/table/react-table.css
@@ -163,6 +163,13 @@
   margin-left: 5px;
 }
 
+.ReactTable .-pagination-small .-previous,
+.ReactTable .-pagination-small .-next,
+.ReactTable .-pagination-small .-first,
+.ReactTable .-pagination-small .-last {
+  width: 35px !important;
+}
+
 .ReactTable .-pagination .-last {
   margin-right: 5px;
   margin-left: 0px;

--- a/packages/dina-ui/components/seqdb/ngs-workflow/NgsSampleSelectionStep.tsx
+++ b/packages/dina-ui/components/seqdb/ngs-workflow/NgsSampleSelectionStep.tsx
@@ -265,25 +265,38 @@ export function NgsSampleSelectionStep({
 
   return (
     <div>
-      {!editMode && (
-        <strong>
-          <SeqdbMessage id="selectedSamplesTitle" />
-        </strong>
+      {!editMode ? (
+        <>
+          <strong>
+            <SeqdbMessage id="selectedSamplesTitle" />
+          </strong>
+          <QueryPage<any>
+            indexName={"dina_material_sample_index"}
+            uniqueName="ngs-material-sample-selection-step-view"
+            columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
+            enableColumnSelector={false}
+            selectionMode={false}
+            selectionResources={selectedResources}
+            viewMode={true}
+            reactTableProps={{ enableSorting: true, enableMultiSort: true }}
+          />
+        </>
+      ) : (
+        <QueryPage<any>
+          indexName={"dina_material_sample_index"}
+          uniqueName="ngs-material-sample-selection-step-edit"
+          columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
+          enableColumnSelector={false}
+          selectionMode={true}
+          selectionResources={selectedResources}
+          setSelectionResources={setSelectedResourcesAndSaveOrder}
+          viewMode={false}
+          enableDnd={true}
+          onDeselect={(unselected) => onSelectMaterial(unselected)}
+          onSelect={(selected) => onDeselectMaterial(selected)}
+          reactTableProps={{ enableSorting: true, enableMultiSort: true }}
+        />
       )}
-      <QueryPage<any>
-        indexName={"dina_material_sample_index"}
-        uniqueName="ngs-material-sample-selection-step"
-        columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
-        enableColumnSelector={false}
-        selectionMode={editMode}
-        selectionResources={selectedResources}
-        setSelectionResources={setSelectedResourcesAndSaveOrder}
-        viewMode={!editMode}
-        enableDnd={true}
-        onDeselect={(unselected) => onSelectMaterial(unselected)}
-        onSelect={(selected) => onDeselectMaterial(selected)}
-        reactTableProps={{ enableSorting: true, enableMultiSort: true }}
-      />
     </div>
   );
 }

--- a/packages/dina-ui/components/seqdb/ngs-workflow/NgsSampleSelectionStep.tsx
+++ b/packages/dina-ui/components/seqdb/ngs-workflow/NgsSampleSelectionStep.tsx
@@ -87,10 +87,10 @@ export function NgsSampleSelectionStep({
   function sortMaterialSamples(samples: MaterialSampleSummary[]) {
     if (materialSampleSortOrder) {
       const sorted = materialSampleSortOrder.map((sampleId) =>
-        samples.find((item) => item.id === sampleId)
+        samples.find((item) => item?.id === sampleId)
       );
       samples.forEach((item) => {
-        if (materialSampleSortOrder.indexOf(item.id ?? "unknown") === -1) {
+        if (materialSampleSortOrder.indexOf(item?.id ?? "unknown") === -1) {
           sorted.push(item);
         }
       });

--- a/packages/dina-ui/components/seqdb/pcr-workflow/SangerSampleSelectionStep.tsx
+++ b/packages/dina-ui/components/seqdb/pcr-workflow/SangerSampleSelectionStep.tsx
@@ -270,31 +270,44 @@ export function SangerSampleSelectionStep({
 
   return (
     <div>
-      {!editMode && (
-        <strong>
-          <SeqdbMessage id="selectedSamplesTitle" />
-        </strong>
+      {!editMode ? (
+        <>
+          <strong>
+            <SeqdbMessage id="selectedSamplesTitle" />
+          </strong>
+          <QueryPage<any>
+            indexName={"dina_material_sample_index"}
+            uniqueName="pcr-material-sample-selection-step-read-only"
+            columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
+            enableColumnSelector={false}
+            selectionMode={false}
+            selectionResources={selectedResources}
+            viewMode={true}
+            reactTableProps={{
+              enableSorting: true,
+              enableMultiSort: true
+            }}
+          />
+        </>
+      ) : (
+        <QueryPage<any>
+          indexName={"dina_material_sample_index"}
+          uniqueName="pcr-material-sample-selection-step-edit"
+          columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
+          enableColumnSelector={false}
+          selectionMode={true}
+          selectionResources={selectedResources}
+          setSelectionResources={setSelectedResourcesAndSaveOrder}
+          viewMode={false}
+          enableDnd={true}
+          onDeselect={(unselected) => onSelectMaterial(unselected)}
+          onSelect={(selected) => onDeselectMaterial(selected)}
+          reactTableProps={{
+            enableSorting: true,
+            enableMultiSort: true
+          }}
+        />
       )}
-      <QueryPage<any>
-        indexName={"dina_material_sample_index"}
-        uniqueName={
-          "pcr-material-sample-selection-step" + (editMode ? "-edit" : "-read")
-        }
-        columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
-        enableColumnSelector={false}
-        selectionMode={editMode}
-        selectionResources={selectedResources}
-        setSelectionResources={setSelectedResourcesAndSaveOrder}
-        viewMode={!editMode}
-        enableDnd={true}
-        onDeselect={(unselected) => onSelectMaterial(unselected)}
-        onSelect={(selected) => onDeselectMaterial(selected)}
-        reactTableProps={{
-          enableSorting: true,
-          enableMultiSort: true
-        }}
-        enableColumnSelector={false}
-      />
     </div>
   );
 }

--- a/packages/dina-ui/components/seqdb/pcr-workflow/SangerSampleSelectionStep.tsx
+++ b/packages/dina-ui/components/seqdb/pcr-workflow/SangerSampleSelectionStep.tsx
@@ -277,7 +277,9 @@ export function SangerSampleSelectionStep({
       )}
       <QueryPage<any>
         indexName={"dina_material_sample_index"}
-        uniqueName="pcr-material-sample-selection-step"
+        uniqueName={
+          "pcr-material-sample-selection-step" + (editMode ? "-edit" : "-read")
+        }
         columns={PCR_WORKFLOW_ELASTIC_SEARCH_COLUMN}
         enableColumnSelector={false}
         selectionMode={editMode}

--- a/packages/dina-ui/pages/seqdb/ngs-workflow-pooling/run.tsx
+++ b/packages/dina-ui/pages/seqdb/ngs-workflow-pooling/run.tsx
@@ -102,7 +102,7 @@ export default function NgsWorkFlowPoolingRunPage() {
               variant={"primary"}
               className="ms-2"
               onClick={() => setPerformSave(true)}
-              style={{ width: "10rem" }}
+              style={{ width: "10rem", marginRight: "15px" }}
             >
               {performSave ? (
                 <>
@@ -123,7 +123,7 @@ export default function NgsWorkFlowPoolingRunPage() {
             </Button>
           ) : (
             <>
-              <Dropdown as={ButtonGroup}>
+              <Dropdown as={ButtonGroup} style={{ width: "12rem" }}>
                 <Button
                   variant={"primary"}
                   className="ms-2"
@@ -182,7 +182,7 @@ export default function NgsWorkFlowPoolingRunPage() {
           variant={"primary"}
           className="ms-auto"
           onClick={() => setEditMode(true)}
-          style={{ width: "10rem" }}
+          style={{ width: "10rem", marginRight: "15px" }}
         >
           <SeqdbMessage id="editButtonText" />
         </Button>

--- a/packages/dina-ui/pages/seqdb/ngs-workflow/run.tsx
+++ b/packages/dina-ui/pages/seqdb/ngs-workflow/run.tsx
@@ -87,12 +87,12 @@ export default function NgsWorkFlowRunPage() {
             Cancel
           </Button>
 
-          {currentStep !== 3 ? (
+          {currentStep !== 2 ? (
             <Button
               variant={"primary"}
               className="ms-2"
               onClick={() => setPerformSave(true)}
-              style={{ width: "10rem" }}
+              style={{ width: "10rem", marginRight: "15px" }}
             >
               {performSave ? (
                 <>
@@ -113,7 +113,7 @@ export default function NgsWorkFlowRunPage() {
             </Button>
           ) : (
             <>
-              <Dropdown as={ButtonGroup}>
+              <Dropdown as={ButtonGroup} style={{ width: "12rem" }}>
                 <Button
                   variant={"primary"}
                   className="ms-2"
@@ -172,7 +172,7 @@ export default function NgsWorkFlowRunPage() {
           variant={"primary"}
           className="ms-auto"
           onClick={() => setEditMode(true)}
-          style={{ width: "10rem" }}
+          style={{ width: "10rem", marginRight: "15px" }}
         >
           <SeqdbMessage id="editButtonText" />
         </Button>

--- a/packages/dina-ui/pages/seqdb/pcr-workflow/run.tsx
+++ b/packages/dina-ui/pages/seqdb/pcr-workflow/run.tsx
@@ -97,7 +97,7 @@ export default function PCRWorkFlowRunPage() {
               variant={"primary"}
               className="ms-2"
               onClick={() => setPerformSave(true)}
-              style={{ width: "10rem" }}
+              style={{ width: "10rem", marginRight: "15px" }}
             >
               {performSave ? (
                 <>
@@ -118,10 +118,10 @@ export default function PCRWorkFlowRunPage() {
             </Button>
           ) : (
             <>
-              <Dropdown as={ButtonGroup}>
+              <Dropdown as={ButtonGroup} style={{ width: "12rem" }}>
                 <Button
                   variant={"primary"}
-                  className="ms-2"
+                  className="ms-auto"
                   onClick={() => setPerformSave(true)}
                   style={{ width: "10rem" }}
                 >
@@ -147,7 +147,6 @@ export default function PCRWorkFlowRunPage() {
                   <Dropdown.Item
                     as="button"
                     href="#/action-1"
-                    className="ms-2"
                     onClick={() => {
                       setPerformComplete(true);
                       setPerformSave(true);
@@ -177,7 +176,7 @@ export default function PCRWorkFlowRunPage() {
           variant={"primary"}
           className="ms-auto"
           onClick={() => setEditMode(true)}
-          style={{ width: "10rem" }}
+          style={{ width: "10rem", marginRight: "15px" }}
         >
           <SeqdbMessage id="editButtonText" />
         </Button>


### PR DESCRIPTION
- Selection mode will now use smaller pagination buttons. These buttons will only display the icons for small tables.
- Fixed issues with button bar on workflows.
- Fixed issue with material sample query page view trying to use the pagination from the selection mode.