### PR TITLE
Support #36096 - Export tab-separated is not adding extension to export file

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelectorList.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorList.tsx
@@ -1,5 +1,5 @@
 import useLocalStorage from "@rehooks/local-storage";
-import Kitsu, { KitsuResource } from "kitsu";
+import { KitsuResource } from "kitsu";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "react-bootstrap";
 import {
@@ -462,29 +462,4 @@ export function ColumnSelectorList<TData extends KitsuResource>({
       )}
     </>
   );
-}
-
-export async function downloadDataExport(
-  apiClient: Kitsu,
-  id: string | undefined,
-  name?: string
-) {
-  if (id) {
-    const getFileResponse = await apiClient.get(
-      `dina-export-api/file/${id}?type=DATA_EXPORT`,
-      {
-        responseType: "blob",
-        timeout: 0
-      }
-    );
-
-    // Download the data
-    const url = window?.URL.createObjectURL(getFileResponse as any);
-    const link = document?.createElement("a");
-    link.href = url ?? "";
-    link?.setAttribute("download", `${name ?? id}`);
-    document?.body?.appendChild(link);
-    link?.click();
-    window?.URL?.revokeObjectURL(url ?? "");
-  }
 }

--- a/packages/common-ui/lib/export/exportUtils.tsx
+++ b/packages/common-ui/lib/export/exportUtils.tsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { DataExport } from "packages/dina-ui/types/dina-export-api";
-import { downloadDataExport } from "common-ui";
-import Kitsu, { KitsuResource, PersistedResource } from "kitsu";
+import Kitsu, { PersistedResource } from "kitsu";
 import { DinaMessage } from "packages/dina-ui/intl/dina-ui-intl";
+import { DataExport } from "packages/dina-ui/types/dina-export-api";
+import { ObjectExport } from "packages/dina-ui/types/objectstore-api";
 
 /**
  * Total number of objects allowed to be exported in the UI.
@@ -37,7 +36,7 @@ const BASE_DELAY_EXPORT_FETCH_MS = 2000;
  * Manages loading state via `setLoading`.
  */
 export async function getExport(
-  exportPostResponse: PersistedResource<KitsuResource>[],
+  exportPostResponse: PersistedResource<DataExport | ObjectExport>[],
   setLoading: (loading: boolean) => void,
   setDataExportError: (error: React.ReactNode | undefined) => void,
   apiClient: Kitsu,
@@ -53,7 +52,7 @@ export async function getExport(
         // Get the exported data
         await downloadDataExport(
           apiClient,
-          exportPostResponse[0].id,
+          exportPostResponse[0],
           formik?.values?.name
         );
         isFetchingDataExport = false;
@@ -100,4 +99,70 @@ export async function getExport(
     }
   }
   isFetchingDataExport = false;
+}
+
+/**
+ * Downloads an exported data file from the server and initiates a download in the browser.
+ *
+ * @param {Kitsu} apiClient - An instance of the API client used to make the request.
+ * @param {DataExport} exportToDownload - The data export object containing information about the export.
+ * @param {string} exportName - The name to be used for the downloaded file.
+ *
+ * @returns {Promise<void>} - A promise that resolves when the download is initiated.
+ *
+ */
+export async function downloadDataExport(
+  apiClient: Kitsu,
+  exportToDownload: DataExport | ObjectExport,
+  exportName?: string
+): Promise<void> {
+  if (exportToDownload?.id) {
+    const getFileResponse = await apiClient.get(
+      `dina-export-api/file/${exportToDownload.id}?type=DATA_EXPORT`,
+      {
+        responseType: "blob",
+        timeout: 0
+      }
+    );
+
+    // Generate the file name and file extension.
+    let fileName: string;
+    let fileExtension: string;
+    if (exportToDownload.type === "data-export") {
+      fileName = exportName ?? exportToDownload?.name ?? exportToDownload.id;
+      if (exportToDownload.exportType === "OBJECT_ARCHIVE") {
+        fileExtension = ".zip";
+      } else {
+        fileExtension =
+          exportToDownload?.exportOptions?.columnSeparator === "COMMA"
+            ? ".csv"
+            : ".tsv";
+      }
+    } else {
+      fileName = exportName ?? exportToDownload?.id;
+      fileExtension = "";
+    }
+
+    // Download the data
+    downloadBlobFile(getFileResponse as any, `${fileName}${fileExtension}`);
+  }
+}
+
+/**
+ * Downloads a file from a Blob response.
+ *
+ * @param {Blob} blob - The blob data to be downloaded.
+ * @param {string} fileName - The name of the file to be downloaded, extension should be appended to it. (e.g "file.csv")
+ */
+export function downloadBlobFile(blob: any, fileName: string): void {
+  const url = window?.URL.createObjectURL(blob);
+  const link = document?.createElement("a");
+  link.href = url ?? "";
+  link?.setAttribute("download", fileName);
+  document?.body?.appendChild(link);
+  link?.click();
+  document?.body?.removeChild(link);
+  if (typeof window !== "undefined" && window?.URL?.revokeObjectURL) {
+    window?.URL?.revokeObjectURL(url ?? "");
+  }
 }

--- a/packages/common-ui/lib/export/exportUtils.tsx
+++ b/packages/common-ui/lib/export/exportUtils.tsx
@@ -1,7 +1,7 @@
 import Kitsu, { PersistedResource } from "kitsu";
-import { DinaMessage } from "packages/dina-ui/intl/dina-ui-intl";
-import { DataExport } from "packages/dina-ui/types/dina-export-api";
-import { ObjectExport } from "packages/dina-ui/types/objectstore-api";
+import { DinaMessage } from "../../../dina-ui/intl/dina-ui-intl";
+import { DataExport } from "../../../dina-ui/types/dina-export-api";
+import { ObjectExport } from "../../../dina-ui/types/objectstore-api";
 
 /**
  * Total number of objects allowed to be exported in the UI.

--- a/packages/common-ui/lib/index.ts
+++ b/packages/common-ui/lib/index.ts
@@ -126,3 +126,4 @@ export * from "./visibility/useIsVisible";
 export * from "./table/ScientificNameCell";
 export * from "./settings-button/SettingsButton";
 export * from "./test-util/mock-app-context";
+export * from "./export/exportUtils";

--- a/packages/common-ui/lib/list-page-layout/DataExportListPageLayout.tsx
+++ b/packages/common-ui/lib/list-page-layout/DataExportListPageLayout.tsx
@@ -4,7 +4,6 @@ import {
   dateCell,
   useApiClient,
   LoadingSpinner,
-  downloadDataExport,
   DinaForm,
   BulkDeleteButton
 } from "..";
@@ -12,6 +11,7 @@ import { DataExport } from "../../../dina-ui/types/dina-export-api";
 import { Button } from "react-bootstrap";
 import { useState } from "react";
 import { useIntl } from "react-intl";
+import { downloadDataExport } from "../export/exportUtils";
 
 export interface DataExportListPageLayoutProps {
   username: string | undefined;
@@ -43,7 +43,7 @@ export function DataExportListPageLayout({
             className="btn btn-primary mt-2 bulk-edit-button"
             onClick={async () => {
               setLoading(true);
-              await downloadDataExport(apiClient, original?.id, original?.name);
+              await downloadDataExport(apiClient, original, original?.name);
               setLoading(false);
             }}
           >

--- a/packages/dina-ui/components/collection/material-sample/GenerateLabelDropdownButton.tsx
+++ b/packages/dina-ui/components/collection/material-sample/GenerateLabelDropdownButton.tsx
@@ -6,7 +6,7 @@ import { ReportTemplate } from "../../../types/dina-export-api";
 import Select from "react-select";
 import { useAccount, useQuery } from "../../../../common-ui/lib";
 import { useApiClient } from "../../../../common-ui/lib/api-client/ApiClientContext";
-import { downloadBlobFile } from "packages/common-ui/lib/export/exportUtils";
+import { downloadBlobFile } from "common-ui";
 
 interface ReportTemplateOption {
   label: string;

--- a/packages/dina-ui/components/collection/material-sample/GenerateLabelDropdownButton.tsx
+++ b/packages/dina-ui/components/collection/material-sample/GenerateLabelDropdownButton.tsx
@@ -6,6 +6,7 @@ import { ReportTemplate } from "../../../types/dina-export-api";
 import Select from "react-select";
 import { useAccount, useQuery } from "../../../../common-ui/lib";
 import { useApiClient } from "../../../../common-ui/lib/api-client/ApiClientContext";
+import { downloadBlobFile } from "packages/common-ui/lib/export/exportUtils";
 
 interface ReportTemplateOption {
   label: string;
@@ -108,26 +109,23 @@ export function GenerateLabelDropdownButton({
         `dina-export-api/file/${reportTemplatePostResponse?.data?.data?.id}`,
         { responseType: "blob" }
       );
-      const url = window?.URL.createObjectURL(reportRequestGetResponse?.data);
-      const link = document?.createElement("a");
-      link.href = url;
+
+      // Generate the file name and file extension.
       const filePath = reportRequestGetResponse?.config?.url;
       const fileName = !filePath
         ? "report"
         : filePath.substring(filePath.lastIndexOf("/") + 1);
-      link?.setAttribute(
-        "download",
-        `${
-          resource.materialSampleName
-            ? resource.materialSampleName
-            : resource.name
-            ? resource.name
-            : fileName
-        }_${reportTemplate.label}`
-      );
-      document?.body?.appendChild(link);
-      link?.click();
-      window?.URL?.revokeObjectURL(url);
+      const fullName = `${
+        resource.materialSampleName
+          ? resource.materialSampleName
+          : resource.name
+          ? resource.name
+          : fileName
+      }_${reportTemplate.label}`;
+
+      // Download file
+      downloadBlobFile(reportRequestGetResponse?.data, fullName);
+
       setGeneratingReport(false);
     } catch (error) {
       setGeneratingReport(false);

--- a/packages/dina-ui/components/export/useMolecularAnalysisExportAPI.tsx
+++ b/packages/dina-ui/components/export/useMolecularAnalysisExportAPI.tsx
@@ -10,17 +10,15 @@ import {
   DATA_EXPORT_QUERY_KEY,
   DATA_EXPORT_TOTAL_RECORDS_KEY,
   filterBy,
+  getExport,
+  MAX_MATERIAL_SAMPLES_FOR_MOLECULAR_ANALYSIS_EXPORT,
+  MAX_OBJECT_EXPORT_TOTAL,
   useApiClient
 } from "common-ui";
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
 import useLocalStorage from "@rehooks/local-storage";
 import { useRouter } from "next/router";
 import { Alert } from "react-bootstrap";
-import {
-  getExport,
-  MAX_MATERIAL_SAMPLES_FOR_MOLECULAR_ANALYSIS_EXPORT,
-  MAX_OBJECT_EXPORT_TOTAL
-} from "./exportUtils";
 import { useSessionStorage } from "usehooks-ts";
 import { DinaMessage } from "packages/dina-ui/intl/dina-ui-intl";
 import {

--- a/packages/dina-ui/components/object-store/object-store-utils.ts
+++ b/packages/dina-ui/components/object-store/object-store-utils.ts
@@ -1,5 +1,5 @@
 import Kitsu from "kitsu";
-import { downloadBlobFile } from "packages/common-ui/lib/export/exportUtils";
+import { downloadBlobFile } from "common-ui";
 import { Dispatch, SetStateAction } from "react";
 
 /**

--- a/packages/dina-ui/components/object-store/object-store-utils.ts
+++ b/packages/dina-ui/components/object-store/object-store-utils.ts
@@ -1,4 +1,5 @@
 import Kitsu from "kitsu";
+import { downloadBlobFile } from "packages/common-ui/lib/export/exportUtils";
 import { Dispatch, SetStateAction } from "react";
 
 /**
@@ -30,17 +31,13 @@ export async function handleDownloadLink(
     try {
       setIsDownloading(true);
       const response = await fetchObjectBlob(path, apiClient);
-      const url = window?.URL?.createObjectURL(response.data);
-      const link = document?.createElement("a");
       const content: string = response.headers["content-disposition"];
       const filename = content
         .slice(content.indexOf("filename=") + "filename=".length)
         .replaceAll('"', "");
-      link.href = url;
-      link?.setAttribute("download", filename); // or any other extension
-      document?.body?.appendChild(link);
-      link?.click();
-      window?.URL?.revokeObjectURL(url);
+
+      downloadBlobFile(response.data, filename);
+
       setIsDownloading(false);
     } catch (error) {
       setIsDownloading(false);

--- a/packages/dina-ui/pages/export/data-export/export.tsx
+++ b/packages/dina-ui/pages/export/data-export/export.tsx
@@ -44,16 +44,16 @@ import { useIntl } from "react-intl";
 import Select from "react-select";
 import { useSessionStorage } from "usehooks-ts";
 import useSavedExports, { VISIBILITY_OPTIONS } from "./useSavedExports";
-import {
-  getExport,
-  MAX_MATERIAL_SAMPLES_FOR_MOLECULAR_ANALYSIS_EXPORT,
-  MAX_OBJECT_EXPORT_TOTAL
-} from "../../../components/export/exportUtils";
 import { QueryFieldSelector } from "packages/common-ui/lib/list-page/query-builder/query-builder-core-components/QueryFieldSelector";
 import QueryRowManagedAttributeSearch from "packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderManagedAttributeSearch";
 import { get } from "lodash";
 import { MATERIAL_SAMPLE_NON_EXPORTABLE_COLUMNS } from "../../collection/material-sample/list";
 import { OBJECT_STORE_NON_EXPORTABLE_COLUMNS } from "../../object-store/object/list";
+import {
+  getExport,
+  MAX_MATERIAL_SAMPLES_FOR_MOLECULAR_ANALYSIS_EXPORT,
+  MAX_OBJECT_EXPORT_TOTAL
+} from "packages/common-ui/lib/export/exportUtils";
 
 export interface SavedExportOption {
   label?: string;

--- a/packages/dina-ui/pages/export/molecular-analysis-export/export.tsx
+++ b/packages/dina-ui/pages/export/molecular-analysis-export/export.tsx
@@ -3,6 +3,7 @@ import {
   checkboxProps,
   DinaForm,
   LoadingSpinner,
+  MAX_OBJECT_EXPORT_TOTAL,
   SubmitButton,
   TextField
 } from "common-ui";
@@ -12,7 +13,6 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import { Card } from "react-bootstrap";
 import useMolecularAnalysisExportAPI from "../../../components/export/useMolecularAnalysisExportAPI";
-import { MAX_OBJECT_EXPORT_TOTAL } from "../../../components/export/exportUtils";
 import React from "react";
 
 export default function ExportMolecularAnalysisPage() {

--- a/packages/dina-ui/pages/workbook/generator.tsx
+++ b/packages/dina-ui/pages/workbook/generator.tsx
@@ -30,7 +30,7 @@ import {
 import InputGroup from "react-bootstrap/InputGroup";
 import { Metadata } from "packages/dina-ui/types/objectstore-api";
 import { handleDownloadLink } from "../../components/object-store/object-store-utils";
-import { downloadBlobFile } from "packages/common-ui/lib/export/exportUtils";
+import { downloadBlobFile } from "common-ui";
 
 export interface EntityConfiguration {
   name: string;

--- a/packages/dina-ui/pages/workbook/generator.tsx
+++ b/packages/dina-ui/pages/workbook/generator.tsx
@@ -30,6 +30,7 @@ import {
 import InputGroup from "react-bootstrap/InputGroup";
 import { Metadata } from "packages/dina-ui/types/objectstore-api";
 import { handleDownloadLink } from "../../components/object-store/object-store-utils";
+import { downloadBlobFile } from "packages/common-ui/lib/export/exportUtils";
 
 export interface EntityConfiguration {
   name: string;
@@ -165,17 +166,10 @@ export function WorkbookTemplateGenerator() {
       );
 
       // Download the data
-      const url = window?.URL?.createObjectURL?.(
-        workbookGenerationPostResponse?.data as any
+      downloadBlobFile(
+        workbookGenerationPostResponse?.data,
+        safeFileName + ".xlsx"
       );
-      const link = document?.createElement("a");
-      link.href = url ?? "";
-      link?.setAttribute("download", safeFileName + ".xlsx");
-      document?.body?.appendChild(link);
-      link?.click();
-      if (typeof window !== "undefined" && window?.URL?.revokeObjectURL) {
-        window?.URL?.revokeObjectURL(url ?? "");
-      }
     } catch (error) {
       // Log the error for debugging
       console.error("Error generating workbook template:", error);


### PR DESCRIPTION
- Moved downloadDataExport to the export utils.
- Moved the export utils to common UI since it's used across the application.
- Created a downloadBlobFile function since this code was duplicated in multiple spots.
- Fixed issue with tsv not getting a file extension. Now working on chrome + firefox.