### PR TITLE
35417 Collecting event display name workbook relationship mapping issue

### DIFF
--- a/packages/dina-ui/components/workbook/column-mapping/WorkbookColumnMapping.tsx
+++ b/packages/dina-ui/components/workbook/column-mapping/WorkbookColumnMapping.tsx
@@ -154,7 +154,7 @@ export function WorkbookColumnMapping({
         const mappedValues = Object.keys(relationshipMapping[columnName] || {});
 
         for (const value of values) {
-          if (mappedValues.indexOf(value.replace(".", "_")) === -1) {
+          if (mappedValues.indexOf(value.replaceAll(".", "_")) === -1) {
             unmappedColumnNames.push(
               workbookColumnMap[columnName].originalColumnName
             );

--- a/packages/dina-ui/components/workbook/column-mapping/useColumnMapping.tsx
+++ b/packages/dina-ui/components/workbook/column-mapping/useColumnMapping.tsx
@@ -257,7 +257,7 @@ export function useColumnMapping() {
     newWorkbookColumnMap: WorkbookColumnMap
   ) {
     const originalColumnHeader = columnHeader;
-    columnHeader = columnHeader.replace(".", "_");
+    columnHeader = columnHeader.replaceAll(".", "_");
 
     const fieldPath = "managedAttributes";
     const targetManagedAttr = managedAttributes.find(
@@ -300,7 +300,7 @@ export function useColumnMapping() {
     newWorkbookColumnMap: WorkbookColumnMap
   ) {
     const originalColumnHeader = columnHeader;
-    columnHeader = columnHeader.replace(".", "_");
+    columnHeader = columnHeader.replaceAll(".", "_");
 
     const fieldPath = "organism.determination.scientificNameDetails";
     const targetTaxonomicRank = taxonomicRanks.find(
@@ -376,7 +376,7 @@ export function useColumnMapping() {
   ) {
     const columnHeaderValue = (
       columnHeader.originalColumn ?? columnHeader.columnHeader
-    ).replace(".", "_");
+    ).replaceAll(".", "_");
     const originalColumnHeader =
       columnHeader.originalColumn ?? columnHeader.columnHeader;
 
@@ -672,11 +672,11 @@ export function useColumnMapping() {
         // If relationship is found, set it. If not, reset it so it's empty.
         if (found) {
           if (PERSON_SELECT_FIELDS.has(fieldPath)) {
-            theRelationshipMapping[columnHeader][value.replace(".", "_")] = [
+            theRelationshipMapping[columnHeader][value.replaceAll(".", "_")] = [
               pick(found, ["id", "type"])
             ];
           } else {
-            theRelationshipMapping[columnHeader][value.replace(".", "_")] =
+            theRelationshipMapping[columnHeader][value.replaceAll(".", "_")] =
               pick(found, ["id", "type"]);
           }
         } else {
@@ -700,7 +700,7 @@ export function useColumnMapping() {
                 );
               }
             }
-            theRelationshipMapping[columnHeader][value.replace(".", "_")] =
+            theRelationshipMapping[columnHeader][value.replaceAll(".", "_")] =
               relationshipMappingDefaultValues;
           }
         }

--- a/packages/dina-ui/components/workbook/utils/useWorkbookConverter.tsx
+++ b/packages/dina-ui/components/workbook/utils/useWorkbookConverter.tsx
@@ -439,7 +439,7 @@ export function useWorkbookConverter(
               ) {
                 valueToLink =
                   columnMap[fieldPath + "." + attrNameInValue]?.[
-                    childValue.trim().replace(".", "_")
+                    childValue.trim().replaceAll(".", "_")
                   ];
                 if (valueToLink) {
                   break;
@@ -579,7 +579,7 @@ export function useWorkbookConverter(
                 ) {
                   valueToLink =
                     columnMap[fieldPath + "." + attrNameInValue]?.[
-                      childValue.trim().replace(".", "_")
+                      childValue.trim().replaceAll(".", "_")
                     ];
 
                   if (valueToLink) {

--- a/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
+++ b/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
@@ -850,7 +850,7 @@ export function calculateColumnUniqueValuesFromSpreadsheetData(
           counts[value] = 1 + (counts[value] || 0);
         }
       }
-      columnUniqueValues[columnNames[colIndex].replace(".", "_")] = counts;
+      columnUniqueValues[columnNames[colIndex].replaceAll(".", "_")] = counts;
     }
     result[sheet] = columnUniqueValues;
   }


### PR DESCRIPTION
- The problem seemed to be that there was a mismatch of usages of replace() and replaceAll() in the parsing of the workbook column headers to replace "." with "_"
- As a result, for longer column names with multiple ".", only the first occurence was replace() by "_" in some parts while other parts replaceAll()
- I changed everything to use replaceAll() everywhere. This is a bit risky since it refactors other areas as well but it should still work