### PR TITLE
36109 Don't put attachments in subfolders for molecular analysis workflow exports

### DIFF
--- a/packages/dina-ui/components/export/useMolecularAnalysisExportAPI.tsx
+++ b/packages/dina-ui/components/export/useMolecularAnalysisExportAPI.tsx
@@ -719,7 +719,7 @@ export default function useMolecularAnalysisExportAPI(): UseMolecularAnalysisExp
           exportLayout.set(`${baseFolder}/results`, itemsAttachments);
         }
         if (qaAttachments.length > 0) {
-          exportLayout.set(`${baseFolder}/qas`, qaAttachments);
+          exportLayout.set(`${baseFolder}/controls`, qaAttachments);
         }
       });
     } else {

--- a/packages/dina-ui/components/export/useMolecularAnalysisExportAPI.tsx
+++ b/packages/dina-ui/components/export/useMolecularAnalysisExportAPI.tsx
@@ -676,38 +676,50 @@ export default function useMolecularAnalysisExportAPI(): UseMolecularAnalysisExp
 
     if (runSummaries && runSummaries.length > 0) {
       runSummaries.forEach((runSummary) => {
-        if (runSummary.enabled) {
-          if (runSummary.attachments && runSummary.attachments.length > 0) {
-            runSummary.attachments.forEach((attachmentFileIdentifier) => {
-              fileIdentifiers.push(attachmentFileIdentifier);
-            });
-            const folderName = runSummary.attributes.name;
-            const uniqueFolderName = generateUniqueFolderName(folderName);
-            exportLayout.set(uniqueFolderName + "/", runSummary.attachments);
-          }
+        if (!runSummary.enabled) return;
+
+        const baseFolder = generateUniqueFolderName(runSummary.attributes.name);
+
+        const runAttachments: string[] = [];
+        const itemsAttachments: string[] = [];
+        const qaAttachments: string[] = [];
+
+        // Collect run-level attachments (go into "run1/")
+        if (runSummary.attachments?.length > 0) {
+          runSummary.attachments.forEach((attachmentFileIdentifier) => {
+            fileIdentifiers.push(attachmentFileIdentifier);
+            runAttachments.push(attachmentFileIdentifier);
+          });
         }
-        if (
-          runSummary.attributes &&
-          runSummary.attributes.items &&
-          runSummary.enabled
-        ) {
+
+        // Collect enabled item attachments
+        if (runSummary.attributes?.items) {
           runSummary.attributes.items.forEach((item) => {
-            if (item.enabled) {
-              if (item.attachments && item.attachments.length > 0) {
+            if (item.enabled && item.attachments?.length > 0) {
+              if (!item.isQualityControl) {
                 item.attachments.forEach((itemFileIdentifier) => {
                   fileIdentifiers.push(itemFileIdentifier);
+                  itemsAttachments.push(itemFileIdentifier);
                 });
-                const itemFolderName =
-                  runSummary.attributes.name +
-                  "/" +
-                  (item?.genericMolecularAnalysisItemSummary?.name ??
-                    "Empty Name");
-                const uniqueItemFolderName =
-                  generateUniqueFolderName(itemFolderName);
-                exportLayout.set(uniqueItemFolderName, item.attachments);
+              } else {
+                item.attachments.forEach((itemFileIdentifier) => {
+                  fileIdentifiers.push(itemFileIdentifier);
+                  qaAttachments.push(itemFileIdentifier);
+                });
               }
             }
           });
+        }
+
+        // Add folders to exportLayout
+        if (runAttachments.length > 0) {
+          exportLayout.set(`${baseFolder}/`, runAttachments);
+        }
+        if (itemsAttachments.length > 0) {
+          exportLayout.set(`${baseFolder}/results`, itemsAttachments);
+        }
+        if (qaAttachments.length > 0) {
+          exportLayout.set(`${baseFolder}/qas`, qaAttachments);
         }
       });
     } else {
@@ -726,7 +738,6 @@ export default function useMolecularAnalysisExportAPI(): UseMolecularAnalysisExp
       setExportLoading(false);
       return;
     }
-
     const objectExportSaveArg = {
       resource: {
         type: "object-export",


### PR DESCRIPTION
- Changed logic to group results into one folder and qa's into one folder