### PR TITLE
36029 Add option to generate query tree URL on the query page

### DIFF
--- a/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
+++ b/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
@@ -1,4 +1,4 @@
-import { DinaMessage } from "packages/dina-ui/intl/dina-ui-intl";
+import { DinaMessage } from "../../../dina-ui/intl/dina-ui-intl";
 import React from "react";
 import { Button } from "react-bootstrap";
 import { FaCheck, FaCopy } from "react-icons/fa";

--- a/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
+++ b/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
@@ -1,0 +1,24 @@
+import { useDinaIntl } from "packages/dina-ui/intl/dina-ui-intl";
+import React from "react";
+
+function CopyToClipboardButton() {
+  const textToCopy = "Hello, world!";
+  const { formatMessage } = useDinaIntl();
+
+  const handleCopyClick = async () => {
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      alert("Copied to clipboard!");
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  return (
+    <button onClick={handleCopyClick}>
+      {formatMessage("generateURLButtonText")}
+    </button>
+  );
+}
+
+export default CopyToClipboardButton;

--- a/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
+++ b/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
@@ -1,6 +1,5 @@
 import { DinaMessage } from "../../../dina-ui/intl/dina-ui-intl";
 import React from "react";
-import { Button } from "react-bootstrap";
 import { FaCheck, FaCopy } from "react-icons/fa";
 
 interface CopyToClipboardButtonProps {
@@ -15,14 +14,14 @@ function CopyToClipboardButton({
   onCopyToClipboard
 }: CopyToClipboardButtonProps) {
   return (
-    <Button onClick={onCopyToClipboard} className="me-2">
+    <div onClick={onCopyToClipboard} className="me-2">
       <DinaMessage id="generateURLButtonText" />{" "}
       {copiedToClipboard ? (
         <FaCheck style={{ marginBottom: "4px" }} />
       ) : (
         <FaCopy style={{ marginBottom: "4px" }} />
       )}
-    </Button>
+    </div>
   );
 }
 

--- a/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
+++ b/packages/common-ui/lib/list-page/CopyToClipboardButton.tsx
@@ -1,23 +1,28 @@
-import { useDinaIntl } from "packages/dina-ui/intl/dina-ui-intl";
+import { DinaMessage } from "packages/dina-ui/intl/dina-ui-intl";
 import React from "react";
+import { Button } from "react-bootstrap";
+import { FaCheck, FaCopy } from "react-icons/fa";
 
-function CopyToClipboardButton() {
-  const textToCopy = "Hello, world!";
-  const { formatMessage } = useDinaIntl();
+interface CopyToClipboardButtonProps {
+  // Callback function to handle copying URL with query filters to clipboard
+  onCopyToClipboard?: () => Promise<void>;
 
-  const handleCopyClick = async () => {
-    try {
-      await navigator.clipboard.writeText(textToCopy);
-      alert("Copied to clipboard!");
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
+  copiedToClipboard?: boolean;
+}
 
+function CopyToClipboardButton({
+  copiedToClipboard,
+  onCopyToClipboard
+}: CopyToClipboardButtonProps) {
   return (
-    <button onClick={handleCopyClick}>
-      {formatMessage("generateURLButtonText")}
-    </button>
+    <Button onClick={onCopyToClipboard} className="me-2">
+      <DinaMessage id="generateURLButtonText" />{" "}
+      {copiedToClipboard ? (
+        <FaCheck style={{ marginBottom: "4px" }} />
+      ) : (
+        <FaCopy style={{ marginBottom: "4px" }} />
+      )}
+    </Button>
   );
 }
 

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -66,7 +66,10 @@ import {
 import { MemoizedReactTable } from "./QueryPageTable";
 import { GroupSelectFieldMemoized } from "./QueryGroupSelection";
 import { useRouter } from "next/router";
-import { parseQueryTreeFromURL } from "./query-url/queryUtils";
+import {
+  parseQueryTreeFromURL,
+  serializeQueryTreeToURL
+} from "./query-url/queryUtils";
 import {
   createLastUsedSavedSearchChangedKey,
   createSessionStorageLastUsedTreeKey
@@ -981,6 +984,22 @@ export function QueryPage<TData extends KitsuResource>({
     }
   }
 
+  async function onCopyToClipboard() {
+    const serializedTree = serializeQueryTreeToURL(queryBuilderTree);
+
+    const query =
+      serializedTree !== null
+        ? `?queryTree=${encodeURIComponent(serializedTree)}`
+        : "";
+    const fullUrl = `${window.location.origin}${router.pathname}${query}`;
+
+    try {
+      await navigator.clipboard.writeText(fullUrl);
+    } catch (err) {
+      console.error("Failed to copy URL:", err);
+    }
+  }
+
   // Generate the key for the DINA form. It should only be generated once.
   const formKey = useMemo(() => uuidv4(), []);
 
@@ -1007,6 +1026,7 @@ export function QueryPage<TData extends KitsuResource>({
             </div>
           )}
           <QueryBuilderMemo
+            onCopyToClipboard={onCopyToClipboard}
             indexName={indexName}
             queryBuilderTree={queryBuilderTree}
             setQueryBuilderTree={onQueryBuildTreeChange}

--- a/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
@@ -12,7 +12,6 @@ import { SavedSearch } from "../saved-searches/SavedSearch";
 import { DinaMessage } from "../../../../dina-ui/intl/dina-ui-intl";
 import { CommonMessage } from "common-ui";
 import { ValidationError } from "./query-builder-elastic-search/QueryBuilderElasticSearchValidator";
-import { FaCopy, FaCheck } from "react-icons/fa";
 
 export interface QueryBuilderContextI {
   performSubmit: () => void;
@@ -173,6 +172,12 @@ function QueryBuilder({
           setGroups={setGroups}
           uniqueName={uniqueName}
           triggerSearch={triggerSearch}
+          copiedToClipboard={copiedToClipboard}
+          setCopiedToClipboard={setCopiedToClipboard}
+          onCopyToClipboard={async () => {
+            await onCopyToClipboard();
+            setCopiedToClipboard(true);
+          }}
         />
         <Query
           {...queryBuilderConfig}
@@ -197,21 +202,6 @@ function QueryBuilder({
             className="me-2"
           >
             <CommonMessage id="resetButtonText" />
-          </Button>
-          <Button
-            onClick={async () => {
-              await onCopyToClipboard();
-              setCopiedToClipboard(true);
-            }}
-            className="me-2"
-            disabled={validationErrors.length > 0}
-          >
-            <DinaMessage id="generateURLButtonText" />{" "}
-            {copiedToClipboard ? (
-              <FaCheck style={{ marginBottom: "4px" }} />
-            ) : (
-              <FaCopy style={{ marginBottom: "4px" }} />
-            )}
           </Button>
         </div>
       </QueryBuilderContextProvider>

--- a/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/QueryBuilder.tsx
@@ -1,6 +1,6 @@
 import { LoadingSpinner } from "../..";
 import { Query, Builder, Utils, JsonTree } from "react-awesome-query-builder";
-import { createContext, useCallback, useContext } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import {
   Config,
   ImmutableTree,
@@ -12,6 +12,7 @@ import { SavedSearch } from "../saved-searches/SavedSearch";
 import { DinaMessage } from "../../../../dina-ui/intl/dina-ui-intl";
 import { CommonMessage } from "common-ui";
 import { ValidationError } from "./query-builder-elastic-search/QueryBuilderElasticSearchValidator";
+import { FaCopy, FaCheck } from "react-icons/fa";
 
 export interface QueryBuilderContextI {
   performSubmit: () => void;
@@ -103,6 +104,9 @@ interface QueryBuilderProps {
 
   // Reference for triggering the search. This helps prevent more searches than necessary.
   triggerSearch: React.MutableRefObject<boolean>;
+
+  // Callback function to handle copying URL with query filters to clipboard
+  onCopyToClipboard: () => Promise<void>;
 }
 
 function QueryBuilder({
@@ -118,8 +122,10 @@ function QueryBuilder({
   setGroups,
   uniqueName,
   validationErrors,
-  triggerSearch
+  triggerSearch,
+  onCopyToClipboard
 }: QueryBuilderProps) {
+  const [copiedToClipboard, setCopiedToClipboard] = useState<boolean>(false);
   const onChange = useCallback((immutableTree: ImmutableTree) => {
     setQueryBuilderTree(immutableTree);
   }, []);
@@ -182,8 +188,30 @@ function QueryBuilder({
           >
             <DinaMessage id="search" />
           </Button>
-          <Button onClick={onReset} variant="secondary">
+          <Button
+            onClick={() => {
+              onReset();
+              setCopiedToClipboard(false);
+            }}
+            variant="secondary"
+            className="me-2"
+          >
             <CommonMessage id="resetButtonText" />
+          </Button>
+          <Button
+            onClick={async () => {
+              await onCopyToClipboard();
+              setCopiedToClipboard(true);
+            }}
+            className="me-2"
+            disabled={validationErrors.length > 0}
+          >
+            <DinaMessage id="generateURLButtonText" />{" "}
+            {copiedToClipboard ? (
+              <FaCheck style={{ marginBottom: "4px" }} />
+            ) : (
+              <FaCopy style={{ marginBottom: "4px" }} />
+            )}
           </Button>
         </div>
       </QueryBuilderContextProvider>

--- a/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
+++ b/packages/common-ui/lib/list-page/saved-searches/SavedSearch.tsx
@@ -33,6 +33,7 @@ import { validateQueryTree } from "../query-builder/query-builder-validator/quer
 import { useIntl } from "react-intl";
 import { useSessionStorage } from "usehooks-ts";
 import { useLocalStorage } from "@rehooks/local-storage";
+import CopyToClipboardButton from "../CopyToClipboardButton";
 
 export interface SavedSearchProps {
   /**
@@ -97,6 +98,13 @@ export interface SavedSearchProps {
 
   // Reference for triggering the search. This helps prevent more searches than necessary.
   triggerSearch: React.MutableRefObject<boolean>;
+
+  // Callback function to handle copying URL with query filters to clipboard
+  onCopyToClipboard?: () => Promise<void>;
+
+  copiedToClipboard?: boolean;
+
+  setCopiedToClipboard?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export function createSessionStorageLastUsedTreeKey(uniqueName: string) {
@@ -131,7 +139,10 @@ export function SavedSearch({
   setGroups,
   performSubmit,
   uniqueName,
-  triggerSearch
+  triggerSearch,
+  onCopyToClipboard,
+  copiedToClipboard,
+  setCopiedToClipboard
 }: SavedSearchProps) {
   const { save, apiClient } = useApiClient();
   const { openModal } = useModal();
@@ -601,6 +612,15 @@ export function SavedSearch({
         <Dropdown.Menu>
           <Dropdown.Item onClick={openSavedSearchModal}>
             <DinaMessage id="createNew" />
+          </Dropdown.Item>
+          <Dropdown.Item>
+            <CopyToClipboardButton
+              copiedToClipboard={copiedToClipboard}
+              onCopyToClipboard={async () => {
+                await onCopyToClipboard?.();
+                setCopiedToClipboard?.(true);
+              }}
+            />
           </Dropdown.Item>
           {selectedSavedSearch && (
             <>

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -1225,5 +1225,6 @@ export const DINAUI_MESSAGES_ENGLISH = {
   fileNameAliasField: "File Name Alias Field",
   downloadTemplate: "Download Template",
   existingTemplates: "Existing Templates",
-  viewMaterialSamplesInCollection: "View material samples in this collection"
+  viewMaterialSamplesInCollection: "View material samples in this collection",
+  generateURLButtonText: "Generate URL"
 };


### PR DESCRIPTION
- Implemented new CopyToClipboardButton
- Added CopyToClipboard button next to Search/Reset buttons in QueryBuilder
- Clicking on the button should copy the whole URL with the queryTree to clipboard