### PR TITLE
35286 Add Sequence module to managed attribute view

### DIFF
--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -1140,5 +1140,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   selectParentMaterialSample:
     "Select Parent Material Sample to link resource to",
   doOperationsFieldError:
-    'Field "{fieldErrorKey}" has the following error: {fieldErrorMessage}'
+    'Field "{fieldErrorKey}" has the following error: {fieldErrorMessage}',
+  seqdbTitle: "SeqDB",
+  genericMolecularAnalysis: "Generic Molecular Analysis"
 };

--- a/packages/dina-ui/pages/managed-attribute/list.tsx
+++ b/packages/dina-ui/pages/managed-attribute/list.tsx
@@ -22,7 +22,9 @@ import {
   COLLECTION_MODULE_TYPE_LABELS,
   CollectionModuleType,
   MANAGED_ATTRIBUTE_TYPE_OPTIONS,
-  ManagedAttribute
+  ManagedAttribute,
+  SEQDB_MODULE_TYPE_LABELS,
+  SeqDBModuleType
 } from "../../types/collection-api";
 
 export function useFilterManagedAttribute() {
@@ -77,6 +79,7 @@ export default function ManagedAttributesListPage() {
           <Tab>{formatMessage("collectionListTitle")}</Tab>
           <Tab>{formatMessage("objectStoreTitle")}</Tab>
           <Tab>{formatMessage("loanTransactionsSectionTitle")}</Tab>
+          <Tab>{formatMessage("seqdbTitle")}</Tab>
         </TabList>
         <TabPanel>
           <CollectionAttributeListView />
@@ -86,6 +89,9 @@ export default function ManagedAttributesListPage() {
         </TabPanel>
         <TabPanel>
           <TransactionAttributeListView />
+        </TabPanel>
+        <TabPanel>
+          <SeqDBAttributeListView />
         </TabPanel>
       </Tabs>
     </PageLayout>
@@ -399,6 +405,101 @@ function TransactionAttributeListView() {
             </div>
           </div>
         )}
+      />
+    </>
+  );
+}
+
+function SeqDBAttributeListView() {
+  const { filterManagedAttributes } = useFilterManagedAttribute();
+  const { formatMessage } = useDinaIntl();
+
+  const SEQDB_ATTRIBUTES_FILTER_ATTRIBUTES = ["name"];
+
+  const SEQDB_ATTRIBUTES_LIST_COLUMNS: ColumnDefinition<
+    ManagedAttribute<SeqDBModuleType>
+  >[] = [
+    {
+      cell: ({
+        row: {
+          original: { id, name }
+        }
+      }) => (
+        <Link href={`/seqdb/managed-attribute/view?id=${id}`}>
+          <a>{name}</a>
+        </Link>
+      ),
+      header: "Name",
+      accessorKey: "name"
+    },
+    {
+      cell: ({ row: { original } }) => {
+        const ma: ManagedAttribute<SeqDBModuleType> = original;
+        return (
+          <div>
+            {formatMessage(
+              SEQDB_MODULE_TYPE_LABELS[ma.managedAttributeComponent!] as any
+            )}
+          </div>
+        );
+      },
+      accessorKey: "managedAttributeComponent"
+    },
+    descriptionCell(false, false, "multilingualDescription"),
+    {
+      cell: ({
+        row: {
+          original: { acceptedValues, vocabularyElementType }
+        }
+      }) => {
+        const labelKey: keyof typeof DINAUI_MESSAGES_ENGLISH | undefined =
+          acceptedValues?.length
+            ? "field_vocabularyElementType_picklist_label"
+            : MANAGED_ATTRIBUTE_TYPE_OPTIONS.find(
+                (option) => option.value === vocabularyElementType
+              )?.labelKey;
+
+        return <div>{labelKey && <DinaMessage id={labelKey} />}</div>;
+      },
+      accessorKey: "vocabularyElementType",
+      // The API sorts alphabetically by key, not displayed intl-ized value,
+      // so the displayed order wouldn't make sense.
+      enableSorting: false
+    },
+    {
+      cell: ({
+        row: {
+          original: { acceptedValues }
+        }
+      }) => <div>{acceptedValues?.map((val) => `"${val}"`)?.join(", ")}</div>,
+      accessorKey: "acceptedValues"
+    },
+    "createdBy",
+    {
+      accessorKey: "group",
+      header: () => <FieldHeader name={"group"} />
+    }
+  ];
+
+  return (
+    <>
+      <h3 className="mb-3">
+        <DinaMessage id="seqdbTitle" />
+      </h3>
+
+      {/* Quick create menu */}
+      <CreateNewSection href="/seqdb/managed-attribute/edit" />
+
+      <ListPageLayout
+        enableInMemoryFilter={true}
+        filterFn={filterManagedAttributes}
+        filterType={ListLayoutFilterType.FREE_TEXT}
+        filterAttributes={SEQDB_ATTRIBUTES_FILTER_ATTRIBUTES}
+        id="seqdb-module-managed-attribute-list"
+        queryTableProps={{
+          columns: SEQDB_ATTRIBUTES_LIST_COLUMNS,
+          path: "seqdb-api/managed-attribute"
+        }}
       />
     </>
   );

--- a/packages/dina-ui/pages/seqdb/managed-attribute/edit.tsx
+++ b/packages/dina-ui/pages/seqdb/managed-attribute/edit.tsx
@@ -1,0 +1,85 @@
+import { SelectField, useQuery, withResponse } from "common-ui";
+import { WithRouterProps } from "next/dist/client/with-router";
+import Link from "next/link";
+import { withRouter } from "next/router";
+import {
+  ManagedAttributeForm,
+  ManagedAttributeFormProps
+} from "../../../components";
+import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
+import {
+  ManagedAttribute,
+  SEQDB_MODULE_TYPE_LABELS,
+  SEQDB_MODULE_TYPES,
+  SeqDBModuleType
+} from "../../../types/collection-api";
+import PageLayout from "packages/dina-ui/components/page/PageLayout";
+
+export function ManagedAttributesEditPage({ router }: WithRouterProps) {
+  const { id } = router.query;
+  const { formatMessage } = useDinaIntl();
+  const title = id ? "editManagedAttributeTitle" : "addManagedAttributeTitle";
+
+  const query = useQuery<ManagedAttribute>(
+    {
+      path: `seqdb-api/managed-attribute/${id}`
+    },
+    { disabled: id === undefined }
+  );
+
+  const backButton =
+    id === undefined ? (
+      <Link href="/managed-attribute/list?step=3">
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToList" />
+        </a>
+      </Link>
+    ) : (
+      <Link href={`/seqdb/managed-attribute/view?id=${id}`}>
+        <a className="back-button my-auto me-auto">
+          <DinaMessage id="backToReadOnlyPage" />
+        </a>
+      </Link>
+    );
+
+  const ATTRIBUTE_COMPONENT_OPTIONS: {
+    label: string;
+    value: SeqDBModuleType;
+  }[] = SEQDB_MODULE_TYPES.map((dataType) => ({
+    label: formatMessage(SEQDB_MODULE_TYPE_LABELS[dataType] as any),
+    value: dataType
+  }));
+
+  const formProps: ManagedAttributeFormProps = {
+    router,
+    postSaveRedirect: "/seqdb/managed-attribute/view",
+    apiBaseUrl: "/seqdb-api",
+    backButton,
+    componentField: (
+      <SelectField
+        className="col-md-6"
+        name="managedAttributeComponent"
+        options={ATTRIBUTE_COMPONENT_OPTIONS}
+      />
+    )
+  };
+
+  return (
+    <PageLayout titleId={formatMessage(title)}>
+      {id ? (
+        <div>
+          {withResponse(query, ({ data }) => (
+            <ManagedAttributeForm
+              {...formProps}
+              fetchedManagedAttribute={data}
+            />
+          ))}
+        </div>
+      ) : (
+        <ManagedAttributeForm {...formProps} />
+      )}
+    </PageLayout>
+  );
+}
+
+export default withRouter(ManagedAttributesEditPage);

--- a/packages/dina-ui/pages/seqdb/managed-attribute/view.tsx
+++ b/packages/dina-ui/pages/seqdb/managed-attribute/view.tsx
@@ -1,0 +1,63 @@
+import { DinaForm, SelectField } from "common-ui";
+import { fromPairs } from "lodash";
+import {
+  ManagedAttributeFormLayout,
+  ViewPageLayout
+} from "../../../components";
+import {
+  ManagedAttribute,
+  SEQDB_MODULE_TYPE_LABELS,
+  SEQDB_MODULE_TYPES,
+  SeqDBModuleType
+} from "../../../types/collection-api";
+import { useDinaIntl } from "../../../intl/dina-ui-intl";
+
+export default function ManagedAttributesViewPage() {
+  const { formatMessage } = useDinaIntl();
+  const ATTRIBUTE_COMPONENT_OPTIONS: {
+    label: string;
+    value: SeqDBModuleType;
+  }[] = SEQDB_MODULE_TYPES.map((dataType) => ({
+    label: formatMessage(SEQDB_MODULE_TYPE_LABELS[dataType] as any),
+    value: dataType
+  }));
+  const componentField = (
+    <SelectField
+      className="col-md-6"
+      name="managedAttributeComponent"
+      options={ATTRIBUTE_COMPONENT_OPTIONS}
+    />
+  );
+  return (
+    <ViewPageLayout<ManagedAttribute>
+      form={(props) => (
+        <DinaForm<ManagedAttribute> {...props}>
+          <ManagedAttributeFormLayout componentField={componentField} />
+        </DinaForm>
+      )}
+      query={(id) => ({ path: `seqdb-api/managed-attribute/${id}` })}
+      alterInitialValues={(data) =>
+        data
+          ? {
+              ...data,
+              // Convert multilingualDescription to editable Dictionary format:
+              multilingualDescription: fromPairs<string | undefined>(
+                data.multilingualDescription?.descriptions?.map(
+                  ({ desc, lang }) => [lang ?? "", desc ?? ""]
+                )
+              ),
+              vocabularyElementType:
+                (data && data?.acceptedValues?.length) || 0 > 0
+                  ? "PICKLIST"
+                  : data.vocabularyElementType
+            }
+          : { type: "managed-attribute" }
+      }
+      entityLink="/seqdb/managed-attribute"
+      specialListUrl="/managed-attribute/list?step=3"
+      type="managed-attribute"
+      apiBaseUrl="/seqdb-api"
+      showDeleteButton={false}
+    />
+  );
+}

--- a/packages/dina-ui/types/collection-api/resources/ManagedAttribute.ts
+++ b/packages/dina-ui/types/collection-api/resources/ManagedAttribute.ts
@@ -32,7 +32,7 @@ export const COLLECTION_MODULE_TYPES = [
   "ORGANISM",
   "PREPARATION"
 ] as const;
-export type CollectionModuleType = typeof COLLECTION_MODULE_TYPES[number];
+export type CollectionModuleType = (typeof COLLECTION_MODULE_TYPES)[number];
 export const COLLECTION_MODULE_TYPE_LABELS: Record<
   CollectionModuleType,
   string
@@ -43,6 +43,12 @@ export const COLLECTION_MODULE_TYPE_LABELS: Record<
   MATERIAL_SAMPLE: "materialSample",
   ORGANISM: "organism",
   PREPARATION: "preparation"
+};
+
+export const SEQDB_MODULE_TYPES = ["GENERIC_MOLECULAR_ANALYSIS"] as const;
+export type SeqDBModuleType = (typeof SEQDB_MODULE_TYPES)[number];
+export const SEQDB_MODULE_TYPE_LABELS: Record<SeqDBModuleType, string> = {
+  GENERIC_MOLECULAR_ANALYSIS: "genericMolecularAnalysis"
 };
 
 export const MANAGED_ATTRIBUTE_TYPE_OPTIONS: {


### PR DESCRIPTION
- Added Seqdb module to Managed Attributes
- Can create seqdb managed attribute with component type, save, and load
- Cannot delete yet as API is not ready