### PR TITLE
36104 Query filters not populated by url

### DIFF
--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -623,6 +623,7 @@ export function QueryPage<TData extends KitsuResource>({
         if (parsedQueryTree) {
           setQueryBuilderTree(parsedQueryTree);
           setSubmittedQueryBuilderTree(parsedQueryTree);
+          setSessionStorageQueryTree(Utils.getTree(parsedQueryTree));
         }
       }
     }


### PR DESCRIPTION
- Fixed bug where URL filter was being applied but the QueryBuilder did not reflect the queryTree
- The QueryBuilder should not reflect the URL's queryTree on load