### PR TITLE
35481 Check why molecular analysis run is not loading

### DIFF
--- a/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
@@ -697,7 +697,7 @@ export function useMolecularAnalysisRunView({
             .filter((runItem) => runItem.usageType !== "quality-control")
             .map(
               (molecularAnalysisRunItem) =>
-                `seqdb-api/generic-molecular-analysis-item?include=storageUnitUsage,materialSample,&filter[rsql]=molecularAnalysisRunItem.uuid==${molecularAnalysisRunItem.id}`
+                `seqdb-api/generic-molecular-analysis-item?include=storageUnitUsage,materialSample,molecularAnalysisRunItem&filter[rsql]=molecularAnalysisRunItem.uuid==${molecularAnalysisRunItem.id}`
             );
           const genericMolecularAnalysisItems: PersistedResource<GenericMolecularAnalysisItem>[] =
             [];
@@ -711,6 +711,7 @@ export function useMolecularAnalysisRunView({
           }
           return genericMolecularAnalysisItems;
         }
+
         async function fetchMetagenomicsBatchItems() {
           const fetchPaths = molecularAnalysisRunItems.map(
             (molecularAnalysisRunItem) =>
@@ -726,6 +727,7 @@ export function useMolecularAnalysisRunView({
           }
           return metagenomicsBatchItems;
         }
+
         const usageType = molecularAnalysisRunItems.filter(
           (runItem) => runItem.usageType !== "quality-control"
         )?.[0]?.usageType;

--- a/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
@@ -747,7 +747,8 @@ export function useMolecularAnalysisRunView({
         );
 
         if (usageType === "seq-reaction") {
-          const seqReactions = await fetchSeqReactions();
+          let seqReactions = await fetchSeqReactions();
+          seqReactions = seqReactions.filter((item) => item !== undefined);
 
           // Chain it all together to create one object.
           let sequencingRunItemsChain = attachSeqReaction(seqReactions);
@@ -769,22 +770,30 @@ export function useMolecularAnalysisRunView({
           setSequencingRunItems(sequencingRunItemsChain);
           setLoading(false);
         } else if (usageType === "generic-molecular-analysis-item") {
-          const genericMolecularAnalysisItems =
+          let genericMolecularAnalysisItems =
             await fetchGenericMolecularAnalysisItems();
+          genericMolecularAnalysisItems = genericMolecularAnalysisItems.filter(
+            (item) => item !== undefined
+          );
+
           let sequencingRunItemsChain = attachGenericMolecularAnalysisItems(
             genericMolecularAnalysisItems
           );
+
           sequencingRunItemsChain = await attachStorageUnitUsage(
             sequencingRunItemsChain,
             bulkGet
           );
+
           sequencingRunItemsChain = await attachMaterialSampleSummary(
             sequencingRunItemsChain,
             bulkGet
           );
+
           const qualityControlRunItems = molecularAnalysisRunItems.filter(
             (runItem) => runItem.usageType === "quality-control"
           );
+
           // Get quality controls
           if (qualityControlRunItems && qualityControlRunItems?.length > 0) {
             const newQualityControls: QualityControl[] = [];
@@ -818,11 +827,15 @@ export function useMolecularAnalysisRunView({
 
             setQualityControls(newQualityControls);
           }
+
           // All finished loading.
           setSequencingRunItems(sequencingRunItemsChain);
           setLoading(false);
         } else if (usageType === "metagenomics-batch-item") {
-          const metagenomicsBatchItems = await fetchMetagenomicsBatchItems();
+          let metagenomicsBatchItems = await fetchMetagenomicsBatchItems();
+          metagenomicsBatchItems = metagenomicsBatchItems.filter(
+            (item) => item !== undefined
+          );
 
           // Chain it all together to create one object.
           let sequencingRunItemsChain = attachMetagenomicsBatchItem(

--- a/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/molecular-analysis/useMolecularAnalysisRun.tsx
@@ -726,10 +726,15 @@ export function useMolecularAnalysisRunView({
           }
           return metagenomicsBatchItems;
         }
-
         const usageType = molecularAnalysisRunItems.filter(
           (runItem) => runItem.usageType !== "quality-control"
-        )?.[0].usageType;
+        )?.[0]?.usageType;
+
+        if (!usageType) {
+          setLoading(false);
+          return;
+        }
+
         setColumns(
           getMolecularAnalysisRunColumns(
             compareByStringAndNumber,


### PR DESCRIPTION
- Identified that the view page was not loading due to molecular-analysis-run having no molecular-analysis-run-item associated
- Normally, this wouldn't be possible through the UI as there is already a check that forces users to select Material Samples as run items
- Implemented a fix that will load the page even if there's no run items