### PR TITLE
35763 Allow quality control types in paste zone

### DIFF
--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/QualityControlSection.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/QualityControlSection.tsx
@@ -12,7 +12,7 @@ interface QualityControlSectionProps {
   editMode?: boolean;
   qualityControls: QualityControl[];
   qualityControlTypes: VocabularyOption[];
-  createNewQualityControl?: (name?: string) => void;
+  createNewQualityControl?: (name?: string, qcType?: string) => void;
   updateQualityControl?: (
     index: number,
     newQualityControl: QualityControl
@@ -34,8 +34,15 @@ export function QualityControlSection({
 
   const onDataPaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const clipboardData = event.clipboardData.getData("text/plain");
-    const names = clipboardData.trim().split("\n");
-    names.forEach((name) => createNewQualityControl?.(name));
+    const rows = clipboardData
+      .trim()
+      .split("\n")
+      .map((row) =>
+        row.split("\t").map((cell) => cell.replace(/\r/g, "").trim())
+      );
+    rows.forEach((row) => {
+      createNewQualityControl?.(row.at(0), row.at(1)?.replaceAll(" ", "_"));
+    });
   };
   return editMode || qualityControls.length > 0 ? (
     <div className="col-12 mt-3 mb-3">

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/useGenericMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/useGenericMolecularAnalysisRun.tsx
@@ -106,7 +106,7 @@ export interface UseGenericMolecularAnalysisRunReturn {
   /**
    * Generates a blank quality control for the user to enter.
    */
-  createNewQualityControl: () => void;
+  createNewQualityControl: (name?: string, qcType?: string) => void;
 
   /**
    * Based on the index, delete the quality control.
@@ -433,13 +433,13 @@ export function useGenericMolecularAnalysisRun({
   /**
    * Creates a new quality control object and adds it to the existing quality controls list.
    */
-  function createNewQualityControl(name?: string) {
+  function createNewQualityControl(name?: string, qcType?: string) {
     setQualityControls((qualityControls) => [
       ...qualityControls,
       {
         group: "",
         name: name ?? "",
-        qcType: "",
+        qcType: qcType ?? "",
         type: MolecularAnalysisRunItemUsageType.QUALITY_CONTROL
       }
     ]);


### PR DESCRIPTION
- quality control data paste zone now handles a second column for qcType
- note that order matters, the name column has to come first
- saving and loading should work as expected