### PR TITLE
Support #36590 - Invalid request to group endpoint from material samp…

### DIFF
--- a/packages/dina-ui/components/group-select/GroupSelectField.tsx
+++ b/packages/dina-ui/components/group-select/GroupSelectField.tsx
@@ -143,7 +143,7 @@ export function useAvailableGroupOptions({
   const { locale } = useDinaIntl();
   const { readOnly } = useContext(DinaFormContext) ?? {};
 
-  const selectableGroupNames = _.uniq([
+  const selectableGroupNames: string[] = _.uniq([
     // If the value is already set, include it in the dropdown regardless of user permissions.
     ...(initialGroupName
       ? Array.isArray(initialGroupName)
@@ -160,9 +160,7 @@ export function useAvailableGroupOptions({
       page: { limit: 1000 },
       // Get the group from backend when groupName is not within current user's group
       filter:
-        showAllGroups || isAdmin
-          ? undefined
-          : JSON.stringify({ name: selectableGroupNames })
+        showAllGroups || isAdmin ? {} : { name: selectableGroupNames.join(",") }
     },
     {
       disabled: readOnly

--- a/packages/dina-ui/components/group-select/__tests__/GroupSelectField.test.tsx
+++ b/packages/dina-ui/components/group-select/__tests__/GroupSelectField.test.tsx
@@ -173,4 +173,43 @@ describe("GroupSelectField component", () => {
     // The default group was selected:
     expect(mockSubmit).lastCalledWith({ group: null });
   });
+
+  it("Calls the API with a name filter for the user's groups", async () => {
+    const mockGet = jest.fn();
+
+    // This mock user is NOT an admin and belongs to two specific groups.
+    const testCtxWithSpecificUser = {
+      apiContext: {
+        apiClient: {
+          get: mockGet as any
+        }
+      },
+      accountContext: {
+        groupNames: ["aafc", "ccfc"],
+        isAdmin: false
+      }
+    };
+
+    mockGet.mockRejectedValueOnce(undefined);
+
+    mountWithAppContext(
+      <DinaForm initialValues={{}} readOnly={false}>
+        <GroupSelectField name="group" showAllGroups={false} />
+      </DinaForm>,
+      testCtxWithSpecificUser
+    );
+
+    // Wait for the API call to be made.
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      expect(mockGet).toHaveBeenCalledWith("user-api/group", {
+        filter: {
+          name: "aafc,ccfc"
+        },
+        page: {
+          limit: 1000
+        }
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Fixed filter that was doing a JSON.stringify on the name filter.