### PR TITLE
Support #35047 - Link to audit not working

### DIFF
--- a/packages/common-ui/lib/api-client/useQuery.tsx
+++ b/packages/common-ui/lib/api-client/useQuery.tsx
@@ -135,16 +135,30 @@ export function useQuery<TData extends KitsuResponseData, TMeta = undefined>(
 interface AuditSnapshotRouterProps {
   error: any;
 }
+
 function AuditSnapshotRouter({ error }: AuditSnapshotRouterProps) {
   const errorDetails = (error as any)?.cause?.data?.errors?.[0];
   const auditSnapshotLink: string = errorDetails?.links?.about;
+
+  // UUID extracted from the audit link.
   const id: string | undefined = auditSnapshotLink
     ?.split("=")
     ?.at(-1)
     ?.split("/")
     ?.at(1);
-  return id ? <Link href={`revisions?id=${id}`}>Audit Snapshot</Link> : null;
+
+  // Resource extracted from the audit link.
+  const resource: string | undefined = auditSnapshotLink
+    ?.split("=")
+    ?.at(-1)
+    ?.split("/")
+    ?.at(0);
+
+  return id && resource ? (
+    <Link href={`../${resource}/revisions?id=${id}`}>Audit Snapshot</Link>
+  ) : null;
 }
+
 /**
  * Only render if there is a response, otherwise show generic 'loading' or 'error' indicators.
  *
@@ -169,7 +183,7 @@ export function withResponse<
         : error?.errors?.map((e) => e.detail).join("\n") ?? String(error);
     const errorDetails = (error as any)?.cause?.data?.errors?.[0];
     return (
-      <div className="alert alert-danger">
+      <div className="alert alert-danger mt-3">
         {`${message}. `}
         {errorDetails?.links?.about && <AuditSnapshotRouter error={error} />}
       </div>

--- a/packages/dina-ui/components/revisions/RevisionsPageLayout.tsx
+++ b/packages/dina-ui/components/revisions/RevisionsPageLayout.tsx
@@ -206,7 +206,7 @@ export function RevisionsPage({
   const resource = query?.response?.data;
 
   const pageTitle = formatMessage("revisionsListTitle", {
-    name: get(resource, nameField) ?? resource?.id
+    name: get(resource, nameField) ?? id
   });
   if (query?.loading) {
     return <LoadingSpinner loading={true} />;
@@ -219,7 +219,7 @@ export function RevisionsPage({
         <Link
           href={`${detailsPageLink}/${
             isExternalResourceMetadata ? "external-resource-view" : "view"
-          }?id=${resource?.id}`}
+          }?id=${id}`}
         >
           <a className="back-button my-auto me-auto mt-2">
             <DinaMessage id="detailsPageLink" />


### PR DESCRIPTION
- Fixed the Audit Snapshot link to pass the resource in the URL instead of using the current one.
- Fixed the layout for the error message.
- Fixed revision page details view link and title to use ID from URL.