### PR TITLE
34530 Storage unit creation isGeneric must not be null error

### DIFF
--- a/packages/dina-ui/components/storage/StorageUnitForm.tsx
+++ b/packages/dina-ui/components/storage/StorageUnitForm.tsx
@@ -75,7 +75,8 @@ export function StorageUnitForm({
 
   const initialValues = storageUnit || {
     type: "storage-unit",
-    parentStorageUnit: initialParent
+    parentStorageUnit: initialParent,
+    isGeneric: false
   };
 
   async function onSubmit({

--- a/packages/dina-ui/page-tests/collection/storage-unit/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/storage-unit/__tests__/edit.test.tsx
@@ -85,6 +85,7 @@ describe("Storage Unit edit page.", () => {
           {
             resource: {
               name: "test-storage-unit",
+              isGeneric: false,
               parentStorageUnit: expect.objectContaining({
                 id: "A",
                 type: "storage-unit"


### PR DESCRIPTION
- Saving storage unit without interacting with Generic toggle now saves without error