### PR TITLE
Support #36112 - Query filter can't edit value after a search

### DIFF
--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -66,10 +66,11 @@ import {
 import { MemoizedReactTable } from "./QueryPageTable";
 import { GroupSelectFieldMemoized } from "./QueryGroupSelection";
 import { useRouter } from "next/router";
+import { parseQueryTreeFromURL } from "./query-url/queryUtils";
 import {
-  parseQueryTreeFromURL,
-  serializeQueryTreeToURL
-} from "./query-url/queryUtils";
+  createLastUsedSavedSearchChangedKey,
+  createSessionStorageLastUsedTreeKey
+} from "./saved-searches/SavedSearch";
 
 const DEFAULT_PAGE_SIZE: number = 25;
 const DEFAULT_SORT: SortingState = [
@@ -435,12 +436,9 @@ export function QueryPage<TData extends KitsuResource>({
     return { group: groups };
   }, [groups]);
 
-  const sessionStorageLastUsedKeyTreeKey = uniqueName + "-last-used-tree";
-  const localStorageLastUsedSavedSearchChangedKey =
-    uniqueName + "-saved-search-changed";
   const [_sessionStorageQueryTree, setSessionStorageQueryTree] =
     useSessionStorage<JsonTree>(
-      sessionStorageLastUsedKeyTreeKey,
+      createSessionStorageLastUsedTreeKey(uniqueName),
       defaultJsonTree
     );
 
@@ -851,7 +849,7 @@ export function QueryPage<TData extends KitsuResource>({
     setSubmittedQueryBuilderTree(defaultQueryTree());
     setQueryBuilderTree(defaultQueryTree());
     setSessionStorageQueryTree(defaultJsonTree);
-    writeStorage(localStorageLastUsedSavedSearchChangedKey, false);
+    writeStorage(createLastUsedSavedSearchChangedKey(uniqueName), false);
     setSortingRules(defaultSort ?? DEFAULT_SORT);
     setError(undefined);
     setPageOffset(0);
@@ -876,15 +874,6 @@ export function QueryPage<TData extends KitsuResource>({
     setSubmittedQueryBuilderTree(queryBuilderTree);
     setPageOffset(0);
     setSessionStorageQueryTree(Utils.getTree(queryBuilderTree));
-    const serializedTree = serializeQueryTreeToURL(queryBuilderTree);
-    router.push(
-      {
-        pathname: router.pathname,
-        query: serializedTree !== null ? { queryTree: serializedTree } : null
-      },
-      undefined,
-      { shallow: true }
-    );
   };
 
   /**

--- a/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
+++ b/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
@@ -103,6 +103,10 @@ export function createSessionStorageLastUsedTreeKey(uniqueName: string) {
   return `${uniqueName}-last-used-tree`;
 }
 
+export function createLastUsedSavedSearchChangedKey(uniqueName: string) {
+  return `${uniqueName}-saved-search-changed`;
+}
+
 /**
  * This component contains the following logic:
  *


### PR DESCRIPTION
- The issue was the saved searching going directly into the URL, removed this and in another ticket a "share" will be used to generate the query instead.
- Created a function to generate the local storage keys for consistency.