### PR TITLE
34503 Clean Bulk Create material sample page

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,5 @@
     ]
   },
   "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72",
-  "dependencies": {
-    "canvas": "^2.11.2"
-  }
+  "dependencies": {}
 }

--- a/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
@@ -219,7 +219,9 @@ function GeneratorFields({
   const { formatMessage } = useDinaIntl();
   const formikForm = useFormikContext<any>();
   useEffect(() => {
-    formikForm.setFieldValue("baseName", baseName);
+    if (!formikForm.values.baseName) {
+      formikForm.setFieldValue("baseName", baseName);
+    }
   }, []);
 
   const SUFFIX_TYPE_OPTIONS = INCREMENT_MODES.map((mode) => ({

--- a/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
@@ -9,9 +9,10 @@ import {
   SelectField,
   SubmitButton,
   TextField,
-  useApiClient
+  useApiClient,
+  useDinaFormContext
 } from "common-ui";
-import { Field, FormikContextType } from "formik";
+import { Field, FormikContextType, useFormikContext } from "formik";
 import { InputResource } from "kitsu";
 import { padStart, range } from "lodash";
 import { useState } from "react";
@@ -26,6 +27,8 @@ import {
 import { DinaMessage, useDinaIntl } from "../../intl/dina-ui-intl";
 import { MaterialSample } from "../../types/collection-api/resources/MaterialSample";
 import { useGenerateSequence } from "../collection/material-sample/useGenerateSequence";
+import { useEffect } from "react";
+import { Collection } from "packages/dina-ui/types/collection-api";
 
 export interface MaterialSampleGenerationFormProps {
   onGenerate: (samples: MaterialSampleGenerationFormSubmission) => void;
@@ -45,7 +48,7 @@ export function MaterialSampleGenerationForm({
   initialMode
 }: MaterialSampleGenerationFormProps) {
   const [generationMode, setGenerationMode] = useState<GenerationMode>(
-    initialMode || "BATCH"
+    initialMode || "SERIES"
   );
   const [useNextSequence, setUseNextSequence] = useState<boolean>(
     initialValues?.useNextSequence || false
@@ -79,25 +82,25 @@ export function MaterialSampleGenerationForm({
         InputResource<MaterialSample>
       >((_, index) => {
         const sample = submittedValues.samples[index];
+        const materialSampleName = sample?.materialSampleName?.trim?.();
         return {
           type: "material-sample",
           parentMaterialSample: undefined,
           group: submittedValues.group,
           collection: submittedValues.collection,
           publiclyReleasable: true,
-          // Batch mode generates samples with the same name, so allow duplicate names in batch mode:
-          allowDuplicateName: generationMode === "BATCH",
           ...sample,
-          materialSampleName:
-            sample?.materialSampleName?.trim?.() || useNextSequence
-              ? submittedValues.baseName
-                ? submittedValues.baseName + (generatedLowId + index)
-                : `${generatedLowId + index}`
-              : generateName({
-                  generationMode,
-                  index,
-                  formState: submittedValues
-                })
+          materialSampleName: materialSampleName
+            ? materialSampleName
+            : useNextSequence
+            ? submittedValues.baseName
+              ? submittedValues.baseName + (generatedLowId + index)
+              : `${generatedLowId + index}`
+            : generateName({
+                generationMode,
+                index,
+                formState: submittedValues
+              })
         };
       });
       onGenerate({ samples, submittedValues, generationMode });
@@ -168,36 +171,15 @@ export function MaterialSampleGenerationForm({
           }}
         />
       </div>
-      <Tabs
-        selectedIndex={GENERATION_MODES.indexOf(generationMode)}
-        onSelect={(index) => setGenerationMode(GENERATION_MODES[index])}
-      >
-        <TabList>
-          <Tab className="react-tabs__tab batch-tab">
-            <DinaMessage id="generateBatch" />
-          </Tab>
-          {!useNextSequence && (
-            <Tab className="react-tabs__tab series-tab">
-              <DinaMessage id="generateSeries" />
-            </Tab>
-          )}
-        </TabList>
-        <TabPanel>
+      {!useNextSequence && (
+        <>
           <GeneratorFields
             generationMode={generationMode}
-            useNextSequence={useNextSequence}
+            baseName={baseNameFromCollection}
           />
-          {!useNextSequence && (
-            <PreviewAndCustomizeFields generationMode={generationMode} />
-          )}
-        </TabPanel>
-        {!useNextSequence && (
-          <TabPanel>
-            <GeneratorFields generationMode={generationMode} />
-            <PreviewAndCustomizeFields generationMode={generationMode} />
-          </TabPanel>
-        )}
-      </Tabs>
+          <PreviewAndCustomizeFields generationMode={generationMode} />
+        </>
+      )}
       <ButtonBar centered={false}>
         <BackToListButton
           className="ms-auto"
@@ -217,22 +199,28 @@ export function MaterialSampleGenerationForm({
   );
 }
 
-export const GENERATION_MODES = ["BATCH", "SERIES"] as const;
-export type GenerationMode = typeof GENERATION_MODES[number];
+export const GENERATION_MODES = ["SERIES"] as const;
+export type GenerationMode = (typeof GENERATION_MODES)[number];
 
 export const INCREMENT_MODES = ["NUMERICAL", "LETTER"] as const;
-export type IncrementMode = typeof INCREMENT_MODES[number];
+export type IncrementMode = (typeof INCREMENT_MODES)[number];
 
 interface GeneratorFieldsProps {
   generationMode: GenerationMode;
   useNextSequence?: boolean;
+  baseName?: string;
 }
 
 function GeneratorFields({
   generationMode,
-  useNextSequence
+  useNextSequence,
+  baseName
 }: GeneratorFieldsProps) {
   const { formatMessage } = useDinaIntl();
+  const formikForm = useFormikContext<any>();
+  useEffect(() => {
+    formikForm.setFieldValue("baseName", baseName);
+  }, []);
 
   const SUFFIX_TYPE_OPTIONS = INCREMENT_MODES.map((mode) => ({
     label: formatMessage(mode),
@@ -244,25 +232,13 @@ function GeneratorFields({
         <DinaMessage id="primaryId" />
       </h4>
       <div className="row">
-        <CollectionSelectField className="col-sm-6" name="collection" />
-        {generationMode === "BATCH" && (
-          <>
-            <TextField
-              name="suffix"
-              className="col-md-3"
-              inputProps={{
-                disabled: useNextSequence
-              }}
-            />
-            <TextField
-              name="separator"
-              className="col-md-3"
-              inputProps={{
-                disabled: useNextSequence
-              }}
-            />
-          </>
-        )}
+        <CollectionSelectField
+          className="col-sm-6"
+          name="collection"
+          onChange={(value) => {
+            formikForm.setFieldValue("baseName", (value as Collection)?.code);
+          }}
+        />
         {generationMode === "SERIES" && (
           <>
             <SelectField
@@ -322,11 +298,6 @@ function PreviewAndCustomizeFields({ generationMode }: GeneratorFieldsProps) {
       <h4>
         <DinaMessage id="previewAndCustomizeLabel" />
       </h4>
-      {generationMode === "BATCH" && (
-        <p>
-          <DinaMessage id="batchModeInfo" />
-        </p>
-      )}
       {generationMode === "SERIES" && (
         <p>
           <DinaMessage id="seriesModeInfo" />
@@ -363,6 +334,9 @@ function PreviewAndCustomizeFields({ generationMode }: GeneratorFieldsProps) {
                       removeLabel={true}
                       removeBottomMargin={true}
                       placeholder={placeholder}
+                      onChangeExternal={(form, name, value) => {
+                        form.setFieldValue(name, value);
+                      }}
                     />
                   </div>
                 </li>
@@ -386,11 +360,7 @@ function generateName(params: GenerateNameParams) {
 
   const generatedName = `${formState.baseName || ""}${
     formState.separator || ""
-  }${
-    generationMode === "BATCH"
-      ? formState.suffix || ""
-      : generateSeriesSuffix(params)
-  }`;
+  }${generateSeriesSuffix(params)}`;
   return generatedName;
 }
 function generateSeriesSuffix({ index, formState }: GenerateNameParams) {

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleGenerationForm.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleGenerationForm.test.tsx
@@ -49,12 +49,6 @@ describe("MaterialSampleGenerationForm", () => {
     await new Promise(setImmediate);
     wrapper.update();
 
-    // Use series mode:
-    wrapper.find("li.series-tab").simulate("click");
-
-    await new Promise(setImmediate);
-    wrapper.update();
-
     // Fill out the form:
     wrapper
       .find(".collection-field")
@@ -99,7 +93,7 @@ describe("MaterialSampleGenerationForm", () => {
     expect(mockOnGenerate).lastCalledWith({
       generationMode: "SERIES",
       samples: expectedNames.map((name) => ({
-        allowDuplicateName: false,
+        parentMaterialSample: undefined,
         collection: { id: "100", name: "test-collection", type: "collection" },
         group: "aafc",
         materialSampleName: name,
@@ -120,90 +114,6 @@ describe("MaterialSampleGenerationForm", () => {
         separator: "-",
         start: "00001",
         suffix: ""
-      }
-    });
-  });
-
-  it("Generates the initial values for the new samples in batch mode.", async () => {
-    const wrapper = mountWithAppContext(
-      <MaterialSampleGenerationForm onGenerate={mockOnGenerate} />,
-      testCtx
-    );
-
-    await new Promise(setImmediate);
-    wrapper.update();
-
-    // Use batch mode:
-    wrapper.find("li.batch-tab").simulate("click");
-
-    await new Promise(setImmediate);
-    wrapper.update();
-
-    // Fill out the form:
-    wrapper
-      .find(".collection-field")
-      .find(ResourceSelect)
-      .prop<any>("onChange")({
-      id: "100",
-      name: "test-collection",
-      type: "collection"
-    });
-    wrapper
-      .find(".numberToCreate-field input")
-      .simulate("change", { target: { value: "5" } });
-    wrapper
-      .find(".baseName-field input")
-      .simulate("change", { target: { value: "my-sample" } });
-    wrapper
-      .find(".separator-field input")
-      .simulate("change", { target: { value: "-" } });
-    wrapper
-      .find(".suffix-field input")
-      .simulate("change", { target: { value: "my-suffix" } });
-
-    const expectedNames = [
-      "my-sample-my-suffix",
-      "my-sample-my-suffix",
-      "my-sample-my-suffix",
-      "my-sample-my-suffix",
-      "my-sample-my-suffix"
-    ];
-
-    // The default names should be in the placeholders:
-    expect(
-      wrapper.find(".sample-name input").map((node) => node.prop("placeholder"))
-    ).toEqual(expectedNames);
-
-    wrapper.find("form").simulate("submit");
-
-    await new Promise(setImmediate);
-    wrapper.update();
-
-    // Sample initialValues are created with the expected names and the linked collection:
-    expect(mockOnGenerate).lastCalledWith({
-      generationMode: "BATCH",
-      samples: expectedNames.map((name) => ({
-        allowDuplicateName: true,
-        collection: { id: "100", name: "test-collection", type: "collection" },
-        group: "aafc",
-        materialSampleName: name,
-        publiclyReleasable: true,
-        type: "material-sample"
-      })),
-      submittedValues: {
-        baseName: "my-sample",
-        collection: {
-          id: "100",
-          name: "test-collection",
-          type: "collection"
-        },
-        group: "aafc",
-        increment: "NUMERICAL",
-        numberToCreate: "5",
-        samples: [],
-        separator: "-",
-        start: "001",
-        suffix: "my-suffix"
       }
     });
   });

--- a/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
+++ b/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
@@ -51,12 +51,6 @@ describe("MaterialSampleBulkCreatePage", () => {
     await new Promise(setImmediate);
     wrapper.update();
 
-    // Use series mode:
-    wrapper.find("li.series-tab").simulate("click");
-
-    await new Promise(setImmediate);
-    wrapper.update();
-
     // Fill out the form:
     wrapper
       .find(".collection-field")
@@ -78,6 +72,8 @@ describe("MaterialSampleBulkCreatePage", () => {
     wrapper
       .find(".separator-field input")
       .simulate("change", { target: { value: "-" } });
+    await new Promise(setImmediate);
+    wrapper.update();
 
     wrapper.find("form").simulate("submit");
 
@@ -90,7 +86,6 @@ describe("MaterialSampleBulkCreatePage", () => {
     wrapper.update();
 
     // Goes back to the previous page with the generator form values:
-    expect(wrapper.find("li.series-tab").hasClass("react-tabs__tab--selected"));
     expect(wrapper.find(".baseName-field input").prop("value")).toEqual(
       "my-sample"
     );


### PR DESCRIPTION
- Removed Generate Batch Option
- Removed tabs, now only has 1 generation mode (series)
- Selecting Collection now fills base name with Collection Code
- When customizing Material Sample name in Preview, the names should now be correctly used in bulk edit mode