### PR TITLE
Support #36076 - Wait for object export to be ready for download

### DIFF
--- a/packages/common-ui/lib/api-client/ApiClientContext.tsx
+++ b/packages/common-ui/lib/api-client/ApiClientContext.tsx
@@ -129,11 +129,6 @@ export class ApiClientImpl implements ApiClientI {
       resourceCase: "none"
     });
 
-    this.apiClient.axios?.interceptors?.response.use(
-      (successResponse) => successResponse,
-      makeAxiosErrorMoreReadable
-    );
-
     // Add caching support for one second since it's likely it's going to be same response.
     const ONE_SECOND = 1000;
     this.apiClient.axios = setupCache(this.apiClient.axios, {
@@ -145,6 +140,12 @@ export class ApiClientImpl implements ApiClientI {
       ),
       ttl: ONE_SECOND
     });
+
+    // This part needs to happen after the cache is setup since it will override it.
+    this.apiClient.axios?.interceptors?.response.use(
+      (successResponse) => successResponse,
+      makeAxiosErrorMoreReadable
+    );
 
     // Bind the methods so context consumers can use object destructuring.
     this.doOperations = this.doOperations.bind(this);


### PR DESCRIPTION
- Moved interceptor logic to after the setupCache is configured. This fixes the issue with 404 errors not being handled correctly.