### PR TITLE
Support #34922 - Check image lazy loading in object store

### DIFF
--- a/packages/common-ui/lib/index.ts
+++ b/packages/common-ui/lib/index.ts
@@ -117,3 +117,4 @@ export * from "./multilingual-components/MultilingualTitle";
 export * from "./instance/InstanceContextProvider";
 export * from "./instance/useInstanceContext";
 export * from "./label/FieldLabel";
+export * from "./visibility/useIsVisible";

--- a/packages/common-ui/lib/visibility/useIsVisible.tsx
+++ b/packages/common-ui/lib/visibility/useIsVisible.tsx
@@ -1,0 +1,56 @@
+import { RefObject, useEffect, useState } from "react";
+
+export interface UseIsVisibleProps {
+  /**
+   * useRef hook, should be attached to a div that's always rendered on the page.
+   */
+  ref: RefObject<any>;
+
+  /**
+   * Determines if it should be reset back to false when it's out of view.
+   */
+  doNotReset?: boolean;
+
+  /**
+   * offset for the viewport, for example: '0px 0px 200px 0px' if you want to consider 200px under
+   * the view port as visible.
+   */
+  offset?: string;
+}
+
+/**
+ * Hook used to determine if a reference is being displayed currently to the user.
+ *
+ * If it's not within the users view port, it's returned as false.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+ * @returns boolean if it's currently being displayed on the screen.
+ */
+export function useIsVisible({
+  ref,
+  doNotReset = false,
+  offset
+}: UseIsVisibleProps) {
+  const [isIntersecting, setIntersecting] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const inView = entry.isIntersecting;
+        if (doNotReset && inView === false) {
+          return;
+        }
+
+        setIntersecting(inView);
+      },
+      { rootMargin: offset }
+    );
+
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref]);
+
+  return isIntersecting;
+}

--- a/packages/common-ui/lib/visibility/useIsVisible.tsx
+++ b/packages/common-ui/lib/visibility/useIsVisible.tsx
@@ -34,6 +34,12 @@ export function useIsVisible({
   const [isIntersecting, setIntersecting] = useState(false);
 
   useEffect(() => {
+    // For unit testing, always consider it in view.
+    if (!window.IntersectionObserver) {
+      setIntersecting(true);
+      return;
+    }
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         const inView = entry.isIntersecting;

--- a/packages/dina-ui/components/object-store/file-view/FileView.tsx
+++ b/packages/dina-ui/components/object-store/file-view/FileView.tsx
@@ -1,7 +1,12 @@
-import { LoadingSpinner, useApiClient, useQuery } from "../../../../common-ui";
+import {
+  LoadingSpinner,
+  useApiClient,
+  useIsVisible,
+  useQuery
+} from "../../../../common-ui";
 import dynamic from "next/dynamic";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
-import { ComponentType, ReactNode, useState, useEffect } from "react";
+import { ComponentType, ReactNode, useState, useRef } from "react";
 import Link from "next/link";
 import { SmallThumbnail } from "../../table/thumbnail-cell";
 import { Metadata } from "../../../types/objectstore-api";
@@ -58,6 +63,7 @@ export function FileView({
 }: FileViewProps) {
   const { apiClient } = useApiClient();
   const { formatMessage } = useDinaIntl();
+
   const [objectURL, setObjectURL] = useState<string>();
   async function fetchObjectBlob(path) {
     return await apiClient.axios.get(path, {
@@ -70,6 +76,16 @@ export function FileView({
   const isTextDoc = DOCUMENT_FORMATS.includes(fileType.toLowerCase());
   const [isFallbackRender, setIsFallBackRender] = useState<boolean>(false);
   const [isDownloading, setIsDownloading] = useState<boolean>(false);
+
+  const visibleRef = useRef<HTMLDivElement>(null);
+
+  const isVisible = useIsVisible({
+    ref: visibleRef,
+    doNotReset: true,
+    // Start loading images when it's 300px below the view port.
+    offset: "0px 0px 300px 0px"
+  });
+
   const shownTypeIndicatorFallback = (
     <div className="shown-file-type">
       <strong>
@@ -83,15 +99,32 @@ export function FileView({
   function onSuccess(response) {
     setObjectURL(window?.URL?.createObjectURL(response));
   }
+
+  const disableRequest = () => {
+    // Check if it's visible to the user, if not, then disable the request.
+    if (isVisible === false) {
+      return true;
+    }
+
+    // Check if it's something that can be loaded...
+    if (metadata) {
+      return (
+        metadata?.dcType !== "IMAGE" && metadata?.dcType !== "MOVING_IMAGE"
+      );
+    }
+
+    // It's visible and the metadata is an image.
+    return false;
+  };
+
   const resp = useQuery(
     { path: filePath, responseType: "blob", timeout: 0 },
     {
       onSuccess,
-      disabled: metadata
-        ? metadata?.dcType !== "IMAGE" && metadata?.dcType !== "MOVING_IMAGE"
-        : false
+      disabled: disableRequest()
     }
   );
+
   if (preview || (!isImage && fileType !== "pdf")) {
     clickToDownload = false;
   }
@@ -155,89 +188,91 @@ export function FileView({
     );
   }
 
-  if (resp?.loading) {
-    return <LoadingSpinner loading={true} />;
-  }
   const errorStatus = (resp.error as any)?.cause?.status;
   return (
-    <div className="file-viewer-wrapper text-center">
-      {showFile ? (
-        errorStatus === undefined ? (
-          <a
-            href={objectURL}
-            target="_blank"
-            style={{
-              color: "inherit",
-              textDecoration: "none",
-              pointerEvents: clickToDownload ? undefined : "none",
-              display: "block",
-              marginLeft: "auto",
-              marginRight: "auto",
-              width: "fit-content"
-            }}
-          >
-            {isImage ? (
-              <img
-                loading="lazy"
-                alt={imgAlt ?? `File path : ${filePath}`}
-                src={objectURL}
-                style={{ height: imgHeight }}
-                onError={(event) =>
-                  (event.currentTarget.style.display = "none")
-                }
-              />
-            ) : (
-              <FileViewer
-                filePath={objectURL}
-                fileType={fileType}
-                unsupportedComponent={fallBackRender}
-                errorComponent={fallBackRender}
-              />
-            )}
-          </a>
-        ) : errorStatus === 403 ? (
-          <DinaMessage id="unauthorized" />
-        ) : (
-          <DinaMessage id="thumbnailNotAvailableText" />
-        )
+    <div className="file-viewer-wrapper text-center" ref={visibleRef}>
+      {resp?.loading ? (
+        <LoadingSpinner loading={true} />
       ) : (
-        <DinaMessage id="previewNotAvailable" />
-      )}
-      {!preview && (
-        <div className="d-flex justify-content-center">
-          {downloadLinks?.original && (
-            <DownloadLink
-              id="originalFile"
-              path={downloadLinks?.original}
-              isDownloading={isDownloading}
-              handleDownloadLink={handleDownloadLink}
-            />
+        <>
+          {showFile ? (
+            errorStatus === undefined ? (
+              <a
+                href={objectURL}
+                target="_blank"
+                style={{
+                  color: "inherit",
+                  textDecoration: "none",
+                  pointerEvents: clickToDownload ? undefined : "none",
+                  display: "block",
+                  marginLeft: "auto",
+                  marginRight: "auto",
+                  width: "fit-content"
+                }}
+              >
+                {isImage ? (
+                  <img
+                    alt={imgAlt ?? `File path : ${filePath}`}
+                    src={objectURL}
+                    style={{ height: imgHeight }}
+                    onError={(event) =>
+                      (event.currentTarget.style.display = "none")
+                    }
+                  />
+                ) : (
+                  <FileViewer
+                    filePath={objectURL}
+                    fileType={fileType}
+                    unsupportedComponent={fallBackRender}
+                    errorComponent={fallBackRender}
+                  />
+                )}
+              </a>
+            ) : errorStatus === 403 ? (
+              <DinaMessage id="unauthorized" />
+            ) : (
+              <DinaMessage id="thumbnailNotAvailableText" />
+            )
+          ) : (
+            <DinaMessage id="previewNotAvailable" />
           )}
-          {downloadLinks?.thumbNail && (
-            <DownloadLink
-              id="thumbnail"
-              path={downloadLinks?.thumbNail}
-              isDownloading={isDownloading}
-              handleDownloadLink={handleDownloadLink}
-            />
+          {!preview && (
+            <div className="d-flex justify-content-center">
+              {downloadLinks?.original && (
+                <DownloadLink
+                  id="originalFile"
+                  path={downloadLinks?.original}
+                  isDownloading={isDownloading}
+                  handleDownloadLink={handleDownloadLink}
+                />
+              )}
+              {downloadLinks?.thumbNail && (
+                <DownloadLink
+                  id="thumbnail"
+                  path={downloadLinks?.thumbNail}
+                  isDownloading={isDownloading}
+                  handleDownloadLink={handleDownloadLink}
+                />
+              )}
+              {downloadLinks?.largeData && (
+                <DownloadLink
+                  id="largeImg"
+                  path={downloadLinks?.largeData}
+                  isDownloading={isDownloading}
+                  handleDownloadLink={handleDownloadLink}
+                />
+              )}
+            </div>
           )}
-          {downloadLinks?.largeData && (
-            <DownloadLink
-              id="largeImg"
-              path={downloadLinks?.largeData}
-              isDownloading={isDownloading}
-              handleDownloadLink={handleDownloadLink}
-            />
+          {!preview && (
+            <div>
+              {showFile &&
+                (isFallbackRender
+                  ? shownTypeIndicatorFallback
+                  : shownTypeIndicator)}
+            </div>
           )}
-        </div>
-      )}
-      {!preview && (
-        <div>
-          {showFile &&
-            (isFallbackRender
-              ? shownTypeIndicatorFallback
-              : shownTypeIndicator)}
-        </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
- Created a new hook called useIsVisible which lets you check if a element on the page has been loaded into the view port.
- File view has been refactored to disable the request if it's not in the view port yet. (Added a buffer of 300px so it will start loading some outside of the view port)