### PR TITLE
35660 Column selector should inject mandatory columns if it's missing…

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelector.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelector.tsx
@@ -112,7 +112,8 @@ export function ColumnSelector<TData extends KitsuResource>(
     setColumnSelectorLoading,
     setDisplayedColumns,
     overrideDisplayedColumns,
-    excludedRelationshipTypes
+    excludedRelationshipTypes,
+    mandatoryDisplayedColumns
   } = props;
 
   // Loading state, specifically for dynamically loaded columns.
@@ -127,6 +128,22 @@ export function ColumnSelector<TData extends KitsuResource>(
       `${uniqueName}_${VISIBLE_INDEX_LOCAL_STORAGE_KEY}`,
       []
     );
+
+  // Inject mandatory columns if they're missing from local storage
+  useEffect(() => {
+    if (mandatoryDisplayedColumns) {
+      const updatedColumns = [
+        ...new Set([
+          ...mandatoryDisplayedColumns,
+          ...localStorageDisplayedColumns
+        ])
+      ];
+
+      if (updatedColumns.length !== localStorageDisplayedColumns.length) {
+        setLocalStorageDisplayedColumns(updatedColumns);
+      }
+    }
+  }, [mandatoryDisplayedColumns]);
 
   useEffect(() => {
     let injectedMappings: (ESIndexMapping | undefined)[] = [];

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -269,11 +269,7 @@ export default function MetadataListPage() {
                   ],
                   relationshipFields: []
                 }}
-                mandatoryDisplayedColumns={[
-                  "selectColumn",
-                  "thumbnail",
-                  "viewDetails"
-                ]}
+                mandatoryDisplayedColumns={["thumbnail", "viewDetails"]}
                 nonExportableColumns={[
                   "selectColumn",
                   "thumbnail",


### PR DESCRIPTION
… from local storage

- Now injects mandatory columns into local storage array if they're missing
- Column should show up for different saved searches as well, just not saved to the backend automatically. Let me know if it should