### PR TITLE
34613 Elastic Search Autocomplete use resource type from search-api

### DIFF
--- a/packages/common-ui/lib/search/useAutocompleteSearchButFallbackToRsqlApiSearch.ts
+++ b/packages/common-ui/lib/search/useAutocompleteSearchButFallbackToRsqlApiSearch.ts
@@ -7,7 +7,6 @@ export interface UseAutocompleteSearchButFallbackToRsqlApiSearchProps
   extends AutocompleteSearchParams {
   searchQuery: string;
   querySpec: JsonApiQuerySpec;
-  type?: string;
 }
 
 /**
@@ -30,8 +29,7 @@ export function useAutocompleteSearchButFallbackToRsqlApiSearch<
   additionalField,
   searchField,
   restrictedField,
-  restrictedFieldValue,
-  type
+  restrictedFieldValue
 }: UseAutocompleteSearchButFallbackToRsqlApiSearchProps) {
   // The mode indicates which API is being used. Either RSQL or Elastic Search.
   const [apiMode, setApiMode] = useState<ApiModeType>("elasticsearch");
@@ -64,9 +62,6 @@ export function useAutocompleteSearchButFallbackToRsqlApiSearch<
   // Put the ResourceSelect's input into the Search hook's state:
   useEffect(() => setInputValue(searchQuery), [searchQuery]);
 
-  elasticSearchResult?.forEach((resource) => {
-    resource.type = type as any;
-  });
   return {
     loading: elasticSearchLoading || rsqlSearchLoading,
     response: {

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleBreadCrumb.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleBreadCrumb.tsx
@@ -27,7 +27,7 @@ export function MaterialSampleBreadCrumb({
   const { readOnly } = useDinaFormContext();
   const parentPath = [...(materialSample.hierarchy?.slice(1) ?? [])];
 
-  const displayName = materialSample.materialSampleName;
+  const displayName = materialSample.materialSampleName ?? materialSample.id;
   const customStyle = {
     option: (base) => {
       return {

--- a/packages/dina-ui/components/resource-select-fields/resource-select-fields.tsx
+++ b/packages/dina-ui/components/resource-select-fields/resource-select-fields.tsx
@@ -125,8 +125,7 @@ export function PersonSelectField(
           querySpec,
           indexName: "dina_agent_index",
           searchField: "data.attributes.displayName",
-          additionalField: "data.attributes.aliases",
-          type: "person"
+          additionalField: "data.attributes.aliases"
         })
       }
       readOnlyLink="/person/view?id="
@@ -176,8 +175,7 @@ export function StorageUnitSelectField({
           indexName: "dina_storage_index",
           searchField: "data.attributes.name",
           restrictedField,
-          restrictedFieldValue,
-          type: "storage-unit"
+          restrictedFieldValue
         })
       }
       readOnlyLink="/collection/storage-unit/view?id="

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -254,7 +254,8 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
           <>
             <Head
               title={formatMessage("materialSampleViewTitle", {
-                primaryID: materialSample?.materialSampleName
+                primaryID:
+                  materialSample?.materialSampleName ?? materialSample.id
               })}
             />
             <Nav marginBottom={false} />


### PR DESCRIPTION
- Removed the "type" prop from useAutoCompleteSearch hook as it's not needed anymore since the auto-complete api returns this value now
- Minor change to material sample view to fall back on id if primary id not available in view page
- "Prepared By" selector should not throw an error on material sample saving if an agent was chosen by typing into the filter