### PR TITLE
Support #34965 - Issue with dynamic field configuration on parent material samples

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
@@ -73,7 +73,7 @@ export function generateColumnPath({
         return (
           dynamicFieldTypeWithRelationship +
           "/" +
-          identifierValues.selectedIdentifier
+          identifierValues.selectedIdentifier?.id
         );
 
       // Relationship Presence (relationshipPresence/[RELATIONSHIP]/[OPERATOR])
@@ -836,7 +836,12 @@ export function getIncludedIdentifierColumn<TData extends KitsuResource>(
       const value = get(original, valuePath);
       return <>{value}</>;
     },
-    header: () => <VocabularyFieldHeader vocabulary={identifier} />,
+    header: () => (
+      <VocabularyFieldHeader
+        vocabulary={identifier}
+        referencedBy={config.referencedBy}
+      />
+    ),
     accessorKey,
     id: `${config.referencedBy}.${fieldName}.${identifier.id}`,
     isKeyword: true,

--- a/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
@@ -445,6 +445,9 @@ export function getIncludedManagedAttributeColumn<TData extends KitsuResource>(
   const managedAttributeKey = managedAttribute.key;
   const accessorKey = `${config.path}.${managedAttributeKey}`;
 
+  const pathParts = config.path.split(".");
+  const fieldName = pathParts[pathParts.length - 1];
+
   const managedAttributesColumn = {
     cell: ({ row: { original } }) => {
       const relationshipAccessor = accessorKey?.split(".");
@@ -457,9 +460,14 @@ export function getIncludedManagedAttributeColumn<TData extends KitsuResource>(
       const value = get(original, valuePath);
       return <>{value}</>;
     },
-    header: () => <FieldHeader name={managedAttribute.name} />,
+    header: () => (
+      <>
+        {config.referencedBy ? startCase(config.referencedBy) + " - " : ""}
+        {startCase(managedAttribute.name)}
+      </>
+    ),
     accessorKey,
-    id: `${config.referencedBy}.${config.label}.${managedAttributeKey}`,
+    id: `${config.referencedBy}.${fieldName}.${managedAttributeKey}`,
     isKeyword: managedAttribute.vocabularyElementType === "STRING",
     isColumnVisible: true,
     relationshipType: config.referencedType,
@@ -480,10 +488,14 @@ export function getAttributesManagedAttributeColumn<
 ): TableColumn<TData> {
   const managedAttributeKey = managedAttribute.key;
   const accessorKey = `${config.path}.${managedAttributeKey}`;
+
+  const pathParts = config.path.split(".");
+  const fieldName = pathParts[pathParts.length - 1];
+
   const managedAttributesColumn = {
     header: () => <FieldHeader name={managedAttribute.name} />,
     accessorKey,
-    id: `${config.label}.${managedAttributeKey}`,
+    id: `${fieldName}.${managedAttributeKey}`,
     isKeyword: managedAttribute.vocabularyElementType === "STRING",
     isColumnVisible: true,
     config,
@@ -656,9 +668,9 @@ export function getIncludedExtensionFieldColumn(
     accessorKey,
     id: `${config.referencedBy}.${fieldExtensionResourceType}.${extensionValue.id}.${extensionField.key}`,
     header: () =>
-      `${startCase(config.referencedBy)} - ${extensionValue.extension.name} - ${
-        extensionField.name
-      }`,
+      `${config.referencedBy ? startCase(config.referencedBy) + " - " : ""}${
+        extensionValue.extension.name
+      } - ${extensionField.name}`,
     label: `${startCase(config.referencedBy)} - ${
       extensionValue.extension.name
     } - ${extensionField.name}`,
@@ -784,10 +796,13 @@ export function getAttributeIdentifierColumn<TData extends KitsuResource>(
   config: DynamicField
 ): TableColumn<TData> {
   const accessorKey = `${config.path}.${identifier.id}`;
+  const pathParts = config.path.split(".");
+  const fieldName = pathParts[pathParts.length - 1];
+
   const identifierColumn = {
     header: () => <VocabularyFieldHeader vocabulary={identifier} />,
     accessorKey,
-    id: `${config.label}.${identifier.id}`,
+    id: `${fieldName}.${identifier.id}`,
     isKeyword: true,
     isColumnVisible: true,
     config,
@@ -806,6 +821,9 @@ export function getIncludedIdentifierColumn<TData extends KitsuResource>(
 ): TableColumn<TData> {
   const accessorKey = `${config.path}.${identifier.id}`;
 
+  const pathParts = config.path.split(".");
+  const fieldName = pathParts[pathParts.length - 1];
+
   const identifierColumn = {
     cell: ({ row: { original } }) => {
       const relationshipAccessor = accessorKey?.split(".");
@@ -820,7 +838,7 @@ export function getIncludedIdentifierColumn<TData extends KitsuResource>(
     },
     header: () => <VocabularyFieldHeader vocabulary={identifier} />,
     accessorKey,
-    id: `${config.referencedBy}.${config.label}.${identifier.id}`,
+    id: `${config.referencedBy}.${fieldName}.${identifier.id}`,
     isKeyword: true,
     isColumnVisible: true,
     relationshipType: config.referencedType,

--- a/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
+++ b/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
@@ -1,4 +1,7 @@
-import { generateColumnPath } from "../ColumnSelectorUtils";
+import {
+  generateColumnPath,
+  parseRelationshipNameFromType
+} from "../ColumnSelectorUtils";
 
 describe("ColumnSelectorUtils", () => {
   describe("generateColumnPath", () => {
@@ -57,7 +60,7 @@ describe("ColumnSelectorUtils", () => {
           dynamicFieldValue: `{"searchValue":"","selectedOperator":"exactMatch","selectedManagedAttribute":{"id":"01905a46-17bb-74ef-a2f5-3e801d52433d","type":"managed-attribute","name":"CollectingEvent","key":"collecting_event_managed_attribute_key","vocabularyElementType":"STRING","unit":null,"managedAttributeComponent":"COLLECTING_EVENT","acceptedValues":null,"createdOn":"2024-06-27T15:17:41.436807Z","createdBy":"dina-admin","group":"aafc","multilingualDescription":{"descriptions":[]}},"selectedType":"STRING"}`
         })
       ).toEqual(
-        "managedAttribute/COLLECTING_EVENT/collecting_event_managed_attribute_key"
+        "managedAttribute~collectingEvent/COLLECTING_EVENT/collecting_event_managed_attribute_key"
       );
     });
 
@@ -115,7 +118,9 @@ describe("ColumnSelectorUtils", () => {
           },
           dynamicFieldValue: `{"selectedExtension":"mixs_water_v4","selectedField":"alkalinity","searchValue":"","selectedOperator":"exactMatch"}`
         })
-      ).toEqual("fieldExtension/COLLECTING_EVENT/mixs_water_v4/alkalinity");
+      ).toEqual(
+        "fieldExtension~collectingEvent/COLLECTING_EVENT/mixs_water_v4/alkalinity"
+      );
     });
 
     it("Generate identifier path", () => {
@@ -172,7 +177,7 @@ describe("ColumnSelectorUtils", () => {
           },
           dynamicFieldValue: `{"searchValue":"","selectedOperator":"exactMatch","selectedIdentifier":"seqdb_id"}`
         })
-      ).toEqual("identifier/seqdb_id");
+      ).toEqual("identifier~parentMaterialSample/seqdb_id");
     });
 
     it("Generate relationship presence path", () => {
@@ -243,6 +248,18 @@ describe("ColumnSelectorUtils", () => {
           }
         })
       ).toEqual("assemblages.name");
+    });
+  });
+
+  describe("parseRelationshipNameFromType", () => {
+    it("Successfully parse the relationship name from the type", () => {
+      expect(
+        parseRelationshipNameFromType("identifier~parentMaterialSample")
+      ).toEqual("parentMaterialSample");
+    });
+
+    it("Returns undefined if no relationshipName is provided", () => {
+      expect(parseRelationshipNameFromType("identifier")).toBeUndefined();
     });
   });
 });

--- a/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
+++ b/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
@@ -146,7 +146,7 @@ describe("ColumnSelectorUtils", () => {
             endsWithSupport: false,
             hideField: false
           },
-          dynamicFieldValue: `{"searchValue":"","selectedOperator":"exactMatch","selectedIdentifier":"seqdb_id"}`
+          dynamicFieldValue: `{"searchValue":"","selectedOperator":"exactMatch","selectedIdentifier":{"id": "seqdb_id"}}`
         })
       ).toEqual("identifier/seqdb_id");
 
@@ -175,7 +175,7 @@ describe("ColumnSelectorUtils", () => {
             endsWithSupport: false,
             hideField: false
           },
-          dynamicFieldValue: `{"searchValue":"","selectedOperator":"exactMatch","selectedIdentifier":"seqdb_id"}`
+          dynamicFieldValue: `{"searchValue":"","selectedOperator":"exactMatch","selectedIdentifier":{"id": "seqdb_id"}}`
         })
       ).toEqual("identifier~parentMaterialSample/seqdb_id");
     });

--- a/packages/dina-ui/components/collection/VocabularySelectField.tsx
+++ b/packages/dina-ui/components/collection/VocabularySelectField.tsx
@@ -4,8 +4,8 @@ import { GroupBase } from "react-select";
 import CreatableSelect, { CreatableProps } from "react-select/creatable";
 import { useDinaIntl } from "../../intl/dina-ui-intl";
 import useVocabularyOptions from "./useVocabularyOptions";
-import { VocabularyElement } from "packages/dina-ui/types/collection-api";
 import { IdentifierType } from "packages/dina-ui/types/collection-api/resources/IdentifierType";
+import { startCase } from "lodash";
 
 export interface VocabularySelectFieldProps extends FieldWrapperProps {
   path: string;
@@ -102,15 +102,22 @@ export function VocabularyReadOnlyView({ path, value }) {
 
 export interface VocabularyFieldHeaderProps {
   vocabulary: IdentifierType;
+  referencedBy?: string;
 }
 
 export function VocabularyFieldHeader({
-  vocabulary
+  vocabulary,
+  referencedBy
 }: VocabularyFieldHeaderProps) {
   const { locale } = useDinaIntl();
   const label =
     vocabulary?.multilingualTitle?.titles?.find(
       (title) => title.lang === locale
     )?.title ?? vocabulary.id;
-  return <>{label}</>;
+  return (
+    <>
+      {referencedBy ? startCase(referencedBy) + " - " : ""}
+      {label}
+    </>
+  );
 }

--- a/packages/dina-ui/pages/collection/material-sample/list.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/list.tsx
@@ -295,7 +295,7 @@ export const dynamicFieldMappingForMaterialSample: DynamicFieldsMappingConfig =
 
       // Parent Material Sample - Material Sample - Managed Attributes
       {
-        type: "unsupported",
+        type: "managedAttribute",
         label: "materialSampleManagedAttributes",
         path: "included.attributes.managedAttributes",
         apiEndpoint: "collection-api/managed-attribute",
@@ -305,7 +305,7 @@ export const dynamicFieldMappingForMaterialSample: DynamicFieldsMappingConfig =
       },
       // Parent Material Sample - Preparation - Managed Attributes
       {
-        type: "unsupported",
+        type: "managedAttribute",
         label: "preparationManagedAttributes",
         path: "included.attributes.preparationManagedAttributes",
         apiEndpoint: "collection-api/managed-attribute",
@@ -315,7 +315,7 @@ export const dynamicFieldMappingForMaterialSample: DynamicFieldsMappingConfig =
       },
       // Parent Material Sample - Material Sample - Field Extensions
       {
-        type: "unsupported",
+        type: "fieldExtension",
         label: "fieldExtensions",
         component: "MATERIAL_SAMPLE",
         path: "included.attributes.extensionValues",
@@ -325,7 +325,7 @@ export const dynamicFieldMappingForMaterialSample: DynamicFieldsMappingConfig =
       },
       // Parent Material Sample - Material Sample - Restrictions
       {
-        type: "unsupported",
+        type: "fieldExtension",
         label: "restrictions",
         component: "RESTRICTION",
         path: "included.attributes.restrictionFieldsExtension",
@@ -335,7 +335,7 @@ export const dynamicFieldMappingForMaterialSample: DynamicFieldsMappingConfig =
       },
       // Parent Material Sample - Material Sample - Identifiers
       {
-        type: "unsupported",
+        type: "identifier",
         label: "identifiers",
         component: "MATERIAL_SAMPLE",
         path: "included.attributes.identifiers",


### PR DESCRIPTION
- Updated the generateColumnPath to include the relationshipName if it's a relationship.
- Updated the test coverage.
- Updated the parsing of the column paths to read the relationship name and link it to the correct relationship field config.