### PR TITLE
Support #34649 - Add sourceSet to bulk create material sample

### DIFF
--- a/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/MaterialSampleGenerationForm.tsx
@@ -9,14 +9,12 @@ import {
   SelectField,
   SubmitButton,
   TextField,
-  useApiClient,
-  useDinaFormContext
+  useApiClient
 } from "common-ui";
 import { Field, FormikContextType, useFormikContext } from "formik";
 import { InputResource } from "kitsu";
 import { padStart, range } from "lodash";
 import { useState } from "react";
-import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import SpreadSheetColumn from "spreadsheet-column";
 import * as yup from "yup";
 import {
@@ -83,12 +81,18 @@ export function MaterialSampleGenerationForm({
       >((_, index) => {
         const sample = submittedValues.samples[index];
         const materialSampleName = sample?.materialSampleName?.trim?.();
+        const sourceSet =
+          submittedValues.sourceSet !== undefined &&
+          submittedValues.sourceSet !== ""
+            ? submittedValues.sourceSet
+            : undefined;
         return {
           type: "material-sample",
           parentMaterialSample: undefined,
           group: submittedValues.group,
           collection: submittedValues.collection,
           publiclyReleasable: true,
+          sourceSet,
           ...sample,
           materialSampleName: materialSampleName
             ? materialSampleName
@@ -129,6 +133,7 @@ export function MaterialSampleGenerationForm({
           start: "001",
           baseName: "",
           separator: "",
+          sourceSet: "",
           collection: collectionQuery.lastUsedCollection
         }
       }
@@ -172,13 +177,23 @@ export function MaterialSampleGenerationForm({
         />
       </div>
       {!useNextSequence && (
-        <>
-          <GeneratorFields
-            generationMode={generationMode}
-            baseName={baseNameFromCollection}
-          />
-          <PreviewAndCustomizeFields generationMode={generationMode} />
-        </>
+        <GeneratorFields
+          generationMode={generationMode}
+          baseName={baseNameFromCollection}
+        />
+      )}
+
+      {/* Source Set */}
+      <div className="row">
+        <TextField
+          className="col-sm-6"
+          name="sourceSet"
+          tooltipOverride={formatMessage("sourceSet_tooltip")}
+        />
+      </div>
+
+      {!useNextSequence && (
+        <PreviewAndCustomizeFields generationMode={generationMode} />
       )}
       <ButtonBar centered={false}>
         <BackToListButton
@@ -402,6 +417,7 @@ const generatorFormSchema = yup.object({
     .required(),
   baseName: yup.string(),
   separator: yup.string(),
+  sourceSet: yup.string(),
   // Batch mode:
   suffix: yup.string(),
   // Series mode:

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleGenerationForm.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleGenerationForm.test.tsx
@@ -1,6 +1,5 @@
 import { writeStorage } from "@rehooks/local-storage";
 import { ResourceSelect } from "common-ui";
-import Select from "react-select";
 import { mountWithAppContext } from "../../../test-util/mock-app-context";
 import { DEFAULT_GROUP_STORAGE_KEY } from "../../group-select/useStoredDefaultGroup";
 import { MaterialSampleGenerationForm } from "../MaterialSampleGenerationForm";
@@ -70,6 +69,9 @@ describe("MaterialSampleGenerationForm", () => {
     wrapper
       .find(".separator-field input")
       .simulate("change", { target: { value: "-" } });
+    wrapper
+      .find(".sourceSet-field input")
+      .simulate("change", { target: { value: "sourceSet1" } });
 
     const expectedNames = [
       "my-sample-00001",
@@ -96,6 +98,7 @@ describe("MaterialSampleGenerationForm", () => {
         parentMaterialSample: undefined,
         collection: { id: "100", name: "test-collection", type: "collection" },
         group: "aafc",
+        sourceSet: "sourceSet1",
         materialSampleName: name,
         publiclyReleasable: true,
         type: "material-sample"
@@ -110,6 +113,7 @@ describe("MaterialSampleGenerationForm", () => {
         group: "aafc",
         increment: "NUMERICAL",
         numberToCreate: "5",
+        sourceSet: "sourceSet1",
         samples: [],
         separator: "-",
         start: "00001",

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -445,6 +445,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   field_scientificName: "Scientific Name",
   field_scientificNameInput: "Scientific Name",
   field_sex: "Sex",
+  field_sourceSet: "Source Set",
   field_startDate: "Start Date",
   field_startEventDateTime: "Start Event Date Time",
   field_startEventDateTime_tooltip:
@@ -872,6 +873,8 @@ export const DINAUI_MESSAGES_ENGLISH = {
   storageUnitType: "Storage Unit Type",
   storageUnitTypeListTitle: "Storage Unit Types",
   storagesCreatedByMe: "Storages Created By Me",
+  sourceSet_tooltip:
+    "User-defined name that can be used to retrieve all material samples that were created in the same batch.",
   tags: "Tags",
   tag: "Tag",
   target: "Target",


### PR DESCRIPTION
- Added sourceset field when adding multiple Material Samples.
- Added tooltip to the field.
- If set, the material samples will have the sourceSet applied and it can be searched on.