### PR TITLE
Support #35439 - Improve molecular analysis run page

### DIFF
--- a/packages/dina-ui/components/molecular-analysis/useMetagenomicsWorkflowMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/molecular-analysis/useMetagenomicsWorkflowMolecularAnalysisRun.tsx
@@ -1,6 +1,6 @@
 import { PcrBatchItem, SeqReaction } from "../../types/seqdb-api";
 import { MolecularAnalysisRunItem } from "../../types/seqdb-api/resources/molecular-analysis/MolecularAnalysisRunItem";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   BulkGetOptions,
   FieldHeader,
@@ -237,12 +237,15 @@ export function useMetagenomicsWorkflowMolecularAnalysisRun({
   // Map of MolecularAnalysisRunItem {id:name}
   const [molecularAnalysisRunItemNames, setMolecularAnalysisRunItemNames] =
     useState<Record<string, string>>({});
-  const columns = getMolecularAnalysisRunColumns(
-    compareByStringAndNumber,
-    "metagenomics-batch-item",
-    setMolecularAnalysisRunItemNames,
-    !editMode
-  );
+
+  const columns = useMemo(() => {
+    return getMolecularAnalysisRunColumns(
+      compareByStringAndNumber,
+      "metagenomics-batch-item",
+      setMolecularAnalysisRunItemNames,
+      !editMode
+    );
+  }, [editMode]);
 
   // Used to display if the network calls are still in progress.
   const [loading, setLoading] = useState<boolean>(true);

--- a/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
@@ -4,6 +4,7 @@ import {
   Dispatch,
   SetStateAction,
   useEffect,
+  useMemo,
   useState
 } from "react";
 import {
@@ -261,12 +262,14 @@ export function useMolecularAnalysisRun({
   const [molecularAnalysisRunItemNames, setMolecularAnalysisRunItemNames] =
     useState<Record<string, string>>({});
 
-  const columns = getMolecularAnalysisRunColumns(
-    compareByStringAndNumber,
-    "seq-reaction",
-    setMolecularAnalysisRunItemNames,
-    !editMode
-  );
+  const columns = useMemo(() => {
+    return getMolecularAnalysisRunColumns(
+      compareByStringAndNumber,
+      "seq-reaction",
+      setMolecularAnalysisRunItemNames,
+      !editMode
+    );
+  }, [editMode]);
 
   // Used to display if the network calls are still in progress.
   const [loading, setLoading] = useState<boolean>(true);

--- a/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
@@ -861,53 +861,6 @@ export function getMolecularAnalysisRunColumns(
   // Table columns to display for the sequencing run.
   const SEQ_REACTION_COLUMNS: ColumnDef<SequencingRunItem>[] = [
     {
-      id: "wellCoordinates",
-      cell: ({ row }) => {
-        return (
-          <>
-            {!row.original?.storageUnitUsage ||
-            row.original?.storageUnitUsage?.wellRow === null ||
-            row.original?.storageUnitUsage?.wellColumn === null
-              ? ""
-              : `${row.original.storageUnitUsage?.wellRow}${row.original.storageUnitUsage?.wellColumn}`}
-          </>
-        );
-      },
-      header: () => <FieldHeader name={"wellCoordinates"} />,
-      accessorKey: "wellCoordinates",
-      sortingFn: (a: any, b: any): number => {
-        const aString =
-          !a.original?.storageUnitUsage ||
-          a.original?.storageUnitUsage?.wellRow === null ||
-          a.original?.storageUnitUsage?.wellColumn === null
-            ? ""
-            : `${a.original.storageUnitUsage?.wellRow}${a.original.storageUnitUsage?.wellColumn}`;
-        const bString =
-          !b.original?.storageUnitUsage ||
-          b.original?.storageUnitUsage?.wellRow === null ||
-          b.original?.storageUnitUsage?.wellColumn === null
-            ? ""
-            : `${b.original.storageUnitUsage?.wellRow}${b.original.storageUnitUsage?.wellColumn}`;
-        return compareByStringAndNumber(aString, bString);
-      }
-    },
-    {
-      id: "tubeNumber",
-      cell: ({ row: { original } }) =>
-        original?.storageUnitUsage?.cellNumber === undefined ? (
-          <></>
-        ) : (
-          <>{original.storageUnitUsage?.cellNumber}</>
-        ),
-      header: () => <FieldHeader name={"tubeNumber"} />,
-      accessorKey: "tubeNumber",
-      sortingFn: (a: any, b: any): number =>
-        compareByStringAndNumber(
-          a?.original?.storageUnitUsage?.cellNumber?.toString(),
-          b?.original?.storageUnitUsage?.cellNumber?.toString()
-        )
-    },
-    {
       id: "materialSampleName",
       cell: ({ row: { original } }) => {
         const materialSampleName =
@@ -972,58 +925,58 @@ export function getMolecularAnalysisRunColumns(
           b?.original?.materialSampleSummary?.materialSampleName
         ),
       enableSorting: true
+    },
+    {
+      id: "wellCoordinates",
+      cell: ({ row }) => {
+        return (
+          <>
+            {!row.original?.storageUnitUsage ||
+            row.original?.storageUnitUsage?.wellRow === null ||
+            row.original?.storageUnitUsage?.wellColumn === null
+              ? ""
+              : `${row.original.storageUnitUsage?.wellRow}${row.original.storageUnitUsage?.wellColumn}`}
+          </>
+        );
+      },
+      header: () => <FieldHeader name={"wellCoordinates"} />,
+      accessorKey: "wellCoordinates",
+      sortingFn: (a: any, b: any): number => {
+        const aString =
+          !a.original?.storageUnitUsage ||
+          a.original?.storageUnitUsage?.wellRow === null ||
+          a.original?.storageUnitUsage?.wellColumn === null
+            ? ""
+            : `${a.original.storageUnitUsage?.wellRow}${a.original.storageUnitUsage?.wellColumn}`;
+        const bString =
+          !b.original?.storageUnitUsage ||
+          b.original?.storageUnitUsage?.wellRow === null ||
+          b.original?.storageUnitUsage?.wellColumn === null
+            ? ""
+            : `${b.original.storageUnitUsage?.wellRow}${b.original.storageUnitUsage?.wellColumn}`;
+        return compareByStringAndNumber(aString, bString);
+      }
+    },
+    {
+      id: "tubeNumber",
+      cell: ({ row: { original } }) =>
+        original?.storageUnitUsage?.cellNumber === undefined ? (
+          <></>
+        ) : (
+          <>{original.storageUnitUsage?.cellNumber}</>
+        ),
+      header: () => <FieldHeader name={"tubeNumber"} />,
+      accessorKey: "tubeNumber",
+      sortingFn: (a: any, b: any): number =>
+        compareByStringAndNumber(
+          a?.original?.storageUnitUsage?.cellNumber?.toString(),
+          b?.original?.storageUnitUsage?.cellNumber?.toString()
+        )
     }
   ];
 
   const GENERIC_MOLECULAR_ANALYSIS_COLUMNS: ColumnDef<SequencingRunItem>[] = [
     {
-      id: "wellCoordinates",
-      cell: ({ row }) => {
-        return (
-          <>
-            {!row.original?.storageUnitUsage ||
-            row.original?.storageUnitUsage?.wellRow === null ||
-            row.original?.storageUnitUsage?.wellColumn === null
-              ? ""
-              : `${row.original.storageUnitUsage?.wellRow}${row.original.storageUnitUsage?.wellColumn}`}
-          </>
-        );
-      },
-      header: () => <FieldHeader name={"wellCoordinates"} />,
-      accessorKey: "wellCoordinates",
-      sortingFn: (a: any, b: any): number => {
-        const aString =
-          !a.original?.storageUnitUsage ||
-          a.original?.storageUnitUsage?.wellRow === null ||
-          a.original?.storageUnitUsage?.wellColumn === null
-            ? ""
-            : `${a.original.storageUnitUsage?.wellRow}${a.original.storageUnitUsage?.wellColumn}`;
-        const bString =
-          !b.original?.storageUnitUsage ||
-          b.original?.storageUnitUsage?.wellRow === null ||
-          b.original?.storageUnitUsage?.wellColumn === null
-            ? ""
-            : `${b.original.storageUnitUsage?.wellRow}${b.original.storageUnitUsage?.wellColumn}`;
-        return compareByStringAndNumber(aString, bString);
-      }
-    },
-    {
-      id: "tubeNumber",
-      cell: ({ row: { original } }) =>
-        original?.storageUnitUsage?.cellNumber === undefined ? (
-          <></>
-        ) : (
-          <>{original.storageUnitUsage?.cellNumber}</>
-        ),
-      header: () => <FieldHeader name={"tubeNumber"} />,
-      accessorKey: "tubeNumber",
-      sortingFn: (a: any, b: any): number =>
-        compareByStringAndNumber(
-          a?.original?.storageUnitUsage?.cellNumber?.toString(),
-          b?.original?.storageUnitUsage?.cellNumber?.toString()
-        )
-    },
-    {
       id: "materialSampleName",
       cell: ({ row: { original } }) => {
         const materialSampleName =
@@ -1085,58 +1038,58 @@ export function getMolecularAnalysisRunColumns(
           b?.original?.materialSampleSummary?.materialSampleName
         ),
       enableSorting: true
+    },
+    {
+      id: "wellCoordinates",
+      cell: ({ row }) => {
+        return (
+          <>
+            {!row.original?.storageUnitUsage ||
+            row.original?.storageUnitUsage?.wellRow === null ||
+            row.original?.storageUnitUsage?.wellColumn === null
+              ? ""
+              : `${row.original.storageUnitUsage?.wellRow}${row.original.storageUnitUsage?.wellColumn}`}
+          </>
+        );
+      },
+      header: () => <FieldHeader name={"wellCoordinates"} />,
+      accessorKey: "wellCoordinates",
+      sortingFn: (a: any, b: any): number => {
+        const aString =
+          !a.original?.storageUnitUsage ||
+          a.original?.storageUnitUsage?.wellRow === null ||
+          a.original?.storageUnitUsage?.wellColumn === null
+            ? ""
+            : `${a.original.storageUnitUsage?.wellRow}${a.original.storageUnitUsage?.wellColumn}`;
+        const bString =
+          !b.original?.storageUnitUsage ||
+          b.original?.storageUnitUsage?.wellRow === null ||
+          b.original?.storageUnitUsage?.wellColumn === null
+            ? ""
+            : `${b.original.storageUnitUsage?.wellRow}${b.original.storageUnitUsage?.wellColumn}`;
+        return compareByStringAndNumber(aString, bString);
+      }
+    },
+    {
+      id: "tubeNumber",
+      cell: ({ row: { original } }) =>
+        original?.storageUnitUsage?.cellNumber === undefined ? (
+          <></>
+        ) : (
+          <>{original.storageUnitUsage?.cellNumber}</>
+        ),
+      header: () => <FieldHeader name={"tubeNumber"} />,
+      accessorKey: "tubeNumber",
+      sortingFn: (a: any, b: any): number =>
+        compareByStringAndNumber(
+          a?.original?.storageUnitUsage?.cellNumber?.toString(),
+          b?.original?.storageUnitUsage?.cellNumber?.toString()
+        )
     }
   ];
 
   const METAGENOMICS_BATCH_ITEM_COLUMNS: ColumnDef<SequencingRunItem>[] = [
     {
-      id: "wellCoordinates",
-      cell: ({ row }) => {
-        return (
-          <>
-            {!row.original?.storageUnitUsage ||
-            row.original?.storageUnitUsage?.wellRow === null ||
-            row.original?.storageUnitUsage?.wellColumn === null
-              ? ""
-              : `${row.original.storageUnitUsage?.wellRow}${row.original.storageUnitUsage?.wellColumn}`}
-          </>
-        );
-      },
-      header: () => <FieldHeader name={"wellCoordinates"} />,
-      accessorKey: "wellCoordinates",
-      sortingFn: (a: any, b: any): number => {
-        const aString =
-          !a.original?.storageUnitUsage ||
-          a.original?.storageUnitUsage?.wellRow === null ||
-          a.original?.storageUnitUsage?.wellColumn === null
-            ? ""
-            : `${a.original.storageUnitUsage?.wellRow}${a.original.storageUnitUsage?.wellColumn}`;
-        const bString =
-          !b.original?.storageUnitUsage ||
-          b.original?.storageUnitUsage?.wellRow === null ||
-          b.original?.storageUnitUsage?.wellColumn === null
-            ? ""
-            : `${b.original.storageUnitUsage?.wellRow}${b.original.storageUnitUsage?.wellColumn}`;
-        return compareByStringAndNumber(aString, bString);
-      }
-    },
-    {
-      id: "tubeNumber",
-      cell: ({ row: { original } }) =>
-        original?.storageUnitUsage?.cellNumber === undefined ? (
-          <></>
-        ) : (
-          <>{original.storageUnitUsage?.cellNumber}</>
-        ),
-      header: () => <FieldHeader name={"tubeNumber"} />,
-      accessorKey: "tubeNumber",
-      sortingFn: (a: any, b: any): number =>
-        compareByStringAndNumber(
-          a?.original?.storageUnitUsage?.cellNumber?.toString(),
-          b?.original?.storageUnitUsage?.cellNumber?.toString()
-        )
-    },
-    {
       id: "materialSampleName",
       cell: ({ row: { original } }) => {
         const materialSampleName =
@@ -1198,6 +1151,53 @@ export function getMolecularAnalysisRunColumns(
           b?.original?.materialSampleSummary?.materialSampleName
         ),
       enableSorting: true
+    },
+    {
+      id: "wellCoordinates",
+      cell: ({ row }) => {
+        return (
+          <>
+            {!row.original?.storageUnitUsage ||
+            row.original?.storageUnitUsage?.wellRow === null ||
+            row.original?.storageUnitUsage?.wellColumn === null
+              ? ""
+              : `${row.original.storageUnitUsage?.wellRow}${row.original.storageUnitUsage?.wellColumn}`}
+          </>
+        );
+      },
+      header: () => <FieldHeader name={"wellCoordinates"} />,
+      accessorKey: "wellCoordinates",
+      sortingFn: (a: any, b: any): number => {
+        const aString =
+          !a.original?.storageUnitUsage ||
+          a.original?.storageUnitUsage?.wellRow === null ||
+          a.original?.storageUnitUsage?.wellColumn === null
+            ? ""
+            : `${a.original.storageUnitUsage?.wellRow}${a.original.storageUnitUsage?.wellColumn}`;
+        const bString =
+          !b.original?.storageUnitUsage ||
+          b.original?.storageUnitUsage?.wellRow === null ||
+          b.original?.storageUnitUsage?.wellColumn === null
+            ? ""
+            : `${b.original.storageUnitUsage?.wellRow}${b.original.storageUnitUsage?.wellColumn}`;
+        return compareByStringAndNumber(aString, bString);
+      }
+    },
+    {
+      id: "tubeNumber",
+      cell: ({ row: { original } }) =>
+        original?.storageUnitUsage?.cellNumber === undefined ? (
+          <></>
+        ) : (
+          <>{original.storageUnitUsage?.cellNumber}</>
+        ),
+      header: () => <FieldHeader name={"tubeNumber"} />,
+      accessorKey: "tubeNumber",
+      sortingFn: (a: any, b: any): number =>
+        compareByStringAndNumber(
+          a?.original?.storageUnitUsage?.cellNumber?.toString(),
+          b?.original?.storageUnitUsage?.cellNumber?.toString()
+        )
     }
   ];
   const MOLECULAR_ANALYSIS_RUN_COLUMNS_MAP = {

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/MolecularAnalysisRunStep.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/MolecularAnalysisRunStep.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import {
   SequencingRunItem,
   useGenericMolecularAnalysisRun
@@ -10,18 +9,16 @@ import {
   ReactTable,
   useStringComparator
 } from "common-ui";
-import { Alert, Button } from "react-bootstrap";
+import { Alert } from "react-bootstrap";
 import { ColumnDef } from "@tanstack/react-table";
 import { DinaMessage } from "../../../intl/dina-ui-intl";
 import { GenericMolecularAnalysis } from "packages/dina-ui/types/seqdb-api/resources/GenericMolecularAnalysis";
 import { AttachmentsEditor } from "../../object-store/attachment-list/AttachmentsField";
 import { AttachmentReadOnlySection } from "../../object-store/attachment-list/AttachmentReadOnlySection";
 import { getMolecularAnalysisRunColumns } from "../../molecular-analysis/useMolecularAnalysisRun";
-import { FaTrash } from "react-icons/fa";
-import { VocabularyOption } from "../../collection/VocabularySelectField";
-import Select from "react-select";
 import { useIntl } from "react-intl";
 import { QualityControlSection } from "./QualityControlSection";
+import { useMemo } from "react";
 
 export interface MolecularAnalysisRunStepProps {
   molecularAnalysisId: string;
@@ -69,13 +66,16 @@ export function MolecularAnalysisRunStep({
   });
 
   // Table columns to display for the sequencing run.
-  const COLUMNS: ColumnDef<SequencingRunItem>[] =
-    getMolecularAnalysisRunColumns(
-      compareByStringAndNumber,
-      "generic-molecular-analysis-item",
-      setMolecularAnalysisRunItemNames,
-      !editMode
-    );
+  const COLUMNS: ColumnDef<SequencingRunItem>[] = useMemo(
+    () =>
+      getMolecularAnalysisRunColumns(
+        compareByStringAndNumber,
+        "generic-molecular-analysis-item",
+        setMolecularAnalysisRunItemNames,
+        !editMode
+      ),
+    [editMode]
+  );
 
   // Display loading if network requests from hook are still loading in...
   if (loading) {

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisRunStep.test.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisRunStep.test.tsx
@@ -1,6 +1,10 @@
 import { mountWithAppContext2 } from "../../../../../dina-ui/test-util/mock-app-context";
 import { noop } from "lodash";
-import { waitFor, waitForElementToBeRemoved } from "@testing-library/react";
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved
+} from "@testing-library/react";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { useState, useEffect } from "react";
@@ -773,6 +777,34 @@ describe("Molecular Analysis Workflow - Step 4 - Molecular Analysis Run Step", (
 
     // Only 3 should exist, since 4 were created and one was blank and automatically removed.
     expect(wrapper.getAllByRole("combobox").length).toBe(3);
+  });
+
+  it("Changing quality controls and run item names together", async () => {
+    const wrapper = mountWithAppContext2(
+      <TestComponent
+        molecularAnalysisId={TEST_MOLECULAR_ANALYSIS_WITH_RUN_ID}
+      />,
+      testCtx
+    );
+
+    // Wait for loading to be finished.
+    await waitForElementToBeRemoved(wrapper.getByText(/loading\.\.\./i));
+
+    // Should not be in edit mode automatically since a run exists already.
+    expect(wrapper.queryByText(/edit mode: false/i)).toBeInTheDocument();
+
+    // Switch into edit mode:
+    userEvent.click(wrapper.getByRole("button", { name: "Edit" }));
+    expect(wrapper.queryByText(/edit mode: true/i)).toBeInTheDocument();
+
+    // Edit the run item name
+    userEvent.type(
+      wrapper.getByDisplayValue(/provided run item name/i),
+      "-update"
+    );
+
+    // Edit the Quality Control
+    userEvent.type(wrapper.getByDisplayValue(/test1/i), "-update");
   });
 
   it("Automatically switch to edit mode and be able to cancel", async () => {

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisRunStep.test.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisRunStep.test.tsx
@@ -1,10 +1,6 @@
 import { mountWithAppContext2 } from "../../../../../dina-ui/test-util/mock-app-context";
 import { noop } from "lodash";
-import {
-  screen,
-  waitFor,
-  waitForElementToBeRemoved
-} from "@testing-library/react";
+import { waitFor, waitForElementToBeRemoved } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { useState, useEffect } from "react";
@@ -539,9 +535,13 @@ describe("Molecular Analysis Workflow - Step 4 - Molecular Analysis Run Step", (
     userEvent.clear(wrapper.getAllByRole("textbox")[0]);
     userEvent.type(wrapper.getAllByRole("textbox")[0], "Updated run name");
 
-    // Update the two run names.
+    // Add a new run name.
     userEvent.clear(wrapper.getAllByRole("textbox")[1]);
-    userEvent.type(wrapper.getAllByRole("textbox")[1], "Run item name 1");
+    userEvent.type(
+      wrapper.getAllByRole("textbox")[1],
+      "Update run item name 1"
+    );
+    userEvent.type(wrapper.getAllByRole("textbox")[2], "Add a new one");
 
     // Edit Quality Control 1
     userEvent.clear(wrapper.getAllByRole("textbox")[3]);
@@ -611,7 +611,15 @@ describe("Molecular Analysis Workflow - Step 4 - Molecular Analysis Run Step", (
           {
             resource: {
               id: "f65ed036-eb92-40d9-af03-d027646e8948",
-              name: "Run item name 1",
+              name: "Update run item name 1",
+              type: "molecular-analysis-run-item"
+            },
+            type: "molecular-analysis-run-item"
+          },
+          {
+            resource: {
+              id: "021e1676-2eff-45e5-aed3-1c1b6cfece0a",
+              name: "Add a new one",
               type: "molecular-analysis-run-item"
             },
             type: "molecular-analysis-run-item"
@@ -777,34 +785,6 @@ describe("Molecular Analysis Workflow - Step 4 - Molecular Analysis Run Step", (
 
     // Only 3 should exist, since 4 were created and one was blank and automatically removed.
     expect(wrapper.getAllByRole("combobox").length).toBe(3);
-  });
-
-  it("Changing quality controls and run item names together", async () => {
-    const wrapper = mountWithAppContext2(
-      <TestComponent
-        molecularAnalysisId={TEST_MOLECULAR_ANALYSIS_WITH_RUN_ID}
-      />,
-      testCtx
-    );
-
-    // Wait for loading to be finished.
-    await waitForElementToBeRemoved(wrapper.getByText(/loading\.\.\./i));
-
-    // Should not be in edit mode automatically since a run exists already.
-    expect(wrapper.queryByText(/edit mode: false/i)).toBeInTheDocument();
-
-    // Switch into edit mode:
-    userEvent.click(wrapper.getByRole("button", { name: "Edit" }));
-    expect(wrapper.queryByText(/edit mode: true/i)).toBeInTheDocument();
-
-    // Edit the run item name
-    userEvent.type(
-      wrapper.getByDisplayValue(/provided run item name/i),
-      "-update"
-    );
-
-    // Edit the Quality Control
-    userEvent.type(wrapper.getByDisplayValue(/test1/i), "-update");
   });
 
   it("Automatically switch to edit mode and be able to cancel", async () => {


### PR DESCRIPTION
- Changed the order of the columns for all workflow run pages (Primary ID and Run item naming first)
- Added a useMemo to the columns so it's only generated on editMode change not on each state change.
- Working on adding test coverage to catch editing both at the same time.