### PR TITLE
34427 Tag missing from object store detail page

### DIFF
--- a/packages/dina-ui/components/object-store/index.ts
+++ b/packages/dina-ui/components/object-store/index.ts
@@ -5,3 +5,4 @@ export * from "./file-view/FileView";
 export * from "./stored-object-gallery/StoredObjectGallery";
 export * from "./metadata/MetadataDetails";
 export * from "./metadata/MetadataPreview";
+export * from "./metadata/MetadataBadges";

--- a/packages/dina-ui/components/object-store/metadata/MetadataBadges.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataBadges.tsx
@@ -1,11 +1,22 @@
 import { TagSelectReadOnly } from "../../tag-editor/TagSelectField";
 
-export default function MetadataBadges() {
+interface MetadataBadgesProps {
+  tagsFieldName?: string;
+  groupSelectorName?: string;
+}
+
+export default function MetadataBadges({
+  tagsFieldName,
+  groupSelectorName
+}: MetadataBadgesProps) {
   return (
     <div>
       {" "}
       <div className="row">
-        <TagSelectReadOnly />
+        <TagSelectReadOnly
+          tagsFieldName={tagsFieldName}
+          groupSelectorName={groupSelectorName}
+        />
       </div>
     </div>
   );

--- a/packages/dina-ui/components/object-store/metadata/MetadataBadges.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataBadges.tsx
@@ -1,0 +1,12 @@
+import { TagSelectReadOnly } from "../../tag-editor/TagSelectField";
+
+export default function MetadataBadges() {
+  return (
+    <div>
+      {" "}
+      <div className="row">
+        <TagSelectReadOnly />
+      </div>
+    </div>
+  );
+}

--- a/packages/dina-ui/components/object-store/metadata/MetadataForm.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataForm.tsx
@@ -28,6 +28,7 @@ import {
 import { ReactNode, Ref } from "react";
 import { InputResource } from "kitsu";
 import { FormikProps } from "formik";
+import MetadataBadges from "./MetadataBadges";
 
 export interface MetadataFormProps {
   metadata?: InputResource<Metadata>;
@@ -86,6 +87,7 @@ export function MetadataForm({
           <MetadataFileView metadata={metadata as Metadata} imgHeight="15rem" />
         )}
       </div>
+      <MetadataBadges />
       <TagsAndRestrictionsSection
         resourcePath="objectstore-api/metadata"
         tagsFieldName="acTags"

--- a/packages/dina-ui/components/object-store/metadata/MetadataPreview.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataPreview.tsx
@@ -9,6 +9,7 @@ import { MetadataFileView } from "./MetadataFileView";
 import { useMetadataViewQuery } from "./useMetadata";
 import Link from "next/link";
 import { DinaMessage } from "../../../intl/dina-ui-intl";
+import MetadataBadges from "./MetadataBadges";
 
 interface MetadataPreviewProps {
   metadataId: string;
@@ -90,6 +91,7 @@ export function MetadataPreview({ metadataId }: MetadataPreviewProps) {
               </div>
             </>
           )}
+          <MetadataBadges tagsFieldName="acTags" />
           <MetadataDetails metadata={metadata} />
           {metadata.fileIdentifier && (
             <ExifView objectUpload={metadata.objectUpload} />

--- a/packages/dina-ui/components/tag-editor/TagSelectField.tsx
+++ b/packages/dina-ui/components/tag-editor/TagSelectField.tsx
@@ -229,10 +229,9 @@ export function TagSelectReadOnly({
   groupSelectorName = "group"
 }: TagSelectReadOnlyProps) {
   const { values } = useFormikContext<any>();
-
   return (
     <>
-      {values?.tags && values.tags.length !== 0 && (
+      {values?.[tagsFieldName] && values?.[tagsFieldName].length !== 0 && (
         <div className="ms-auto">
           <TagSelectField
             resourcePath={resourcePath}


### PR DESCRIPTION
- Added MetatadataBadges component with TagSelectReadOnly
- Object Store view page should now have a tag badge if one was added from edit page