### PR TITLE
Bug #34806 - Part of AND query ignored

### DIFF
--- a/packages/common-ui/lib/list-page/reload-last-search/useLastSavedSearch.tsx
+++ b/packages/common-ui/lib/list-page/reload-last-search/useLastSavedSearch.tsx
@@ -56,19 +56,13 @@ export function useLastSavedSearch({
   );
 
   const loadLastSavedSearch = () => {
-    if (sessionStorageQueryTree) {
-      setQueryBuilderTree(Utils.loadTree(sessionStorageQueryTree as JsonTree));
-      setSubmittedQueryBuilderTree(
-        Utils.loadTree(sessionStorageQueryTree as JsonTree)
-      );
-    }
-
     setQueryLoaded(true);
   };
 
   // Once the query builder tree has been loaded in, perform a submit.
   useEffect(() => {
     if (sessionStorageQueryTree) {
+      setQueryBuilderTree(Utils.loadTree(sessionStorageQueryTree as JsonTree));
       setSubmittedQueryBuilderTree(
         Utils.loadTree(sessionStorageQueryTree as JsonTree)
       );


### PR DESCRIPTION
- Updated the lastSavedSearch to ensure the setQueryBuilderTree is also called (not just the submitted version)
- Don't need to run save the states twice which causes some issues.