### PR TITLE
33342 Allow to select columns on material sample children list

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelector.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelector.tsx
@@ -54,6 +54,11 @@ export interface ColumnSelectorProps<TData extends KitsuResource> {
    * Indicate if all the columns have been loading in...
    */
   setColumnSelectorLoading?: React.Dispatch<React.SetStateAction<boolean>>;
+
+  /**
+   * Array of relationshipType columns to be excluded from the dropdown menu
+   */
+  excludedRelationshipTypes?: string[];
 }
 
 export function ColumnSelector<TData extends KitsuResource>(
@@ -67,7 +72,8 @@ export function ColumnSelector<TData extends KitsuResource>(
     uniqueName,
     defaultColumns,
     setColumnSelectorLoading,
-    setDisplayedColumns
+    setDisplayedColumns,
+    excludedRelationshipTypes
   } = props;
 
   // These are all the possible columns displayed to the user.
@@ -125,7 +131,8 @@ export function ColumnSelector<TData extends KitsuResource>(
         setColumnOptions,
         setLoading: setInternalLoading,
         defaultColumns,
-        apiClient
+        apiClient,
+        excludedRelationshipTypes
       });
     }
   }, [indexMapping]);

--- a/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
@@ -29,6 +29,11 @@ export interface ColumnSelectorIndexMapColumns<TData extends KitsuResource> {
    * API client to be used for the dynamic fields.
    */
   apiClient: Kitsu;
+
+  /**
+   * Array of relationshipType columns to be excluded from the dropdown menu
+   */
+  excludedRelationshipTypes?: string[];
 }
 
 // Hook to get all of index map columns to be added to column selector
@@ -39,9 +44,10 @@ export async function getColumnSelectorIndexMapColumns<
   defaultColumns,
   setColumnOptions,
   setLoading,
-  apiClient
+  apiClient,
+  excludedRelationshipTypes
 }: ColumnSelectorIndexMapColumns<TData>) {
-  const columnOptions: TableColumn<TData>[] = [];
+  let columnOptions: TableColumn<TData>[] = [];
   let defaultColumnsCopy = defaultColumns;
 
   if (indexMapping) {
@@ -88,6 +94,14 @@ export async function getColumnSelectorIndexMapColumns<
     // Add the rest of the default options not added yet.
     if (defaultColumnsCopy) {
       columnOptions.push(...defaultColumnsCopy);
+    }
+    if (excludedRelationshipTypes) {
+      const excludedColumnOptions = columnOptions.filter((columnOption) =>
+        columnOption.relationshipType
+          ? !excludedRelationshipTypes.includes(columnOption.relationshipType)
+          : true
+      );
+      columnOptions = excludedColumnOptions;
     }
 
     setColumnOptions?.(columnOptions);

--- a/packages/common-ui/lib/custom-query-view/CustomQueryPageView.tsx
+++ b/packages/common-ui/lib/custom-query-view/CustomQueryPageView.tsx
@@ -154,7 +154,6 @@ export function CustomQueryPageView<TData extends KitsuResource>({
         <>
           <QueryPage<TData>
             {...queryPageProps}
-            enableColumnSelector={false}
             customViewQuery={customQuerySelected.customQuery}
             customViewFields={customQuerySelected.customViewFields ?? []}
             customViewElasticSearchQuery={

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -956,7 +956,7 @@ export function QueryPage<TData extends KitsuResource>({
 
       <DinaForm key={formKey} initialValues={defaultGroups} onSubmit={onSubmit}>
         {/* Group Selection */}
-        {!viewMode && (
+        {!viewMode ? (
           <DinaFormSection horizontal={"flex"}>
             <div className="row">
               <GroupSelectFieldMemoized
@@ -1003,6 +1003,28 @@ export function QueryPage<TData extends KitsuResource>({
                   )}
                   {bulkSplitPath && (
                     <BulkSplitButton pathname={bulkSplitPath} />
+                  )}
+                </div>
+              )}
+            </div>
+          </DinaFormSection>
+        ) : (
+          <DinaFormSection horizontal={"flex"}>
+            <div className="row">
+              {/* Bulk edit buttons - Only shown when not in selection mode. */}
+              {!selectionMode && (
+                <div className="col-md-12 mt-3 d-flex gap-2 justify-content-end align-items-start">
+                  {enableColumnSelector && (
+                    <ColumnSelectorMemo
+                      uniqueName={uniqueName}
+                      exportMode={false}
+                      indexMapping={indexMap}
+                      displayedColumns={displayedColumns as any}
+                      setDisplayedColumns={onDisplayedColumnsChange as any}
+                      defaultColumns={columns as any}
+                      setColumnSelectorLoading={setColumnSelectorLoading}
+                      excludedRelationshipTypes={["collecting-event"]}
+                    />
                   )}
                 </div>
               )}

--- a/packages/dina-ui/components/collection/material-sample/useMaterialSampleRelationshipColumns.tsx
+++ b/packages/dina-ui/components/collection/material-sample/useMaterialSampleRelationshipColumns.tsx
@@ -191,6 +191,7 @@ export function useMaterialSampleRelationshipColumns() {
 
   const ELASTIC_SEARCH_COLUMN_CHILDREN_VIEW: TableColumn<MaterialSample>[] = [
     {
+      id: "materialSampleName",
       cell: ({ row: { original } }) => (
         <Link href={`/collection/material-sample/view?id=${original.id}`}>
           <a>
@@ -210,6 +211,7 @@ export function useMaterialSampleRelationshipColumns() {
       isKeyword: true
     },
     {
+      id: "materialSampleType",
       accessorKey: "data.attributes.materialSampleType",
       header: () => <FieldHeader name="materialSampleType" />,
       isKeyword: true


### PR DESCRIPTION
- Enabled ColumnSelector in material sample children table
- Fixed infinite loading bug
- Fixed column ids missing
- Filtered out collecting event menu options since children can't have a collecting event