### PR TITLE
36390 Paste zone for run item names does not maintain order

### DIFF
--- a/packages/common-ui/lib/table/ReactTable.tsx
+++ b/packages/common-ui/lib/table/ReactTable.tsx
@@ -15,7 +15,7 @@ import {
   useReactTable
 } from "@tanstack/react-table";
 import classnames from "classnames";
-import { Fragment, useEffect, useState } from "react";
+import { Dispatch, Fragment, SetStateAction, useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import { LoadingSpinner } from "../loading-spinner/LoadingSpinner";
 import { FilterInput } from "./FilterInput";
@@ -79,6 +79,8 @@ export interface ReactTableProps<TData> {
 
   // Hides the table rendering. Useful for accessing table states but don't want to render table
   hideTable?: boolean;
+
+  setResourceRowModel?: Dispatch<SetStateAction<Row<TData>[] | undefined>>;
 }
 
 const DEFAULT_SORT: SortingState = [
@@ -123,7 +125,8 @@ export function ReactTable<TData>({
   manualFiltering = false,
   onColumnFiltersChange,
   defaultColumnFilters = [],
-  hideTable = false
+  hideTable = false,
+  setResourceRowModel
 }: ReactTableProps<TData>) {
   const { formatMessage } = useIntl();
   const [sorting, setSorting] = useState<SortingState>(sort ?? DEFAULT_SORT);
@@ -239,6 +242,10 @@ export function ReactTable<TData>({
   };
 
   const table = useReactTable<TData>(tableOption);
+
+  useEffect(() => {
+    setResourceRowModel?.(table.getRowModel().rows);
+  }, table.getRowModel().rows);
 
   return !hideTable ? (
     <div

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/SequencingRunContentSection.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/SequencingRunContentSection.tsx
@@ -1,7 +1,7 @@
 import { CollapsibleSection, ReactTable } from "../../../../common-ui/lib";
 import { DinaMessage } from "../../../intl/dina-ui-intl";
 import { SequencingRunItem } from "./useGenericMolecularAnalysisRun";
-import { ColumnDef } from "@tanstack/table-core";
+import { ColumnDef, Row } from "@tanstack/table-core";
 import DataPasteZone from "../../molecular-analysis/DataPasteZone";
 import { Dispatch, SetStateAction, useState } from "react";
 
@@ -20,31 +20,32 @@ export default function SequencingRunContentSection({
   editMode,
   setMolecularAnalysisRunItemNames
 }: SequencingRunContentSectionProps) {
-  const [sequencingRunItemsInternal, setSequencingRunItemsInternal] = useState<
-    SequencingRunItem[] | undefined
-  >(sequencingRunItems);
+  const [rowModel, setRowModel] = useState<
+    Row<SequencingRunItem>[] | undefined
+  >([]);
   const onDataPaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const clipboardData = event.clipboardData.getData("text/plain");
     const names = clipboardData.trim().split("\n");
     const molecularAnalysisRunItemNamesMap = {};
-    if (sequencingRunItemsInternal) {
-      const newSequencingRunItems = [...sequencingRunItemsInternal];
+    if (rowModel) {
+      const newSequencingRunItems = [...rowModel];
       newSequencingRunItems?.forEach((sequencingRunitem, index) => {
-        const materialSampleId = sequencingRunitem.materialSampleId;
+        const materialSampleId = sequencingRunitem.original.materialSampleId;
         if (materialSampleId) {
           molecularAnalysisRunItemNamesMap[materialSampleId] = names[index];
-          if (!sequencingRunitem.molecularAnalysisRunItem) {
-            sequencingRunitem.molecularAnalysisRunItem = {
+          if (!sequencingRunitem.original.molecularAnalysisRunItem) {
+            sequencingRunitem.original.molecularAnalysisRunItem = {
               type: "molecular-analysis-run-item",
               name: names[index],
               usageType: ""
             };
           } else {
-            sequencingRunitem.molecularAnalysisRunItem.name = names[index];
+            sequencingRunitem.original.molecularAnalysisRunItem.name =
+              names[index];
           }
         }
       });
-      setSequencingRunItemsInternal(newSequencingRunItems);
+      setRowModel(newSequencingRunItems);
       setMolecularAnalysisRunItemNames?.(molecularAnalysisRunItemNamesMap);
     }
   };
@@ -63,6 +64,7 @@ export default function SequencingRunContentSection({
           data={sequencingRunItems ?? []}
           sort={[{ id: "materialSampleName", desc: false }]}
           showPagination={true}
+          setResourceRowModel={setRowModel}
         />
         {editMode && (
           <div className="mt-3">


### PR DESCRIPTION
- Added prop to ReactTable to pass the table's row model information to parent component
- The onDataPaste logic now uses the table's row model when assigning sequencing item names instead of the order that was returned by the back end