### PR TITLE
34404 Bulk Edit Prepared By not working

### DIFF
--- a/packages/common-ui/lib/search/useAutocompleteSearchButFallbackToRsqlApiSearch.ts
+++ b/packages/common-ui/lib/search/useAutocompleteSearchButFallbackToRsqlApiSearch.ts
@@ -7,6 +7,7 @@ export interface UseAutocompleteSearchButFallbackToRsqlApiSearchProps
   extends AutocompleteSearchParams {
   searchQuery: string;
   querySpec: JsonApiQuerySpec;
+  type?: string;
 }
 
 /**
@@ -29,7 +30,8 @@ export function useAutocompleteSearchButFallbackToRsqlApiSearch<
   additionalField,
   searchField,
   restrictedField,
-  restrictedFieldValue
+  restrictedFieldValue,
+  type
 }: UseAutocompleteSearchButFallbackToRsqlApiSearchProps) {
   // The mode indicates which API is being used. Either RSQL or Elastic Search.
   const [apiMode, setApiMode] = useState<ApiModeType>("elasticsearch");
@@ -62,6 +64,9 @@ export function useAutocompleteSearchButFallbackToRsqlApiSearch<
   // Put the ResourceSelect's input into the Search hook's state:
   useEffect(() => setInputValue(searchQuery), [searchQuery]);
 
+  elasticSearchResult?.forEach((resource) => {
+    resource.type = type as any;
+  });
   return {
     loading: elasticSearchLoading || rsqlSearchLoading,
     response: {

--- a/packages/dina-ui/components/resource-select-fields/resource-select-fields.tsx
+++ b/packages/dina-ui/components/resource-select-fields/resource-select-fields.tsx
@@ -125,7 +125,8 @@ export function PersonSelectField(
           querySpec,
           indexName: "dina_agent_index",
           searchField: "data.attributes.displayName",
-          additionalField: "data.attributes.aliases"
+          additionalField: "data.attributes.aliases",
+          type: "person"
         })
       }
       readOnlyLink="/person/view?id="
@@ -175,7 +176,8 @@ export function StorageUnitSelectField({
           indexName: "dina_storage_index",
           searchField: "data.attributes.name",
           restrictedField,
-          restrictedFieldValue
+          restrictedFieldValue,
+          type: "storage-unit"
         })
       }
       readOnlyLink="/collection/storage-unit/view?id="


### PR DESCRIPTION
- Added resource "type" to elasticSearchResult
- Typing in the "Prepared By" field and selecting a "Person" should no longer throw error on save