### PR TITLE
Support #36580 bulk edit tab warning has typos

### DIFF
--- a/packages/dina-ui/components/bulk-edit/BulkEditTabWarning.tsx
+++ b/packages/dina-ui/components/bulk-edit/BulkEditTabWarning.tsx
@@ -69,7 +69,7 @@ export function BulkEditTabWarning({
         );
       }
     }
-  }, [bulkEditCtx, bulkField]);
+  }, []);
 
   if (bulkEditCtx && bulkField) {
     const { hasBulkEditValue, hasNoValues, hasSameValues } = bulkField;

--- a/packages/dina-ui/components/bulk-edit/BulkEditTabWarning.tsx
+++ b/packages/dina-ui/components/bulk-edit/BulkEditTabWarning.tsx
@@ -96,6 +96,7 @@ export function BulkEditTabWarning({
         <FieldSpy fieldName={fieldName}>
           {(fieldValue: Array<any>, { bulkContext }) =>
             bulkContext?.hasBulkEditValue && fieldValue.length ? (
+              // Show a different warning when there are multiple values
               <div className="alert alert-warning">
                 {fieldValue.length == 1 ? (
                   <DinaMessage id={messageIdSingle as any} />

--- a/packages/dina-ui/components/bulk-edit/BulkEditTabWarning.tsx
+++ b/packages/dina-ui/components/bulk-edit/BulkEditTabWarning.tsx
@@ -13,15 +13,33 @@ import { DinaMessage } from "../../intl/dina-ui-intl";
 
 export interface BulkEditTabWarningProps {
   fieldName: string;
-  targetType: string;
+  messageIdSingle: string;
+  messageIdMultiple: string;
   setDefaultValue?: (ctx: BulkEditTabContextI) => void;
   showWarningWhenValuesAreTheSame?: boolean;
 }
 
+/**
+ * Displays a warning and override option in bulk edit tabs when multiple values are detected for a field.
+ *
+ * This component checks the bulk edit context and field state to determine whether to show a warning
+ * about multiple values, and provides an "Override All" button to set a default value for all items.
+ * The warning and override button are conditionally rendered based on the field's state and props.
+ *
+ * @param fieldName - The name of the field being edited in bulk.
+ * @param setDefaultValue - Optional callback to set the default value for the field in the bulk edit context.
+ * @param messageIdSingle - DinaMessage ID to display when only one value is present.
+ * @param messageIdMultiple - DinaMessage ID to display when multiple values are present.
+ * @param children - Child components to render within the warning container.
+ * @param showWarningWhenValuesAreTheSame - If false, suppresses the warning when all values are the same.
+ *
+ * @returns JSX element displaying the warning and override button, or just children if no warning is needed.
+ */
 export function BulkEditTabWarning({
   fieldName,
   setDefaultValue,
-  targetType,
+  messageIdSingle,
+  messageIdMultiple,
   children,
   showWarningWhenValuesAreTheSame
 }: PropsWithChildren<BulkEditTabWarningProps>) {
@@ -51,7 +69,7 @@ export function BulkEditTabWarning({
         );
       }
     }
-  }, []);
+  }, [bulkEditCtx, bulkField]);
 
   if (bulkEditCtx && bulkField) {
     const { hasBulkEditValue, hasNoValues, hasSameValues } = bulkField;
@@ -76,16 +94,14 @@ export function BulkEditTabWarning({
     return skipBulkEditWarning || override ? (
       <div>
         <FieldSpy fieldName={fieldName}>
-          {(_, { bulkContext }) =>
-            bulkContext?.hasBulkEditValue ? (
+          {(fieldValue: Array<any>, { bulkContext }) =>
+            bulkContext?.hasBulkEditValue && fieldValue.length ? (
               <div className="alert alert-warning">
-                <DinaMessage
-                  id="bulkEditResourceSetWarningMulti"
-                  values={{
-                    targetType: getFieldLabel({ name: targetType }).fieldLabel,
-                    fieldName: getFieldLabel({ name: fieldName }).fieldLabel
-                  }}
-                />
+                {fieldValue.length == 1 ? (
+                  <DinaMessage id={messageIdSingle as any} />
+                ) : (
+                  <DinaMessage id={messageIdMultiple as any} />
+                )}
               </div>
             ) : null
           }
@@ -123,6 +139,7 @@ export function BulkEditTabWarning({
             <DinaMessage id="overrideAll" />
           </FormikButton>
         </div>
+        <div>{children}</div>
       </div>
     );
   }

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
@@ -953,16 +953,16 @@ describe("MaterialSampleBulkEditor", () => {
     }
 
     // Organisms section opens with an initial value, so it has the green indicator on the fieldset:
-    await waitFor(() =>
+    await waitFor(() => {
       expect(
         wrapper.getByText(
-          /these organisms will be set on all material samples\./i
+          /this organism will be linked to all material samples\./i
         )
-      ).toBeInTheDocument()
-    );
+      ).toBeInTheDocument();
+    });
     expect(
       wrapper.getByText(
-        /these organisms will be set on all material samples\./i
+        /this organism will be linked to all material samples\./i
       )
     ).toBeInTheDocument();
 
@@ -970,21 +970,22 @@ describe("MaterialSampleBulkEditor", () => {
     // so they don't initially show the green indicator on the fieldset:
     expect(
       wrapper.queryByText(
-        /these attachments will be set on all material samples\./i
+        /this attachment will be linked to all material samples\./i
       )
     ).not.toBeInTheDocument();
 
     // Associations list section opens with an initial value, so it has the green indicator on the fieldset:
+
     expect(
       wrapper.getByText(
-        /these associationss will be set on all material samples\./i
+        /this association will be set on all material samples\./i
       )
     ).toBeInTheDocument();
 
     // Scheduled should not display it as well:
     expect(
       wrapper.queryByText(
-        /these scheduled actions will be set on all material samples\./i
+        /this attachment will be linked to all material samples\./i
       )
     ).not.toBeInTheDocument();
 

--- a/packages/dina-ui/components/collection/MaterialSampleAssociationsField.tsx
+++ b/packages/dina-ui/components/collection/MaterialSampleAssociationsField.tsx
@@ -45,7 +45,8 @@ export function MaterialSampleAssociationsField({
       // Wrap in the bulk edit tab warning in case this is bulk edit mode:
       wrapContent={(content) => (
         <BulkEditTabWarning
-          targetType="material-sample"
+          messageIdSingle="bulkEditResourceSetWarning_Associations_MaterialSample_Single"
+          messageIdMultiple="bulkEditResourceSetWarning_Associations_MaterialSample_Multi"
           fieldName={fieldName}
           setDefaultValue={(ctx) =>
             // Auto-create the first association:

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -335,7 +335,8 @@ export function MaterialSampleForm({
           id={id}
           wrapContent={(content) => (
             <BulkEditTabWarning
-              targetType="material-sample"
+              messageIdSingle="bulkEditResourceSetWarning_ScheduledActions_MaterialSample_Single"
+              messageIdMultiple="bulkEditResourceSetWarning_ScheduledActions_MaterialSample_Multi"
               fieldName="scheduledActions"
             >
               {content}
@@ -404,7 +405,8 @@ export function MaterialSampleForm({
             attachmentPath={`collection-api/material-sample/${materialSample?.id}/attachment`}
             wrapContent={(content) => (
               <BulkEditTabWarning
-                targetType="material-sample"
+                messageIdSingle="bulkEditResourceLinkerWarning_Attachments_MaterialSample_Single"
+                messageIdMultiple="bulkEditResourceLinkerWarning_Attachments_MaterialSample_Multi"
                 fieldName={attachmentsField}
               >
                 {content}

--- a/packages/dina-ui/components/collection/material-sample/OrganismsField.tsx
+++ b/packages/dina-ui/components/collection/material-sample/OrganismsField.tsx
@@ -74,7 +74,8 @@ export function OrganismsField({
       componentName={ORGANISMS_COMPONENT_NAME}
     >
       <BulkEditTabWarning
-        targetType="material-sample"
+        messageIdSingle="bulkEditResourceLinkerWarning_Organisms_MaterialSample_Single"
+        messageIdMultiple="bulkEditResourceLinkerWarning_Organisms_MaterialSample_Multi"
         fieldName={name}
         setDefaultValue={(ctx) => {
           // Auto-create the first organism:

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -96,6 +96,27 @@ export const DINAUI_MESSAGES_ENGLISH = {
     "This {fieldName} will be linked to all {targetType}s.",
   bulkEditResourceSetWarningMulti:
     "These {fieldName}s will be set on all {targetType}s.",
+
+  bulkEditResourceLinkerWarning_Organisms_MaterialSample_Single:
+    "This Organism will be linked to all Material Samples.",
+  bulkEditResourceLinkerWarning_Attachments_MaterialSample_Single:
+    "This Attachment will be linked to all Material Samples.",
+
+  bulkEditResourceLinkerWarning_Organisms_MaterialSample_Multi:
+    "These Organisms will be linked to all Material Samples.",
+  bulkEditResourceLinkerWarning_Attachments_MaterialSample_Multi:
+    "These Attachments will be linked to all Material Samples.",
+
+  bulkEditResourceSetWarning_Associations_MaterialSample_Single:
+    "This Association will be set on all Material Samples.",
+  bulkEditResourceSetWarning_ScheduledActions_MaterialSample_Single:
+    "This Scheduled Action will be set on all Material Samples.",
+
+  bulkEditResourceSetWarning_Associations_MaterialSample_Multi:
+    "These Associations will be set on all Material Samples.",
+  bulkEditResourceSetWarning_ScheduledActions_MaterialSample_Multi:
+    "These Scheduled Actions will be set on all Material Samples.",
+
   bulkOperationCompleteTitle: "Bulk Operation Complete",
   cancelButtonText: "Cancel",
   cataloguedObjectListTitle: "Catalogued Objects",


### PR DESCRIPTION
-changed bulkEditWarning to have different warning message based on how many items are being set
-changed bulkEditWarning to take unique message descriptors for each combination of field and target type