### PR TITLE
Support #35223 - Sanger workflow run step needs to set the UsageType

### DIFF
--- a/packages/dina-ui/components/seqdb/seq-workflow/SangerSeqReactionStep.tsx
+++ b/packages/dina-ui/components/seqdb/seq-workflow/SangerSeqReactionStep.tsx
@@ -156,6 +156,7 @@ export function SangerSeqReactionStep({
           itemsToCreate.map((_) => ({
             resource: {
               type: "molecular-analysis-run-item",
+              usageType: "seq-reaction",
               relationships: {
                 run: {
                   data: {

--- a/packages/dina-ui/components/seqdb/seq-workflow/__mocks__/SangerRunStepMocks.ts
+++ b/packages/dina-ui/components/seqdb/seq-workflow/__mocks__/SangerRunStepMocks.ts
@@ -35,6 +35,7 @@ export const SEQ_REACTIONS_MULTIPLE: KitsuResponse<SeqReaction[], undefined> = {
       molecularAnalysisRunItem: {
         id: "d21066cc-c4e3-4263-aeba-8e6bc6badb36",
         type: "molecular-analysis-run-item",
+        usageType: "seq-reaction",
         createdBy: "dina-admin",
         createdOn: "2024-11-05T15:29:30.230786Z",
         run: {
@@ -73,6 +74,7 @@ export const SEQ_REACTIONS_MULTIPLE: KitsuResponse<SeqReaction[], undefined> = {
       molecularAnalysisRunItem: {
         id: "83d21135-51eb-4637-a202-e5b73f7a8ff9",
         type: "molecular-analysis-run-item",
+        usageType: "seq-reaction",
         createdBy: "dina-admin",
         createdOn: "2024-11-05T15:29:30.230786Z",
         run: {
@@ -111,6 +113,7 @@ export const SEQ_REACTIONS_MULTIPLE: KitsuResponse<SeqReaction[], undefined> = {
       molecularAnalysisRunItem: {
         id: "9a836ab0-f0ae-4d6a-aa48-b386ea6af2cf",
         type: "molecular-analysis-run-item",
+        usageType: "seq-reaction",
         createdBy: "dina-admin",
         createdOn: "2024-11-05T15:29:30.230786Z",
         run: {
@@ -155,6 +158,7 @@ export const SEQ_REACTIONS: KitsuResponse<SeqReaction[], undefined> = {
       molecularAnalysisRunItem: {
         id: "cd8c4d28-586a-45c0-8f27-63030aba07cf",
         type: "molecular-analysis-run-item",
+        usageType: "seq-reaction",
         createdBy: "dina-admin",
         createdOn: "2024-11-05T15:29:30.230786Z",
         run: {
@@ -193,6 +197,7 @@ export const SEQ_REACTIONS: KitsuResponse<SeqReaction[], undefined> = {
       molecularAnalysisRunItem: {
         id: "ce53527e-7794-4c37-91d8-28efff006a56",
         type: "molecular-analysis-run-item",
+        usageType: "seq-reaction",
         createdBy: "dina-admin",
         createdOn: "2024-11-05T15:29:30.230786Z",
         run: {
@@ -231,6 +236,7 @@ export const SEQ_REACTIONS: KitsuResponse<SeqReaction[], undefined> = {
       molecularAnalysisRunItem: {
         id: "16cf5f0e-24d4-4080-a476-2c97f0adc18e",
         type: "molecular-analysis-run-item",
+        usageType: "seq-reaction",
         createdBy: "dina-admin",
         createdOn: "2024-11-05T15:29:30.230786Z",
         run: {

--- a/packages/dina-ui/components/seqdb/seq-workflow/__tests__/SangerRunStep.test.tsx
+++ b/packages/dina-ui/components/seqdb/seq-workflow/__tests__/SangerRunStep.test.tsx
@@ -297,10 +297,10 @@ describe("Sanger Run Step from Sanger Workflow", () => {
                   }
                 }
               },
+              usageType: "seq-reaction",
               type: "molecular-analysis-run-item"
             },
-            type: "molecular-analysis-run-item",
-            usageType: "seq-reaction"
+            type: "molecular-analysis-run-item"
           },
           {
             resource: {
@@ -312,10 +312,10 @@ describe("Sanger Run Step from Sanger Workflow", () => {
                   }
                 }
               },
+              usageType: "seq-reaction",
               type: "molecular-analysis-run-item"
             },
-            type: "molecular-analysis-run-item",
-            usageType: "seq-reaction"
+            type: "molecular-analysis-run-item"
           },
           {
             resource: {
@@ -327,10 +327,10 @@ describe("Sanger Run Step from Sanger Workflow", () => {
                   }
                 }
               },
+              usageType: "seq-reaction",
               type: "molecular-analysis-run-item"
             },
-            type: "molecular-analysis-run-item",
-            usageType: "seq-reaction"
+            type: "molecular-analysis-run-item"
           }
         ],
         {

--- a/packages/dina-ui/components/seqdb/seq-workflow/__tests__/SangerRunStep.test.tsx
+++ b/packages/dina-ui/components/seqdb/seq-workflow/__tests__/SangerRunStep.test.tsx
@@ -299,7 +299,8 @@ describe("Sanger Run Step from Sanger Workflow", () => {
               },
               type: "molecular-analysis-run-item"
             },
-            type: "molecular-analysis-run-item"
+            type: "molecular-analysis-run-item",
+            usageType: "seq-reaction"
           },
           {
             resource: {
@@ -313,7 +314,8 @@ describe("Sanger Run Step from Sanger Workflow", () => {
               },
               type: "molecular-analysis-run-item"
             },
-            type: "molecular-analysis-run-item"
+            type: "molecular-analysis-run-item",
+            usageType: "seq-reaction"
           },
           {
             resource: {
@@ -327,7 +329,8 @@ describe("Sanger Run Step from Sanger Workflow", () => {
               },
               type: "molecular-analysis-run-item"
             },
-            type: "molecular-analysis-run-item"
+            type: "molecular-analysis-run-item",
+            usageType: "seq-reaction"
           }
         ],
         {

--- a/packages/dina-ui/components/seqdb/seq-workflow/useMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/seqdb/seq-workflow/useMolecularAnalysisRun.tsx
@@ -339,9 +339,9 @@ export function useMolecularAnalysisRun({
       const molecularAnalysisRunItemSaveArgs: SaveArgs<MolecularAnalysisRunItem>[] =
         sequencingRunItems.map(() => ({
           type: "molecular-analysis-run-item",
-          usageType: "seq-reaction",
           resource: {
             type: "molecular-analysis-run-item",
+            usageType: "seq-reaction",
             relationships: {
               run: {
                 data: {

--- a/packages/dina-ui/components/seqdb/seq-workflow/useMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/seqdb/seq-workflow/useMolecularAnalysisRun.tsx
@@ -339,6 +339,7 @@ export function useMolecularAnalysisRun({
       const molecularAnalysisRunItemSaveArgs: SaveArgs<MolecularAnalysisRunItem>[] =
         sequencingRunItems.map(() => ({
           type: "molecular-analysis-run-item",
+          usageType: "seq-reaction",
           resource: {
             type: "molecular-analysis-run-item",
             relationships: {

--- a/packages/dina-ui/types/seqdb-api/resources/MolecularAnalysisRunItem.ts
+++ b/packages/dina-ui/types/seqdb-api/resources/MolecularAnalysisRunItem.ts
@@ -6,6 +6,7 @@ export interface MolecularAnalysisRunItemAttributes {
   type: "molecular-analysis-run-item";
   createdBy?: string;
   createdOn?: string;
+  usageType: string;
 }
 
 export interface MolecularAnalysisRunItemRelationships {


### PR DESCRIPTION
- Added usageType to the typescript type.
- "seq-reaction" being set for the Sanger Workflow run step on creation.
- Updated mocks and test.
- Also applied it to the SangerSeqReactionStep when adding more when a run already exists. The usageType will be applied.