### PR TITLE
35789 Allow to prefill query builder from url query parameters

### DIFF
--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -613,8 +613,8 @@ export function QueryPage<TData extends KitsuResource>({
           query.queryTree as string
         );
         if (parsedQueryTree) {
+          setQueryBuilderTree(parsedQueryTree);
           setSubmittedQueryBuilderTree(parsedQueryTree);
-          setSessionStorageQueryTree(Utils.getTree(parsedQueryTree));
         }
       }
     }

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -607,7 +607,7 @@ export function QueryPage<TData extends KitsuResource>({
           setQueryBuilderTree(emptyQueryTree());
         }
       }
-      if (router.query.queryTree) {
+      if (router?.query?.queryTree) {
         const parsedQueryTree = parseQueryTreeFromURL(
           router.query.queryTree as string
         );

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -345,7 +345,6 @@ export function QueryPage<TData extends KitsuResource>({
   const { groupNames } = useAccount();
   const isActionTriggeredQuery = useRef(false);
   const router = useRouter();
-  const { query } = router;
 
   // Search results returned by Elastic Search
   const [searchResults, setSearchResults] = useState<TData[]>([]);
@@ -608,9 +607,9 @@ export function QueryPage<TData extends KitsuResource>({
           setQueryBuilderTree(emptyQueryTree());
         }
       }
-      if (query.queryTree) {
+      if (router.query.queryTree) {
         const parsedQueryTree = parseQueryTreeFromURL(
-          query.queryTree as string
+          router.query.queryTree as string
         );
         if (parsedQueryTree) {
           setQueryBuilderTree(parsedQueryTree);
@@ -623,7 +622,7 @@ export function QueryPage<TData extends KitsuResource>({
     customViewQuery,
     customViewFields,
     customViewElasticSearchQuery,
-    query.queryTree
+    router?.query?.queryTree
   ]);
 
   // If column selector is disabled, the loading spinner should be turned off.

--- a/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
@@ -12,6 +12,7 @@ import { SavedSearch } from "../saved-searches/SavedSearch";
 import { DinaMessage } from "../../../../dina-ui/intl/dina-ui-intl";
 import { CommonMessage } from "common-ui";
 import { ValidationError } from "./query-builder-elastic-search/QueryBuilderElasticSearchValidator";
+import { SimpleQueryGroup, SimpleQueryRow } from "../types";
 
 export interface QueryBuilderContextI {
   performSubmit: () => void;
@@ -255,6 +256,34 @@ export function generateUUIDTree(uuid: string, path: string): JsonTree {
         }
       }
     }
+  };
+}
+
+export function generateJsonTreeFromSimpleQueryGroup(
+  simpleQueryGroup: SimpleQueryGroup
+): JsonTree {
+  const children: any = simpleQueryGroup.props.map(
+    (simpleQueryRow: SimpleQueryRow) => {
+      return {
+        id: Utils.uuid(),
+        type: "rule",
+        properties: {
+          field: simpleQueryRow.field,
+          operator: simpleQueryRow.operator,
+          value: [simpleQueryRow.value],
+          valueSrc: ["value"],
+          valueType: ["autoComplete"]
+        }
+      };
+    }
+  );
+  return {
+    id: Utils.uuid(),
+    type: "group",
+    properties: {
+      conjunction: simpleQueryGroup.conj
+    },
+    children1: children
   };
 }
 

--- a/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
@@ -272,7 +272,7 @@ export function generateJsonTreeFromSimpleQueryGroup(
           operator: simpleQueryRow.operator,
           value: [simpleQueryRow.value],
           valueSrc: ["value"],
-          valueType: ["autoComplete"]
+          valueType: [simpleQueryRow.type]
         }
       };
     }

--- a/packages/common-ui/lib/list-page/types.ts
+++ b/packages/common-ui/lib/list-page/types.ts
@@ -328,3 +328,14 @@ export interface RelationshipDynamicField extends DynamicField {
   referencedBy: string;
   referencedType: string;
 }
+
+export interface SimpleQueryGroup {
+  conj: string;
+  props: SimpleQueryRow[];
+}
+
+export interface SimpleQueryRow {
+  field: string;
+  operator: string;
+  value: string;
+}

--- a/packages/common-ui/lib/list-page/types.ts
+++ b/packages/common-ui/lib/list-page/types.ts
@@ -338,4 +338,5 @@ export interface SimpleQueryRow {
   field: string;
   operator: string;
   value: string;
+  type: string;
 }


### PR DESCRIPTION
- Saves queryTree as an encoded URI component when user presses the Search button
- QueryPage now parses the URL for an encoded queryTree  parameter and decodes this parameter back into a queryTree
- Pasting the URL with the encoded parameter into a new browser session should populate the query builder with the accordingly