### PR TITLE
35957 SRA Export Template not saving functions to template

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelector.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelector.tsx
@@ -274,7 +274,15 @@ export function ColumnSelector<TData extends KitsuResource>(
         const promises = overrideDisplayedColumns?.columns?.map?.(
           async (localColumn, index) => {
             const columnFunctionPath = localColumn.includes("function")
-              ? `columnFunction/${localColumn}/${overrideDisplayedColumns.columnFunctions?.[localColumn].functionName}`
+              ? overrideDisplayedColumns.columnFunctions?.[localColumn]
+                  .functionName === "CONCAT"
+                ? `columnFunction/${localColumn}/${
+                    overrideDisplayedColumns.columnFunctions?.[localColumn]
+                      .functionName
+                  }/${overrideDisplayedColumns.columnFunctions?.[
+                    localColumn
+                  ].params.join("+")}`
+                : `columnFunction/${localColumn}/${overrideDisplayedColumns.columnFunctions?.[localColumn].functionName}`
               : undefined;
 
             const newColumnDefinition = await generateColumnDefinition({

--- a/packages/common-ui/lib/column-selector/ColumnSelector.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelector.tsx
@@ -273,14 +273,17 @@ export function ColumnSelector<TData extends KitsuResource>(
       if (injectedIndexMapping && overrideDisplayedColumns) {
         const promises = overrideDisplayedColumns?.columns?.map?.(
           async (localColumn, index) => {
+            const columnFunctionPath = localColumn.includes("function")
+              ? `columnFunction/${localColumn}/${overrideDisplayedColumns.columnFunctions?.[localColumn].functionName}`
+              : undefined;
+
             const newColumnDefinition = await generateColumnDefinition({
               indexMappings: injectedIndexMapping,
               dynamicFieldsMappingConfig,
               apiClient,
               defaultColumns,
-              path: localColumn
+              path: columnFunctionPath ?? localColumn
             });
-
             // Set the column header if saved.
             if (newColumnDefinition) {
               newColumnDefinition.exportHeader =

--- a/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
@@ -20,6 +20,46 @@ import {
 import { ClassificationSearchStates } from "../list-page/query-builder/query-builder-value-types/QueryBuilderClassificationSearch";
 import { VocabularyElement } from "packages/dina-ui/types/collection-api";
 
+export function convertColumnsToAliases(columns): string[] {
+  if (!columns) {
+    return [];
+  }
+  return columns.map((column) => column?.exportHeader ?? "");
+}
+
+export function convertColumnsToPaths(columns): string[] {
+  if (!columns) {
+    return [];
+  }
+  return columns.map((column) =>
+    column.columnSelectorString?.startsWith("columnFunction/")
+      ? column.columnSelectorString?.split("/")[1] // Get functionId
+      : column.id ?? ""
+  );
+}
+
+export function getColumnFunctions<TData extends KitsuResource>(
+  columnsToExport: TableColumn<TData>[]
+) {
+  return columnsToExport
+    .filter((c) => c.columnSelectorString?.startsWith("columnFunction/"))
+    .reduce((prev, curr) => {
+      const columnParts = curr.columnSelectorString?.split("/");
+      if (columnParts) {
+        return {
+          ...prev,
+          [columnParts[1]]: {
+            functionName: columnParts[2],
+            params:
+              columnParts[2] === "CONVERT_COORDINATES_DD"
+                ? ["collectingEvent.eventGeom"]
+                : columnParts[3].split("+")
+          }
+        };
+      }
+    }, {});
+}
+
 export interface GenerateColumnPathProps {
   /** Index mapping for the column to generate the column path. */
   indexMapping: ESIndexMapping;

--- a/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
@@ -46,14 +46,17 @@ export function getColumnFunctions<TData extends KitsuResource>(
     .reduce((prev, curr) => {
       const columnParts = curr.columnSelectorString?.split("/");
       if (columnParts) {
+        const functionName = columnParts[2];
+        const functionParams = columnParts[3]?.split("+");
+        const params =
+          functionName === "CONVERT_COORDINATES_DD"
+            ? ["collectingEvent.eventGeom"]
+            : functionParams;
         return {
           ...prev,
           [columnParts[1]]: {
             functionName: columnParts[2],
-            params:
-              columnParts[2] === "CONVERT_COORDINATES_DD"
-                ? ["collectingEvent.eventGeom"]
-                : columnParts[3].split("+")
+            params: params
           }
         };
       }

--- a/packages/dina-ui/pages/export/data-export/export.tsx
+++ b/packages/dina-ui/pages/export/data-export/export.tsx
@@ -54,6 +54,11 @@ import {
   MAX_MATERIAL_SAMPLES_FOR_MOLECULAR_ANALYSIS_EXPORT,
   MAX_OBJECT_EXPORT_TOTAL
 } from "packages/common-ui/lib/export/exportUtils";
+import {
+  convertColumnsToAliases,
+  convertColumnsToPaths,
+  getColumnFunctions
+} from "packages/common-ui/lib/column-selector/ColumnSelectorUtils";
 
 export interface SavedExportOption {
   label?: string;
@@ -156,6 +161,7 @@ export default function ExportPage<TData extends KitsuResource>() {
     setRestrictToCreatedBy,
     setPubliclyReleaseable
   } = useSavedExports<TData>({ exportType, selectedSeparator });
+
   async function exportData(formik) {
     setLoading(true);
 
@@ -168,23 +174,7 @@ export default function ExportPage<TData extends KitsuResource>() {
     }
     const queryString = JSON.stringify(queryObject)?.replace(/"/g, '"');
 
-    const columnFunctions = columnsToExport
-      .filter((c) => c.columnSelectorString?.startsWith("columnFunction/"))
-      .reduce((prev, curr) => {
-        const columnParts = curr.columnSelectorString?.split("/");
-        if (columnParts) {
-          return {
-            ...prev,
-            [columnParts[1]]: {
-              functionName: columnParts[2],
-              params:
-                columnParts[2] === "CONVERT_COORDINATES_DD"
-                  ? ["collectingEvent.eventGeom"]
-                  : columnParts[3].split("+")
-            }
-          };
-        }
-      }, {});
+    const columnFunctions = getColumnFunctions<TData>(columnsToExport);
 
     // Make query to data-export
     const dataExportSaveArg: SaveArgs<DataExport> = {
@@ -192,12 +182,8 @@ export default function ExportPage<TData extends KitsuResource>() {
         type: "data-export",
         source: indexName,
         query: queryString,
-        columns: columnsToExport.map((item) =>
-          item.columnSelectorString?.startsWith("columnFunction/")
-            ? item.columnSelectorString?.split("/")[1] // Get functionId
-            : item.id ?? ""
-        ),
-        columnAliases: columnsToExport.map((item) => item?.exportHeader ?? ""),
+        columns: convertColumnsToPaths(columnsToExport),
+        columnAliases: convertColumnsToAliases(columnsToExport),
         columnFunctions:
           Object.keys(columnFunctions ?? {}).length === 0
             ? undefined


### PR DESCRIPTION
- Fixed logic to include columnFunctions in data-export-template POST/PATCH requests
- Now correctly saves columnFunctions to backend
- Fixed logic to load columnFunctions when selecting a saved data-export-template
- Now correctly creates a column definition for columnFunctions and exporting should work