### PR TITLE
Support #35184 - Dev user endpoint shouldn't be requested unless in i…

### DIFF
--- a/packages/common-ui/lib/account/DevUserProvider.tsx
+++ b/packages/common-ui/lib/account/DevUserProvider.tsx
@@ -33,8 +33,8 @@ export function DevUserAccountProvider({
     };
 
     if (instanceContext !== undefined && keycloakEnabled === null) {
-      // Dev-user should only be enabled if using "developer" instance name.
-      if (instanceContext.instanceName === "developer") {
+      // Dev-user should only be enabled if using "developer" instance mode.
+      if (instanceContext.instanceMode === "developer") {
         getDevUserConfig();
       } else {
         // Use keycloak in this case.

--- a/packages/common-ui/lib/account/DevUserProvider.tsx
+++ b/packages/common-ui/lib/account/DevUserProvider.tsx
@@ -4,12 +4,15 @@ import { AccountProvider } from "./AccountProvider";
 import { noop } from "lodash";
 import { DINA_ADMIN } from "common-ui/types/DinaRoles";
 import { LoadingSpinner } from "../loading-spinner/LoadingSpinner";
+import { useInstanceContext } from "../instance/useInstanceContext";
 
 export function DevUserAccountProvider({
   children
 }: {
   children: ReactNode;
 }): JSX.Element {
+  const instanceContext = useInstanceContext();
+
   const [devModeEnabled, setDevModeEnabled] = useState<boolean | null>(null);
   const [keycloakEnabled, setKeycloakEnabled] = useState<boolean | null>(null);
   const [groupRole, setGroupRole] = useState<string | null>(null);
@@ -28,8 +31,18 @@ export function DevUserAccountProvider({
         setKeycloakEnabled(true);
       }
     };
-    getDevUserConfig();
-  }, []);
+
+    if (instanceContext !== undefined && keycloakEnabled === null) {
+      // Dev-user should only be enabled if using "developer" instance name.
+      if (instanceContext.instanceName === "developer") {
+        getDevUserConfig();
+      } else {
+        // Use keycloak in this case.
+        setDevModeEnabled(false);
+        setKeycloakEnabled(true);
+      }
+    }
+  }, [instanceContext]);
 
   // Check if in dev environment first.
   if (process.env.NODE_ENV !== "development" || devModeEnabled === false) {

--- a/packages/dina-ui/pages/_app.tsx
+++ b/packages/dina-ui/pages/_app.tsx
@@ -46,11 +46,11 @@ export default function DinaUiApp({ Component, pageProps }: AppProps) {
 
   return (
     <ApiClientImplProvider>
-      <DevUserAccountProvider>
-        <KeycloakAccountProvider>
-          <AuthenticatedApiClientProvider>
-            <DinaIntlProvider>
-              <DefaultInstanceContextProvider>
+      <DefaultInstanceContextProvider>
+        <DevUserAccountProvider>
+          <KeycloakAccountProvider>
+            <AuthenticatedApiClientProvider>
+              <DinaIntlProvider>
                 <FileUploadProviderImpl>
                   <ErrorBoundaryPage>
                     <DndProvider backend={HTML5Backend}>
@@ -62,11 +62,11 @@ export default function DinaUiApp({ Component, pageProps }: AppProps) {
                     </DndProvider>
                   </ErrorBoundaryPage>
                 </FileUploadProviderImpl>
-              </DefaultInstanceContextProvider>
-            </DinaIntlProvider>
-          </AuthenticatedApiClientProvider>
-        </KeycloakAccountProvider>
-      </DevUserAccountProvider>
+              </DinaIntlProvider>
+            </AuthenticatedApiClientProvider>
+          </KeycloakAccountProvider>
+        </DevUserAccountProvider>
+      </DefaultInstanceContextProvider>
     </ApiClientImplProvider>
   );
 }

--- a/packages/dina-ui/test-util/mock-app-context.tsx
+++ b/packages/dina-ui/test-util/mock-app-context.tsx
@@ -19,41 +19,6 @@ import { PartialDeep } from "type-fest";
 import { FileUploadProviderImpl } from "../components/object-store/file-upload/FileUploadProvider";
 import { DinaIntlProvider } from "../intl/dina-ui-intl";
 
-const INSTANCE_DATA = {
-  data: {
-    "instance-mode": "developer",
-    "supported-languages-iso": "en,fr"
-  },
-  status: 200,
-  statusText: "",
-  headers: {
-    "content-length": "99",
-    "content-type": "text/plain; charset=utf-8",
-    date: "Tue, 09 Jan 2024 17:03:48 GMT"
-  },
-  config: {
-    url: "/instance.json",
-    method: "get",
-    headers: {
-      Accept: "application/json, text/plain, */*"
-    },
-    transformRequest: [null],
-    transformResponse: [null],
-    timeout: 0,
-    xsrfCookieName: "XSRF-TOKEN",
-    xsrfHeaderName: "X-XSRF-TOKEN",
-    maxContentLength: -1
-  },
-  request: {}
-};
-const mockGet: any = jest.fn(async (path: string, _param: any) => {
-  if (path === "/instance.json") {
-    return INSTANCE_DATA;
-  } else {
-    return undefined;
-  }
-});
-
 interface MockAppContextProviderProps {
   apiContext?: PartialDeep<ApiClientI>;
   accountContext?: Partial<AccountContextI>;


### PR DESCRIPTION
- Changed order in the _app root component so instance mode is always checked first.
- DevUserProvider will now check the instance mode and only go into dev-user mode if in developer mode.
- Removed some unused logic in the mock-app-context.