### PR TITLE
Support #36033 - Remove original filename from default columns in object store

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelector.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelector.tsx
@@ -263,6 +263,9 @@ export function ColumnSelector<TData extends KitsuResource>(
 
         const columns = (await Promise.all(promises)).filter(isDefinedColumn);
         setDisplayedColumns(columns);
+
+        setLoading(false);
+        setColumnSelectorLoading?.(false);
       }
     }
 
@@ -290,6 +293,9 @@ export function ColumnSelector<TData extends KitsuResource>(
         if (promises) {
           const columns = (await Promise.all(promises)).filter(isDefinedColumn);
           setDisplayedColumns(columns);
+
+          setLoading(false);
+          setColumnSelectorLoading?.(false);
         }
       }
     }
@@ -297,8 +303,6 @@ export function ColumnSelector<TData extends KitsuResource>(
     // Check if overrides are provided from the saved exports.
     if (overrideDisplayedColumns) {
       loadColumnsFromSavedExport();
-      setLoading(false);
-      setColumnSelectorLoading?.(false);
       return;
     }
 
@@ -306,21 +310,15 @@ export function ColumnSelector<TData extends KitsuResource>(
       !localStorageDisplayedColumns ||
       localStorageDisplayedColumns?.length === 0
     ) {
-      // No local storage to load from, load the default columns in.
-      setDisplayedColumns(defaultColumns ?? []);
-
       // Set the default columns into local storage.
       if (defaultColumns) {
         setLocalStorageDisplayedColumns(
           defaultColumns.map((column) => column?.id ?? "")
         );
       }
-      setLoading(false);
-    } else {
-      loadColumnsFromLocalStorage();
-      setLoading(false);
-      setColumnSelectorLoading?.(false);
     }
+
+    loadColumnsFromLocalStorage();
   }, [
     localStorageDisplayedColumns,
     injectedIndexMapping,

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -120,6 +120,10 @@ export default function MetadataListPage() {
           </Link>
         ) : null,
       accessorKey: "data.attributes.id",
+      additionalAccessors: [
+        "data.attributes.originalFilename",
+        "data.attributes.resourceExternalURL"
+      ],
       header: () => <DinaMessage id="viewDetails" />,
       enableSorting: false,
       id: "viewDetails"
@@ -127,31 +131,6 @@ export default function MetadataListPage() {
     ThumbnailCell({
       bucketField: "data.attributes.bucket"
     }),
-    {
-      cell: ({ row: { original } }) =>
-        (original as any)?.data?.attributes?.resourceExternalURL ? (
-          <Link
-            href={`/object-store/object/external-resource-view?id=${original?.id}`}
-          >
-            <a className="m-auto">
-              <DinaMessage id="detailsPageLink" />
-            </a>
-          </Link>
-        ) : (original as any).data?.attributes?.originalFilename ? (
-          <Link
-            href={`/object-store/object/view?id=${original.id}`}
-            passHref={true}
-          >
-            <a id={`file-name-${original.id}`}>
-              {(original as any).data?.attributes?.originalFilename}
-            </a>
-          </Link>
-        ) : null,
-      header: () => <FieldHeader name="originalFilename" />,
-      accessorKey: "data.attributes.originalFilename",
-      isKeyword: true,
-      id: "originalFilename"
-    },
     {
       header: () => <FieldHeader name="acCaption" />,
       accessorKey: "data.attributes.acCaption",


### PR DESCRIPTION
- Removed original filename as a default option, can still be added using the column selector or exported like before.
- Fixed a QueryPage issue if no local storage exists, it gets stuck loading.
- Fixed issue with additional accessors missing for view details.