### PR TITLE
Support #36370 - Upgrade to NodeJS 20.19.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20.19.1'
           cache: 'yarn'
       - run: yarn install 
 
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20.19.1'
           cache: 'yarn'
       - run: yarn install
       - name: Run all tests in chunk
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20.19.1'
           cache: 'yarn'
 
       - name: Install
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20.19.1'
       - name: Building ascii docs
         run: |
           yarn install

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ React based user interface for AAFC-DINA.
 
 ## Required
 
-- NodeJS (18)
+- NodeJS (20.19.1)
 - Yarn (1.22)
 
 ## Dependencies


### PR DESCRIPTION
- Upgraded readme to contain NodeJS 20.19.1.
- Updated github ci to now use NodeJS 20.19.1