### PR TITLE
Support #35443 - Collecting Event taags should show Collecting Event …

### DIFF
--- a/packages/dina-ui/components/collection/collecting-event/CollectingEventFormLayout.tsx
+++ b/packages/dina-ui/components/collection/collecting-event/CollectingEventFormLayout.tsx
@@ -614,6 +614,7 @@ export function CollectingEventFormLayout({
               <TagsAndRestrictionsSection
                 resourcePath="collection-api/collecting-event"
                 indexName="dina_material_sample_index"
+                tagIncludedType="collecting-event"
               />
             }
           />

--- a/packages/dina-ui/components/tag-editor/TagSelectField.tsx
+++ b/packages/dina-ui/components/tag-editor/TagSelectField.tsx
@@ -25,6 +25,10 @@ export interface TagSelectFieldProps extends FieldWrapperProps {
   groupSelectorName?: string;
   /** The field name to use when finding other tags via RSQL filter. */
   tagsFieldName?: string;
+
+  /** The relationship type of the tag to include in the search. Only available with elasticsearch. */
+  tagIncludedType?: string;
+
   indexName?: string;
 }
 
@@ -75,6 +79,7 @@ export function TagSelectField({
           groupSelectorName={props.groupSelectorName}
           placeholder={placeholder}
           tagsFieldName={tagsFieldName}
+          tagIncludedType={props.tagIncludedType}
           indexName={indexName}
         />
       )}
@@ -88,6 +93,7 @@ interface TagSelectProps {
   resourcePath?: string;
   invalid?: boolean;
   tagsFieldName?: string;
+  tagIncludedType?: string;
   groupSelectorName?: string;
   placeholder?: string;
   indexName?: string;
@@ -101,6 +107,7 @@ function TagSelect({
   invalid,
   groupSelectorName = "group",
   tagsFieldName = "tags",
+  tagIncludedType,
   placeholder,
   indexName
 }: TagSelectProps) {
@@ -118,13 +125,16 @@ function TagSelect({
 
   if (indexName) {
     const suggestions = useElasticSearchDistinctTerm({
-      fieldName: `data.attributes.${tagsFieldName}`,
+      fieldName: tagIncludedType
+        ? `included.attributes.${tagsFieldName}`
+        : `data.attributes.${tagsFieldName}`,
       indexName,
       keywordMultiFieldSupport: true,
       isFieldArray: true,
       inputValue: debouncedInputValue,
       groupNames,
-      size: 10
+      size: 10,
+      relationshipType: tagIncludedType
     });
     tagOptions.current = suggestions.map((tag) => toOption(tag));
   } else {

--- a/packages/dina-ui/components/tag-editor/TagsAndRestrictionsSection.tsx
+++ b/packages/dina-ui/components/tag-editor/TagsAndRestrictionsSection.tsx
@@ -14,6 +14,7 @@ export const TAG_SECTION_FIELDS: (keyof MaterialSample)[] = [
 export interface TagsAndRestrictionsSection {
   resourcePath?: string;
   tagsFieldName?: string;
+  tagIncludedType?: string;
   groupSelectorName?: string;
   indexName?: string;
 }
@@ -22,6 +23,7 @@ export function TagsAndRestrictionsSection({
   resourcePath,
   groupSelectorName = "group",
   tagsFieldName = "tags",
+  tagIncludedType,
   indexName
 }: TagsAndRestrictionsSection) {
   const { readOnly, initialValues } = useDinaFormContext();
@@ -53,6 +55,7 @@ export function TagsAndRestrictionsSection({
           name={tagsFieldName}
           groupSelectorName={groupSelectorName}
           tagsFieldName={tagsFieldName}
+          tagIncludedType={tagIncludedType}
           removeBottomMargin={true}
           label={
             <span>

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -1168,7 +1168,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   qualityControlName: "Name:",
   qualityControlType: "Type:",
   collecting_event_tag_info:
-    "Suggestions are currently based on Material Sample tags.",
+    "Tag suggestions are currently based on collecting event tags associated with Material Samples.",
   selectFunctionToUse: "Select function to use",
   selectFieldToUseWithFunction: "Select a field to use with the function"
 };


### PR DESCRIPTION
- Changed tooltip to indicate it's only displaying collecting event tag suggestions that are associated to a material sample.
- Added props to allow the tag editor to specify the included type.