### PR TITLE
Support #36502 adapt UI code for collection api v2 managed attributes

### DIFF
--- a/packages/common-ui/lib/api-client/ApiClientContext.tsx
+++ b/packages/common-ui/lib/api-client/ApiClientContext.tsx
@@ -241,7 +241,8 @@ export class ApiClientImpl implements ApiClientI {
     const supportedBaseApis = [
       "/agent-api",
       "/dina-export-api",
-      "/objectstore-api"
+      "/objectstore-api",
+      "/collection-api"
     ];
 
     // Resource types that are supported for bulk operations.

--- a/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
+++ b/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
@@ -112,6 +112,39 @@ const mockGet = jest.fn<any, any>(async (path) => {
           }
         ]
       };
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.a":
+      return {
+        data: {
+          id: "1",
+          type: "managed-attribute",
+          vocabularyElementType: "STRING",
+          managedAttributeComponent: "MATERIAL_SAMPLE",
+          key: "a",
+          name: "Managed Attribute 1"
+        }
+      };
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.b":
+      return {
+        data: {
+          id: "2",
+          type: "managed-attribute",
+          vocabularyElementType: "STRING",
+          managedAttributeComponent: "MATERIAL_SAMPLE",
+          key: "b",
+          name: "Managed Attribute 2"
+        }
+      };
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.c":
+      return {
+        data: {
+          id: "3",
+          type: "managed-attribute",
+          vocabularyElementType: "STRING",
+          managedAttributeComponent: "MATERIAL_SAMPLE",
+          key: "c",
+          name: "Managed Attribute 3"
+        }
+      };
     case "agent-api/person":
     case "collection-api/collection":
     case "collection-api/collection-method":
@@ -134,40 +167,6 @@ const mockGet = jest.fn<any, any>(async (path) => {
   }
 });
 
-const mockBulkGet = jest.fn<any, any>(async (paths: string[]) => {
-  return paths.map((path) => {
-    switch (path) {
-      case "managed-attribute/MATERIAL_SAMPLE.a":
-        return {
-          id: "1",
-          type: "managed-attribute",
-          vocabularyElementType: "STRING",
-          managedAttributeComponent: "MATERIAL_SAMPLE",
-          key: "a",
-          name: "Managed Attribute 1"
-        };
-      case "managed-attribute/MATERIAL_SAMPLE.b":
-        return {
-          id: "2",
-          type: "managed-attribute",
-          vocabularyElementType: "STRING",
-          managedAttributeComponent: "MATERIAL_SAMPLE",
-          key: "b",
-          name: "Managed Attribute 2"
-        };
-      case "managed-attribute/MATERIAL_SAMPLE.c":
-        return {
-          id: "3",
-          type: "managed-attribute",
-          vocabularyElementType: "STRING",
-          managedAttributeComponent: "MATERIAL_SAMPLE",
-          key: "c",
-          name: "Managed Attribute 3"
-        };
-    }
-  });
-});
-
 const mockSave = jest.fn<any, any>((ops) =>
   ops.map((op) => ({
     ...op.resource,
@@ -178,8 +177,7 @@ const mockSave = jest.fn<any, any>((ops) =>
 const testCtx = {
   apiContext: {
     apiClient: { get: mockGet },
-    save: mockSave,
-    bulkGet: mockBulkGet
+    save: mockSave
   }
 };
 

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
@@ -45,6 +45,59 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           materialSampleName: "material-sample-500"
         }
       };
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.m1":
+      return Promise.resolve({
+        data: {
+          type: "managed-attribute",
+          id: "1",
+          key: "m1",
+          vocabularyElementType: "STRING",
+          managedAttributeComponent: "MATERIAL_SAMPLE",
+          name: "Managed Attribute 1"
+        }
+      });
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.m2":
+      return Promise.resolve({
+        data: {
+          type: "managed-attribute",
+          id: "2",
+          key: "m2",
+          vocabularyElementType: "STRING",
+          managedAttributeComponent: "MATERIAL_SAMPLE",
+          name: "Managed Attribute 2"
+        }
+      });
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.m3":
+      return Promise.resolve({
+        data: {
+          type: "managed-attribute",
+          id: "3",
+          key: "m3",
+          vocabularyElementType: "STRING",
+          managedAttributeComponent: "MATERIAL_SAMPLE",
+          name: "Managed Attribute 3"
+        }
+      });
+    case "managed-attribute/MATERIAL_SAMPLE.sample_attribute_1":
+      return Promise.resolve({
+        id: "1",
+        key: "sample_attribute_1",
+        name: "Attribute 1"
+      });
+    case "managed-attribute/DETERMINATION.determination_attribute_1":
+      return Promise.resolve({
+        id: "1",
+        key: "determination_attribute_1",
+        name: "Attribute 1"
+      });
+    case "managed-attribute/COLLECTING_EVENT.collecting_event_attribute_1":
+      return Promise.resolve({
+        data: {
+          id: "1",
+          key: "collecting_event_attribute_1",
+          name: "Attribute 1"
+        }
+      });
     case "collection-api/collecting-event/col-event-1?include=collectors,attachment,collectionMethod,protocol":
       return { data: TEST_COLLECTING_EVENT };
     case "collection-api/storage-unit":
@@ -128,49 +181,8 @@ const mockBulkGet = jest.fn<any, any>(async (paths: string[]) => {
           id: "initial-attachment-2",
           originalFileName: "initial-attachment-2"
         };
-      case "managed-attribute/MATERIAL_SAMPLE.m1":
-        return {
-          type: "managed-attribute",
-          id: "1",
-          key: "m1",
-          vocabularyElementType: "STRING",
-          managedAttributeComponent: "MATERIAL_SAMPLE",
-          name: "Managed Attribute 1"
-        };
-      case "managed-attribute/MATERIAL_SAMPLE.m2":
-        return {
-          type: "managed-attribute",
-          id: "2",
-          key: "m2",
-          vocabularyElementType: "STRING",
-          managedAttributeComponent: "MATERIAL_SAMPLE",
-          name: "Managed Attribute 2"
-        };
-      case "managed-attribute/MATERIAL_SAMPLE.m3":
-        return {
-          type: "managed-attribute",
-          id: "3",
-          key: "m3",
-          vocabularyElementType: "STRING",
-          managedAttributeComponent: "MATERIAL_SAMPLE",
-          name: "Managed Attribute 3"
-        };
       case "collection/1":
         return TEST_COLLECTION_1;
-      case "managed-attribute/MATERIAL_SAMPLE.sample_attribute_1":
-        return { id: "1", key: "sample_attribute_1", name: "Attribute 1" };
-      case "managed-attribute/DETERMINATION.determination_attribute_1":
-        return {
-          id: "1",
-          key: "determination_attribute_1",
-          name: "Attribute 1"
-        };
-      case "managed-attribute/COLLECTING_EVENT.collecting_event_attribute_1":
-        return {
-          id: "1",
-          key: "collecting_event_attribute_1",
-          name: "Attribute 1"
-        };
     }
   });
 });
@@ -194,7 +206,10 @@ const mockOnSaved = jest.fn();
 
 describe("MaterialSampleBulkEditor", () => {
   beforeEach(() => deleteFromStorage("test-user." + SAMPLE_FORM_TEMPLATE_KEY));
-  beforeEach(jest.clearAllMocks);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
 
   it("Bulk creates material samples.", async () => {
     const wrapper = mountWithAppContext(

--- a/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
+++ b/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
@@ -9,7 +9,9 @@ import {
 import {
   fireEvent,
   waitFor,
-  waitForElementToBeRemoved
+  waitForElementToBeRemoved,
+  screen,
+  within
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
@@ -146,6 +148,14 @@ const mockGet = jest.fn<any, any>(async (path) => {
         data: { id: "2", key: "attribute_2", name: "Attribute 2" }
       });
     case "collection-api/managed-attribute/COLLECTING_EVENT.attribute_3":
+      return Promise.resolve({
+        data: { id: "3", key: "attribute_3", name: "Attribute 3" }
+      });
+    case "collection-api/managed-attribute/ORGANISM.attribute_2":
+      return Promise.resolve({
+        data: { id: "2", key: "attribute_2", name: "Attribute 2" }
+      });
+    case "collection-api/managed-attribute/ORGANISM.attribute_3":
       return Promise.resolve({
         data: { id: "3", key: "attribute_3", name: "Attribute 3" }
       });
@@ -2545,14 +2555,12 @@ describe("Material Sample Edit Page", () => {
     userEvent.click(
       wrapper.getByRole("button", { name: /add new determination/i })
     );
-    await waitFor(() => {
-      expect(wrapper.queryByText(/attribute 2/i)).toBeInTheDocument();
-      expect(wrapper.queryByText(/attribute 3/i)).toBeInTheDocument();
-    });
 
-    // Attributes 2 and 3 are visible and empty:
-    expect(wrapper.queryByText(/attribute 2/i)).toBeInTheDocument();
-    expect(wrapper.queryByText(/attribute 3/i)).toBeInTheDocument();
+    const tabpanel = screen.getByRole("tabpanel");
+    await waitFor(() => {
+      expect(within(tabpanel).getByText(/attribute 2/i)).toBeInTheDocument();
+      expect(within(tabpanel).getByText(/attribute 3/i)).toBeInTheDocument();
+    });
   });
 
   describe("Collecting event permissions", () => {

--- a/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
+++ b/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
@@ -129,6 +129,34 @@ const mockGeographicSearchResults = [
 
 const mockGet = jest.fn<any, any>(async (path) => {
   switch (path) {
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.attribute_1":
+      return Promise.resolve({
+        data: { id: "1", key: "attribute_1", name: "Attribute 1" }
+      });
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.attribute_2":
+      return Promise.resolve({
+        data: { id: "2", key: "attribute_2", name: "Attribute 2" }
+      });
+    case "collection-api/managed-attribute/MATERIAL_SAMPLE.attribute_3":
+      return Promise.resolve({
+        data: { id: "3", key: "attribute_3", name: "Attribute 3" }
+      });
+    case "collection-api/managed-attribute/COLLECTING_EVENT.attribute_2":
+      return Promise.resolve({
+        data: { id: "2", key: "attribute_2", name: "Attribute 2" }
+      });
+    case "collection-api/managed-attribute/COLLECTING_EVENT.attribute_3":
+      return Promise.resolve({
+        data: { id: "3", key: "attribute_3", name: "Attribute 3" }
+      });
+    case "collection-api/managed-attribute/DETERMINATION.attribute_2":
+      return Promise.resolve({
+        data: { id: "2", key: "attribute_2", name: "Attribute 2" }
+      });
+    case "collection-api/managed-attribute/DETERMINATION.attribute_3":
+      return Promise.resolve({
+        data: { id: "3", key: "attribute_3", name: "Attribute 3" }
+      });
     case "collection-api/collecting-event":
       return { data: [testCollectionEvent()] };
     case "collection-api/collecting-event/1?include=collectors,attachment,collectionMethod,protocol":
@@ -191,30 +219,8 @@ const mockSave = jest.fn<any, any>(async (saves) => {
   });
 });
 
-const mockBulkGet = jest.fn<any, any>(async (paths: string[]) =>
-  paths.map((path) => {
-    switch (path) {
-      case "managed-attribute/MATERIAL_SAMPLE.attribute_1":
-        return { id: "1", key: "attribute_1", name: "Attribute 1" };
-      case "managed-attribute/MATERIAL_SAMPLE.attribute_2":
-        return { id: "2", key: "attribute_2", name: "Attribute 2" };
-      case "managed-attribute/MATERIAL_SAMPLE.attribute_3":
-        return { id: "3", key: "attribute_3", name: "Attribute 3" };
-      case "managed-attribute/COLLECTING_EVENT.attribute_2":
-        return { id: "2", key: "attribute_2", name: "Attribute 2" };
-      case "managed-attribute/COLLECTING_EVENT.attribute_3":
-        return { id: "3", key: "attribute_3", name: "Attribute 3" };
-      case "managed-attribute/DETERMINATION.attribute_2":
-        return { id: "2", key: "attribute_2", name: "Attribute 2" };
-      case "managed-attribute/DETERMINATION.attribute_3":
-        return { id: "3", key: "attribute_3", name: "Attribute 3" };
-    }
-  })
-);
-
 const testCtx = {
   apiContext: {
-    bulkGet: mockBulkGet,
     save: mockSave,
     apiClient: {
       get: mockGet

--- a/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
+++ b/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
@@ -88,13 +88,14 @@ export function ManagedAttributesEditor({
 
         // Fetch the attributes, but omit any that are missing e.g. were deleted.
 
-        const { dataWithNullForMissing: fetchedAttributes, loading } =
-          useManagedAttributeQueries({
+        const { data: fetchedAttributes, loading } = useManagedAttributeQueries(
+          {
             keys: visibleAttributeKeys,
             managedAttributeApiPath,
             managedAttributeComponent,
             disabled: !visibleAttributeKeys.length
-          });
+          }
+        );
 
         // Store the last fetched Attributes in a ref instead of showing a
         // loading state when the visible attributes change.
@@ -105,7 +106,7 @@ export function ManagedAttributesEditor({
         if (!visibleAttributeKeys.length) {
           lastFetchedAttributes.current = [];
         } else if (fetchedAttributes) {
-          lastFetchedAttributes.current = _.compact(fetchedAttributes);
+          lastFetchedAttributes.current = fetchedAttributes;
         }
 
         const visibleAttributes = lastFetchedAttributes.current;
@@ -135,9 +136,9 @@ export function ManagedAttributesEditor({
                             values={values}
                             valuesPath={valuesPath}
                             onRemoveClick={(attributeKey) =>
-                              setVisibleAttributeKeys((current) => {
-                                current.filter((it) => it != attributeKey);
-                              })
+                              setVisibleAttributeKeys((current) =>
+                                current.filter((it) => it != attributeKey)
+                              )
                             }
                           />
                         ))}

--- a/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
+++ b/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
@@ -87,12 +87,13 @@ export function ManagedAttributesEditor({
         }, [visibleAttributeKeysProp]);
 
         // Fetch the attributes, but omit any that are missing e.g. were deleted.
+
         const { dataWithNullForMissing: fetchedAttributes, loading } =
           useManagedAttributeQueries({
             keys: visibleAttributeKeys,
             managedAttributeApiPath,
             managedAttributeComponent,
-            disabled: false
+            disabled: !visibleAttributeKeys.length
           });
 
         // Store the last fetched Attributes in a ref instead of showing a
@@ -100,7 +101,10 @@ export function ManagedAttributesEditor({
         const lastFetchedAttributes = useRef<
           PersistedResource<ManagedAttribute>[]
         >([]);
-        if (fetchedAttributes) {
+
+        if (!visibleAttributeKeys.length) {
+          lastFetchedAttributes.current = [];
+        } else if (fetchedAttributes) {
           lastFetchedAttributes.current = _.compact(fetchedAttributes);
         }
 
@@ -131,9 +135,9 @@ export function ManagedAttributesEditor({
                             values={values}
                             valuesPath={valuesPath}
                             onRemoveClick={(attributeKey) =>
-                              setVisibleAttributeKeys((current) =>
-                                current.filter((it) => it !== attributeKey)
-                              )
+                              setVisibleAttributeKeys((current) => {
+                                current.filter((it) => it != attributeKey);
+                              })
                             }
                           />
                         ))}

--- a/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
+++ b/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
@@ -5,16 +5,16 @@ import {
   filterBy,
   ResourceSelect,
   useBulkEditTabContext,
-  useBulkGet,
   useDinaFormContext
 } from "common-ui";
 import { PersistedResource } from "kitsu";
-import _ from "lodash";
 import { useEffect, useRef, useState } from "react";
 import { DinaMessage } from "../../intl/dina-ui-intl";
 import { ManagedAttribute } from "../../types/collection-api";
 import { ManagedAttributesSorter } from "./managed-attributes-custom-views/ManagedAttributesSorter";
 import { ManagedAttributeFieldWithLabel } from "./ManagedAttributeField";
+import { useManagedAttributeQueries } from "./useManagedAttributeQueries";
+import _ from "lodash";
 
 export interface ManagedAttributesEditorProps {
   /** Formik path to the ManagedAttribute values field. */
@@ -88,12 +88,11 @@ export function ManagedAttributesEditor({
 
         // Fetch the attributes, but omit any that are missing e.g. were deleted.
         const { dataWithNullForMissing: fetchedAttributes, loading } =
-          useBulkGet<ManagedAttribute>({
-            ids: visibleAttributeKeys.map((key) =>
-              // Use the component prefix if needed by the back-end:
-              _.compact([managedAttributeComponent, key]).join(".")
-            ),
-            listPath: managedAttributeApiPath
+          useManagedAttributeQueries({
+            keys: visibleAttributeKeys,
+            managedAttributeApiPath,
+            managedAttributeComponent,
+            disabled: false
           });
 
         // Store the last fetched Attributes in a ref instead of showing a

--- a/packages/dina-ui/components/managed-attributes/__tests__/ManagedAttributesEditor.test.tsx
+++ b/packages/dina-ui/components/managed-attributes/__tests__/ManagedAttributesEditor.test.tsx
@@ -122,15 +122,37 @@ describe("ManagedAttributesEditor component", () => {
 
     // Wait for the data to load and ensure mockBulkGet was called with expected arguments.
     await waitFor(() => {
-      expect(mockBulkGet.mock.calls).toEqual([
+      expect(mockGet.mock.calls).toEqual([
         [
-          [
-            "managed-attribute/COLLECTING_EVENT.example_attribute_1",
-            "managed-attribute/COLLECTING_EVENT.example_attribute_2"
-          ],
+          "collection-api/managed-attribute",
           {
-            apiBaseUrl: "/collection-api",
-            returnNullForMissingResource: true
+            filter: {
+              managedAttributeComponent: "COLLECTING_EVENT"
+            },
+            page: {
+              limit: 6
+            },
+            sort: "-createdOn"
+          }
+        ],
+        [
+          "collection-api/managed-attribute/COLLECTING_EVENT.example_attribute_1",
+          {
+            header: {
+              Accept: "application/vnd.api+json",
+              "Content-Type": "application/vnd.api+json",
+              "Crnk-Compact": "true"
+            }
+          }
+        ],
+        [
+          "collection-api/managed-attribute/COLLECTING_EVENT.example_attribute_2",
+          {
+            header: {
+              Accept: "application/vnd.api+json",
+              "Content-Type": "application/vnd.api+json",
+              "Crnk-Compact": "true"
+            }
           }
         ]
       ]);

--- a/packages/dina-ui/components/managed-attributes/useManagedAttributeQueries.tsx
+++ b/packages/dina-ui/components/managed-attributes/useManagedAttributeQueries.tsx
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 import { useApiClient } from "common-ui";
 import { ManagedAttribute } from "packages/dina-ui/types/collection-api";
+import _ from "lodash";
 
 export interface UseBulkGetParams {
   managedAttributeApiPath: string;
@@ -27,16 +28,19 @@ export interface UseBulkGetParams {
  */
 export function useManagedAttributeQueries({
   managedAttributeApiPath,
-  managedAttributeComponent,
+  managedAttributeComponent = "",
   keys,
   disabled = false
 }: UseBulkGetParams) {
   const { apiClient } = useApiClient();
 
   const fetchResources = async (keys: string[]) => {
-    const paths = keys.map(
-      (key) => `${managedAttributeApiPath}/${managedAttributeComponent}.${key}`
-    );
+    const paths = managedAttributeComponent
+      ? keys.map(
+          (key) =>
+            `${managedAttributeApiPath}/${managedAttributeComponent}.${key}`
+        )
+      : keys.map((key) => `${managedAttributeApiPath}/${key}`);
 
     const headers = {
       Accept: "application/vnd.api+json",
@@ -57,9 +61,7 @@ export function useManagedAttributeQueries({
     const results = await Promise.all(caught_promises);
 
     // Filter out any null results (e.g. if the resource was not found).
-    return results
-      .filter((result) => result !== null)
-      .map((result) => result.data);
+    return _.compact(results).map((result) => result.data);
   };
 
   const shouldFetch = keys?.length > 0 && !disabled;

--- a/packages/dina-ui/components/managed-attributes/useManagedAttributeQueries.tsx
+++ b/packages/dina-ui/components/managed-attributes/useManagedAttributeQueries.tsx
@@ -1,0 +1,54 @@
+import useSWR from "swr";
+import { useApiClient } from "common-ui";
+import { ManagedAttribute } from "packages/dina-ui/types/collection-api";
+
+export interface UseBulkGetParams {
+  managedAttributeApiPath: string;
+  managedAttributeComponent?: string;
+  keys: string[];
+  disabled?: boolean;
+  /** onSuccess callback. */
+}
+
+export function useManagedAttributeQueries({
+  managedAttributeApiPath,
+  managedAttributeComponent,
+  keys,
+  disabled = false
+}: UseBulkGetParams) {
+  const { apiClient } = useApiClient();
+
+  const fetchResources = async (keys: string[]) => {
+    const paths = keys.map(
+      (key) => `${managedAttributeApiPath}/${managedAttributeComponent}.${key}`
+    );
+
+    const headers = {
+      Accept: "application/vnd.api+json",
+      "Content-Type": "application/vnd.api+json",
+      "Crnk-Compact": "true"
+    };
+
+    const results = await Promise.all(
+      paths.map((url) =>
+        apiClient.get<ManagedAttribute>(url, { header: headers })
+      )
+    );
+
+    return results.map((result) => result.data);
+  };
+
+  const shouldFetch = keys?.length > 0 && !disabled;
+
+  const { data: fetchResponse, isValidating } = useSWR(
+    shouldFetch ? keys : null,
+    () => fetchResources(keys),
+    {
+      revalidateOnFocus: false
+    }
+  );
+
+  const dataWithNullForMissing = fetchResponse;
+
+  return { dataWithNullForMissing, loading: isValidating };
+}

--- a/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
@@ -1,11 +1,11 @@
-import { makeAxiosErrorMoreReadable, OperationsResponse } from "common-ui";
+import { OperationsResponse } from "common-ui";
 import CollectingEventEditPage from "../../../../pages/collection/collecting-event/edit";
 import { mountWithAppContext } from "common-ui";
 import { Person } from "../../../../types/agent-api/resources/Person";
 import { CollectingEvent } from "../../../../types/collection-api/resources/CollectingEvent";
 import { CoordinateSystem } from "../../../../types/collection-api/resources/CoordinateSystem";
 import { SRS } from "../../../../types/collection-api/resources/SRS";
-import { fireEvent, waitFor, screen } from "@testing-library/react";
+import { fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -211,7 +211,6 @@ describe("collecting-event edit page", () => {
       apiContext
     });
 
-    screen.logTestingPlaygroundURL(); // For debugging purposes --- IGNORE ---
     // Edit the verbatim datetime
     fireEvent.change(
       wrapper.getByRole("textbox", { name: /verbatim event datetime/i }),
@@ -329,20 +328,16 @@ describe("collecting-event edit page", () => {
     await waitFor(() => {
       expect(mockPatch).toBeCalledTimes(1);
       expect(mockPatch).lastCalledWith(
-        "/collection-api/operations",
-        [
-          {
-            op: "PATCH",
-            path: "collecting-event/1",
-            value: {
-              attributes: {
-                verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 6pm"
-              },
-              id: "1",
-              type: "collecting-event"
-            }
+        "/collection-api/collecting-event/1",
+        {
+          data: {
+            attributes: {
+              verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 6pm"
+            },
+            id: "1",
+            type: "collecting-event"
           }
-        ],
+        },
         expect.anything()
       );
     });
@@ -387,20 +382,16 @@ describe("collecting-event edit page", () => {
     await waitFor(() => {
       expect(mockPatch).toBeCalledTimes(1);
       expect(mockPatch).lastCalledWith(
-        "/collection-api/operations",
-        [
-          {
-            op: "PATCH",
-            path: "collecting-event/1",
-            value: {
-              attributes: {
-                otherRecordNumbers: null
-              },
-              id: "1",
-              type: "collecting-event"
-            }
+        "/collection-api/collecting-event/1",
+        {
+          data: {
+            attributes: {
+              otherRecordNumbers: null
+            },
+            id: "1",
+            type: "collecting-event"
           }
-        ],
+        },
         expect.anything()
       );
     });
@@ -433,7 +424,7 @@ describe("collecting-event edit page", () => {
     })();
 
     mockPost.mockImplementationOnce(() => {
-      return Promise.reject(makeAxiosErrorMoreReadable(MOCK_POST_ERROR));
+      return Promise.reject(MOCK_POST_ERROR);
     });
 
     mockQuery = {};
@@ -466,7 +457,6 @@ describe("collecting-event edit page", () => {
     // Test for expected error
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    screen.logTestingPlaygroundURL(); // For debugging purposes --- IGNORE ---
     await waitFor(() => {
       expect(
         wrapper.getByText(
@@ -526,12 +516,15 @@ describe("collecting-event edit page", () => {
         "/collection-api/collecting-event",
         {
           data: {
-            attributes: expect.objectContaining({
-              dwcVerbatimCoordinateSystem: null
-            })
-          },
-          id: "00000000-0000-0000-0000-000000000000",
-          type: "collecting-event"
+            attributes: {
+              dwcVerbatimCoordinateSystem: null,
+              dwcVerbatimSRS: "WGS84 (EPSG:4326)",
+              publiclyReleasable: true, // Default value
+              geoReferenceAssertions: [{ isPrimary: true }]
+            },
+            id: "00000000-0000-0000-0000-000000000000",
+            type: "collecting-event"
+          }
         },
         expect.anything()
       );

--- a/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
@@ -191,7 +191,7 @@ describe("collecting-event edit page", () => {
 
   it("Lets you add georeference assertions on a new Collecting Event.", async () => {
     // Return the collecting event so it can then be attached to the new georeference assertion:
-    mockGet.mockReturnValueOnce(
+    mockPost.mockReturnValueOnce(
       Promise.resolve({
         data: {
           data: {
@@ -205,8 +205,6 @@ describe("collecting-event edit page", () => {
       } as any)
     );
 
-    mockQuery = { id: 1 };
-
     const wrapper = mountWithAppContext(<CollectingEventEditPage />, {
       apiContext
     });
@@ -216,7 +214,6 @@ describe("collecting-event edit page", () => {
       wrapper.getByRole("textbox", { name: /verbatim event datetime/i }),
       {
         target: {
-          name: "verbatimEventDateTime",
           value: "From 2019,12,21 4pm to 2019,12,22 5pm"
         }
       }
@@ -256,29 +253,30 @@ describe("collecting-event edit page", () => {
     // Saves the collecting event and the georeference assertion in separate requests:
     // (The collecting event id is required to save the georeference assertion)
     await waitFor(() => {
-      expect(mockPost.mock.calls).toEqual([
-        [
-          "/collection-api/collecting-event/1",
-          {
-            value: {
-              attributes: expect.objectContaining({
-                geoReferenceAssertions: [
-                  {
-                    isPrimary: true,
-                    dwcCoordinateUncertaintyInMeters: "5",
-                    dwcDecimalLatitude: "45.394728",
-                    dwcDecimalLongitude: "-75.701452"
-                  }
-                ],
-                verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 5pm"
-              }),
-              id: "1",
-              type: "collecting-event"
-            }
-          },
-          expect.anything()
-        ]
-      ]);
+      expect(mockPost).lastCalledWith(
+        "/collection-api/collecting-event",
+        {
+          data: {
+            attributes: {
+              geoReferenceAssertions: [
+                {
+                  isPrimary: true,
+                  dwcCoordinateUncertaintyInMeters: "5",
+                  dwcDecimalLatitude: "45.394728",
+                  dwcDecimalLongitude: "-75.701452"
+                }
+              ],
+              dwcVerbatimSRS: "WGS84 (EPSG:4326)",
+              dwcVerbatimCoordinateSystem: null,
+              publiclyReleasable: true,
+              verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 5pm"
+            },
+            id: "00000000-0000-0000-0000-000000000000",
+            type: "collecting-event"
+          }
+        },
+        expect.anything()
+      );
     });
   });
 

--- a/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
@@ -98,22 +98,24 @@ describe("collecting-event edit page", () => {
     mockQuery = {};
   });
   it("Provides a form to add a collecting-event.", async () => {
-    mockPatch.mockReturnValueOnce({
-      data: [
-        {
+    mockPost
+      .mockReturnValueOnce(Promise.resolve("default"))
+      .mockReturnValueOnce(
+        Promise.resolve({
           data: {
-            attributes: {
-              startEventDateTime: "12/21/2019T16:00",
-              endEventDateTime: "12/22/2019T16:00",
-              verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 4pm"
-            },
-            id: "1",
-            type: "collecting-event"
+            data: {
+              attributes: {
+                startEventDateTime: "12/21/2019T16:00",
+                endEventDateTime: "12/22/2019T16:00",
+                verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 4pm"
+              },
+              id: "1",
+              type: "collecting-event"
+            }
           },
           status: 201
-        }
-      ] as OperationsResponse
-    });
+        })
+      );
 
     mockQuery = {};
 
@@ -162,26 +164,23 @@ describe("collecting-event edit page", () => {
 
     // Test expected API Response
     await waitFor(() => {
-      expect(mockPatch).lastCalledWith(
-        "/collection-api/operations",
-        [
-          {
-            op: "POST",
-            path: "collecting-event",
-            value: {
-              attributes: {
-                dwcVerbatimCoordinateSystem: null,
-                dwcVerbatimSRS: "WGS84 (EPSG:4326)",
-                publiclyReleasable: true, // Default value
-                verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 5pm",
-                otherRecordNumbers: ["12", "23"],
-                geoReferenceAssertions: [{ isPrimary: true }]
-              },
-              id: "00000000-0000-0000-0000-000000000000",
-              type: "collecting-event"
-            }
+      expect(mockPost).lastCalledWith(
+        "/collection-api/collecting-event",
+
+        {
+          data: {
+            attributes: {
+              dwcVerbatimCoordinateSystem: null,
+              dwcVerbatimSRS: "WGS84 (EPSG:4326)",
+              publiclyReleasable: true, // Default value
+              verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 5pm",
+              otherRecordNumbers: ["12", "23"],
+              geoReferenceAssertions: [{ isPrimary: true }]
+            },
+            id: "00000000-0000-0000-0000-000000000000",
+            type: "collecting-event"
           }
-        ],
+        },
         expect.anything()
       );
     });
@@ -192,20 +191,19 @@ describe("collecting-event edit page", () => {
 
   it("Lets you add georeference assertions on a new Collecting Event.", async () => {
     // Return the collecting event so it can then be attached to the new georeference assertion:
-    mockPatch.mockReturnValueOnce({
-      data: [
-        {
+    mockGet.mockReturnValueOnce(
+      Promise.resolve({
+        data: {
           data: {
             attributes: {
               startEventDateTime: "12/21/2019T16:00"
             },
             id: "1",
             type: "collecting-event"
-          },
-          status: 201
+          }
         }
-      ] as OperationsResponse
-    });
+      } as any)
+    );
 
     const wrapper = mountWithAppContext(<CollectingEventEditPage />, {
       apiContext

--- a/packages/dina-ui/page-tests/collection/preparation-method/__test__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/preparation-method/__test__/edit.test.tsx
@@ -3,7 +3,7 @@ import PreparationMethodEditPage, {
   PreparationMethodForm
 } from "../../../../pages/collection/preparation-method/edit";
 import { mountWithAppContext } from "common-ui";
-import { fireEvent, waitFor, screen } from "@testing-library/react";
+import { fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 const INSTANCE_DATA = {
@@ -232,7 +232,7 @@ describe("preparation-method edit page", () => {
         url: "/collection-api/preparation-method"
       };
       error.response = {
-        responseURL: "/collection-api/preparation-method",
+        statusText: "422",
         data: {
           errors: [
             {
@@ -262,10 +262,9 @@ describe("preparation-method edit page", () => {
 
     // Test expected error
     await waitFor(() => {
-      screen.logTestingPlaygroundURL();
       expect(
-        screen.getByText(
-          /: undefined constraint violation: name must not be blank/i
+        wrapper.getByText(
+          /\/collection\-api\/preparation\-method: 422 constraint violation: name must not be blank/i
         )
       ).toBeInTheDocument();
       expect(mockPush).toBeCalledTimes(0);

--- a/packages/dina-ui/page-tests/collection/preparation-method/__test__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/preparation-method/__test__/edit.test.tsx
@@ -1,9 +1,9 @@
-import { OperationsResponse } from "common-ui";
+import { makeAxiosErrorMoreReadable } from "common-ui";
 import PreparationMethodEditPage, {
   PreparationMethodForm
 } from "../../../../pages/collection/preparation-method/edit";
 import { mountWithAppContext } from "common-ui";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { fireEvent, waitFor, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 const INSTANCE_DATA = {
@@ -72,8 +72,12 @@ const mockGet = jest.fn(async (path) => {
 
 // Mock API requests:
 const mockPatch = jest.fn();
+const mockPost = jest.fn();
 const apiContext: any = {
-  apiClient: { get: mockGet, axios: { patch: mockPatch, get: mockGetAxios } }
+  apiClient: {
+    get: mockGet,
+    axios: { patch: mockPatch, get: mockGetAxios, post: mockPost }
+  }
 };
 
 describe("preparation-method edit page", () => {
@@ -82,16 +86,14 @@ describe("preparation-method edit page", () => {
     mockQuery = {};
   });
   it("Provides a form to add a preparation-method.", async () => {
-    mockPatch.mockReturnValueOnce({
-      data: [
-        {
-          data: {
-            id: "1",
-            type: "preparation-method"
-          },
-          status: 201
+    mockPost.mockReturnValueOnce({
+      data: {
+        data: {
+          id: "1",
+          type: "preparation-method"
         }
-      ] as OperationsResponse
+      },
+      status: 201
     });
 
     mockQuery = {};
@@ -123,26 +125,27 @@ describe("preparation-method edit page", () => {
 
     // Test expected API response
     await waitFor(() => {
-      expect(mockPatch).lastCalledWith(
-        "/collection-api/operations",
-        [
-          {
-            op: "POST",
-            path: "preparation-method",
-            value: {
-              attributes: {
-                multilingualDescription: {
-                  descriptions: [
-                    { lang: "en", desc: "test english description" }
-                  ]
-                },
-                name: "updated Name"
+      expect(mockPost).lastCalledWith(
+        "/collection-api/preparation-method",
+
+        {
+          data: {
+            attributes: {
+              multilingualDescription: {
+                descriptions: [
+                  {
+                    desc: "test english description",
+                    lang: "en"
+                  }
+                ]
               },
-              id: "00000000-0000-0000-0000-000000000000",
-              type: "preparation-method"
-            }
+              name: "updated Name"
+            },
+            id: "00000000-0000-0000-0000-000000000000",
+            type: "preparation-method"
           }
-        ],
+        },
+
         expect.anything()
       );
     });
@@ -158,6 +161,7 @@ describe("preparation-method edit page", () => {
       <PreparationMethodForm
         onSaved={mockOnSaved}
         fetchedPrepMethod={{
+          id: "00000000-0000-0000-0000-000000000000",
           name: "test-prep-method",
           type: "preparation-method",
           multilingualDescription: {
@@ -189,32 +193,30 @@ describe("preparation-method edit page", () => {
     // Test expected API response
     await waitFor(() => {
       expect(mockPatch).lastCalledWith(
-        "/collection-api/operations",
-        [
-          {
-            op: "POST",
-            path: "preparation-method",
-            value: {
-              attributes: {
-                multilingualDescription: {
-                  descriptions: [
-                    {
-                      desc: "test english description",
-                      lang: "en"
-                    },
-                    {
-                      desc: "test french description",
-                      lang: "fr"
-                    }
-                  ]
-                },
-                name: "test-prep-method"
+        "/collection-api/preparation-method/00000000-0000-0000-0000-000000000000",
+
+        {
+          data: {
+            attributes: {
+              multilingualDescription: {
+                descriptions: [
+                  {
+                    desc: "test english description",
+                    lang: "en"
+                  },
+                  {
+                    desc: "test french description",
+                    lang: "fr"
+                  }
+                ]
               },
-              id: "00000000-0000-0000-0000-000000000000",
-              type: "preparation-method"
-            }
+              name: "test-prep-method"
+            },
+            id: "00000000-0000-0000-0000-000000000000",
+            type: "preparation-method"
           }
-        ],
+        },
+
         expect.anything()
       );
     });
@@ -222,20 +224,32 @@ describe("preparation-method edit page", () => {
 
   it("Renders an error after form submit without specifying mandatory field.", async () => {
     // The patch request will return an error.
-    mockPatch.mockImplementationOnce(() => ({
-      data: [
-        {
+
+    const MOCK_POST_ERROR = (() => {
+      const error = new Error() as any;
+      error.isAxiosError = true;
+      error.config = {
+        url: "/collection-api/preparation-method"
+      };
+      error.response = {
+        responseURL: "/collection-api/preparation-method",
+        data: {
           errors: [
             {
-              detail: "Name is mandatory",
-              status: "422",
+              status: 422,
+              detail: "name must not be blank",
               title: "Constraint violation"
             }
-          ],
-          status: 422
+          ]
         }
-      ] as OperationsResponse
-    }));
+      };
+
+      return error;
+    })();
+
+    mockPost.mockImplementationOnce(() => {
+      makeAxiosErrorMoreReadable(MOCK_POST_ERROR);
+    });
 
     mockQuery = {};
 
@@ -248,8 +262,11 @@ describe("preparation-method edit page", () => {
 
     // Test expected error
     await waitFor(() => {
+      screen.logTestingPlaygroundURL();
       expect(
-        wrapper.getByText(/constraint violation: name is mandatory/i)
+        screen.getByText(
+          /: undefined constraint violation: name must not be blank/i
+        )
       ).toBeInTheDocument();
       expect(mockPush).toBeCalledTimes(0);
     });

--- a/packages/dina-ui/page-tests/object-store/metadata/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/object-store/metadata/__tests__/edit.test.tsx
@@ -17,6 +17,15 @@ const mockGet = jest.fn(async (path) => {
       return { data: TEST_LICENSES };
     case "objectstore-api/license/open-government-license-canada":
       return { data: TEST_LICENSES[0] };
+    case "objectstore-api/managed-attribute/test_managed_attribute":
+      return Promise.resolve({
+        data: {
+          id: "a360a695-bbff-4d58-9a07-b6d6c134b208",
+          name: "test-managed-attribute",
+          key: "test_managed_attribute",
+          vocabularyElementType: "STRING"
+        }
+      });
     case "agent-api/person":
     case "objectstore-api/metadata":
     case "objectstore-api/object-subtype":
@@ -32,13 +41,6 @@ const mockBulkGet = jest.fn<any, any>(async (paths: string[]) =>
           id: "6e80e42a-bcf6-4062-9db3-946e0f26458f",
           type: "person",
           displayName: "Mat Poff"
-        };
-      case "managed-attribute/test_managed_attribute":
-        return {
-          id: "a360a695-bbff-4d58-9a07-b6d6c134b208",
-          name: "test-managed-attribute",
-          key: "test_managed_attribute",
-          vocabularyElementType: "STRING"
         };
     }
   })


### PR DESCRIPTION
-collection-api now uses skipOperationForSingleRequest for all doOperations calls
-fixed unit tests that broke as a result of this change
-added new hook in managedAttributeEditor that does parallel single queries using keys for managedAttributes