### PR TITLE
34543 Unselect Form Template from material sample split

### DIFF
--- a/packages/dina-ui/components/bulk-material-sample/MaterialSampleSplitGenerationForm.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/MaterialSampleSplitGenerationForm.tsx
@@ -146,7 +146,12 @@ export function MaterialSampleSplitGenerationForm({
 
       {/* Submit Button */}
       <div className="col-md-6 col-sm-12 d-flex">
-        <SubmitButton className={"ms-auto"}>
+        <SubmitButton
+          className={"ms-auto"}
+          buttonProps={() => ({
+            disabled: !splitConfiguration
+          })}
+        >
           <DinaMessage id="splitButton" />
         </SubmitButton>
       </div>

--- a/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
+++ b/packages/dina-ui/components/collection/form-template/useMaterialSampleFormTemplateSelectState.tsx
@@ -40,7 +40,8 @@ export function useMaterialSampleFormTemplateSelectState({
   const { username } = useAccount();
   const { apiClient } = useApiClient();
   const router = useRouter();
-  const formTemplateId = router?.query?.formTemplateId?.toString();
+  const formTemplateId =
+    router?.query?.formTemplateId?.toString() ?? temporaryFormTemplateUUID;
   // Store the nav order in the Page components state:
   const [navOrder, setNavOrder] = useState<string[] | null>(null);
 
@@ -54,13 +55,13 @@ export function useMaterialSampleFormTemplateSelectState({
     useState<PersistedResource<FormTemplate>>();
 
   useEffect(() => {
-    if (temporaryFormTemplateUUID || sampleFormTemplateUUID) {
+    if (sampleFormTemplateUUID) {
       getFormTemplate();
     } else {
       setSampleFormTemplate(undefined);
       setNavOrder(null);
     }
-  }, [sampleFormTemplateUUID, temporaryFormTemplateUUID]);
+  }, [sampleFormTemplateUUID]);
 
   useEffect(() => {
     if (formTemplateId) {
@@ -71,9 +72,7 @@ export function useMaterialSampleFormTemplateSelectState({
   async function getFormTemplate() {
     await apiClient
       .get<FormTemplate>(
-        `collection-api/form-template/${
-          temporaryFormTemplateUUID ?? sampleFormTemplateUUID
-        }`,
+        `collection-api/form-template/${sampleFormTemplateUUID}`,
         {}
       )
       .then((response) => {


### PR DESCRIPTION
- Users can now unselect Form Template in bulk edit screen after the bulk-split config screen
- Added small change to disable Split button on split configs screen if no split config is selected i.e if user selected a material sample with no valid split config and selected bulk split