### PR TITLE
Support #35084 - Change GitHub feedback url

### DIFF
--- a/packages/common-ui/lib/instance/InstanceContextProvider.tsx
+++ b/packages/common-ui/lib/instance/InstanceContextProvider.tsx
@@ -4,6 +4,7 @@ import { useApiClient } from "../api-client/ApiClientContext";
 export interface InstanceContextI {
   supportedLanguages: string;
   instanceMode: string;
+  instanceName: string;
 }
 
 export const InstanceContext = createContext<InstanceContextI | undefined>(
@@ -31,12 +32,16 @@ export function DefaultInstanceContextProvider({
               : "en",
             instanceMode: !!response["instance-mode"]
               ? response["instance-mode"]
-              : "developer"
+              : "developer",
+            instanceName: !!response["instance-name"]
+              ? response["instance-name"]
+              : "AAFC"
           });
         } else {
           setInstanceJson({
             supportedLanguages: "en",
-            instanceMode: "developer"
+            instanceMode: "developer",
+            instanceName: "AAFC"
           });
         }
       } catch (error) {

--- a/packages/common-ui/lib/test-util/mock-app-context.tsx
+++ b/packages/common-ui/lib/test-util/mock-app-context.tsx
@@ -60,7 +60,11 @@ export function MockAppContextProvider({
   );
 
   const DEFAULT_INSTANCE_CONTEXT_VALUE: InstanceContextI = useMemo(
-    () => ({ supportedLanguages: "en,fr", instanceMode: "developer" }),
+    () => ({
+      supportedLanguages: "en,fr",
+      instanceMode: "developer",
+      instanceName: "AAFC"
+    }),
     []
   );
 

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/__snapshots__/MaterialSampleSplitGenerationForm.test.tsx.snap
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/__snapshots__/MaterialSampleSplitGenerationForm.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`MaterialSampleSplitGenerationForm Layout snapshot with matching materia
                 >
                   <a
                     class="px-0 btn btn-link"
-                    href="https://github.com/AAFC-BICoE/dina-planning/issues/new?labels=demo%20feedback"
+                    href="https://github.com/AAFC-BICoE/dina-feedback/issues/new?labels=AAFC"
                     role="button"
                     tabindex="0"
                   >
@@ -693,7 +693,7 @@ exports[`MaterialSampleSplitGenerationForm Layout snapshot without matching mate
                 >
                   <a
                     class="px-0 btn btn-link"
-                    href="https://github.com/AAFC-BICoE/dina-planning/issues/new?labels=demo%20feedback"
+                    href="https://github.com/AAFC-BICoE/dina-feedback/issues/new?labels=AAFC"
                     role="button"
                     tabindex="0"
                   >

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/__snapshots__/MaterialSampleSplitGenerationForm.test.tsx.snap
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/__snapshots__/MaterialSampleSplitGenerationForm.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`MaterialSampleSplitGenerationForm Layout snapshot with matching materia
                 >
                   <a
                     class="px-0 btn btn-link"
-                    href="https://github.com/AAFC-BICoE/dina-feedback/issues/new?labels=AAFC"
+                    href="https://github.com/AAFC-BICoE/dina-feedback/issues/new?template=bug_report.md&labels=template&title=%5BAAFC%5D%20"
                     role="button"
                     tabindex="0"
                   >
@@ -693,7 +693,7 @@ exports[`MaterialSampleSplitGenerationForm Layout snapshot without matching mate
                 >
                   <a
                     class="px-0 btn btn-link"
-                    href="https://github.com/AAFC-BICoE/dina-feedback/issues/new?labels=AAFC"
+                    href="https://github.com/AAFC-BICoE/dina-feedback/issues/new?template=bug_report.md&labels=template&title=%5BAAFC%5D%20"
                     role="button"
                     tabindex="0"
                   >

--- a/packages/dina-ui/components/button-bar/nav/nav.tsx
+++ b/packages/dina-ui/components/button-bar/nav/nav.tsx
@@ -128,9 +128,13 @@ function SkipLinks() {
 }
 
 function FeedbackButton() {
+  const instanceContext = useInstanceContext();
+
   return (
     <Link
-      href="https://github.com/AAFC-BICoE/dina-planning/issues/new?labels=demo%20feedback"
+      href={`https://github.com/AAFC-BICoE/dina-feedback/issues/new?labels=${
+        instanceContext?.instanceName ?? "AAFC"
+      }`}
       passHref={true}
     >
       <Button variant="link" className="px-0">

--- a/packages/dina-ui/components/button-bar/nav/nav.tsx
+++ b/packages/dina-ui/components/button-bar/nav/nav.tsx
@@ -130,11 +130,14 @@ function SkipLinks() {
 function FeedbackButton() {
   const instanceContext = useInstanceContext();
 
+  // The labels are set using the template (bug_report.md), however, it still needs to be set to
+  // a value using the URL param. I just used "template" since it will just revert to the bug_report.md
+  // provided value. The title will be pre-populated with the instance name.
   return (
     <Link
-      href={`https://github.com/AAFC-BICoE/dina-feedback/issues/new?labels=${
+      href={`https://github.com/AAFC-BICoE/dina-feedback/issues/new?template=bug_report.md&labels=template&title=%5B${
         instanceContext?.instanceName ?? "AAFC"
-      }`}
+      }%5D%20`}
       passHref={true}
     >
       <Button variant="link" className="px-0">

--- a/packages/dina-ui/dev.Caddyfile
+++ b/packages/dina-ui/dev.Caddyfile
@@ -33,6 +33,7 @@ respond /keycloak.json "{
 
 respond /api/instance.json "{ 
 	\"instance-mode\": \"{$INSTANCE_MODE}\",
+	\"instance-name\": \"{$INSTANCE_NAME}\",
 	\"supported-languages-iso\": \"{$SUPPORTED_LANGUAGES_ISO}\"
 }"
 

--- a/packages/dina-ui/prod.Caddyfile
+++ b/packages/dina-ui/prod.Caddyfile
@@ -36,6 +36,7 @@ respond /keycloak.json "{
 
 respond /api/instance.json "{ 
 	\"instance-mode\": \"{$INSTANCE_MODE}\",
+	\"instance-name\": \"{$INSTANCE_NAME}\",
 	\"supported-languages-iso\": \"{$SUPPORTED_LANGUAGES_ISO}\"
 }"
 

--- a/packages/dina-ui/test-util/mock-app-context.tsx
+++ b/packages/dina-ui/test-util/mock-app-context.tsx
@@ -87,7 +87,11 @@ export function MockAppContextProvider({
   );
 
   const DEFAULT_INSTANCE_CONTEXT_VALUE: InstanceContextI = useMemo(
-    () => ({ supportedLanguages: "en,fr", instanceMode: "developer" }),
+    () => ({
+      supportedLanguages: "en,fr",
+      instanceMode: "developer",
+      instanceName: "AAFC"
+    }),
     []
   );
 


### PR DESCRIPTION
- Added instanceName to the instance context.
- Added instanceName to both caddyfiles.
- Updated the URL and it now uses the instanceName to supply the label URL