### PR TITLE
Support #36618 material sample view storage location should not be displaying coordinates

### DIFF
--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -321,7 +321,6 @@ export function MaterialSampleForm({
             name="storageUnit"
             hideLabel={true}
             targetType="material-sample"
-            createStorageMode={true}
           />
         </FieldSet>
       ),

--- a/packages/dina-ui/components/storage/AssignedStorage.tsx
+++ b/packages/dina-ui/components/storage/AssignedStorage.tsx
@@ -23,6 +23,7 @@ export interface AssignedStorageProps {
   ) => Promisable<void>;
   noneMessage?: JSX.Element;
   parentIdInURL?: string;
+  isParentStorageUnit?: boolean;
 }
 
 /** Displays the currently assigned Storage, and lets you unlink it. */
@@ -31,7 +32,8 @@ export function AssignedStorage({
   readOnly,
   value,
   noneMessage,
-  parentIdInURL
+  parentIdInURL,
+  isParentStorageUnit
 }: AssignedStorageProps) {
   const storageQuery = useStorageUnit(value?.id);
   const encoder = new AlphanumericEncoder();
@@ -80,7 +82,8 @@ export function AssignedStorage({
               )}
             </div>
             {!!storageUnit.storageUnitType?.gridLayoutDefinition &&
-              !isBulkEditAllTab && (
+              !isBulkEditAllTab &&
+              !isParentStorageUnit && (
                 <div className="list-inline mb-3">
                   <SelectField
                     options={options}

--- a/packages/dina-ui/components/storage/AssignedStorage.tsx
+++ b/packages/dina-ui/components/storage/AssignedStorage.tsx
@@ -23,7 +23,7 @@ export interface AssignedStorageProps {
   ) => Promisable<void>;
   noneMessage?: JSX.Element;
   parentIdInURL?: string;
-  isParentStorageUnit?: boolean;
+  showRowAndColumnFields?: boolean;
 }
 
 /** Displays the currently assigned Storage, and lets you unlink it. */
@@ -33,7 +33,7 @@ export function AssignedStorage({
   value,
   noneMessage,
   parentIdInURL,
-  isParentStorageUnit
+  showRowAndColumnFields = true
 }: AssignedStorageProps) {
   const storageQuery = useStorageUnit(value?.id);
   const encoder = new AlphanumericEncoder();
@@ -83,7 +83,7 @@ export function AssignedStorage({
             </div>
             {!!storageUnit.storageUnitType?.gridLayoutDefinition &&
               !isBulkEditAllTab &&
-              !isParentStorageUnit && (
+              showRowAndColumnFields && (
                 <div className="list-inline mb-3">
                   <SelectField
                     options={options}

--- a/packages/dina-ui/components/storage/StorageLinker.tsx
+++ b/packages/dina-ui/components/storage/StorageLinker.tsx
@@ -176,7 +176,11 @@ export function StorageLinkerField({
     <FieldWrapper
       name={name}
       readOnlyRender={(value) => (
-        <AssignedStorage readOnly={true} value={value} />
+        <AssignedStorage
+          readOnly={true}
+          value={value}
+          isParentStorageUnit={parentStorageUnitUUID !== undefined}
+        />
       )}
       disableLabelClick={true}
       customName={customName}

--- a/packages/dina-ui/components/storage/StorageLinker.tsx
+++ b/packages/dina-ui/components/storage/StorageLinker.tsx
@@ -80,6 +80,8 @@ export function StorageLinker({
           value={value}
           parentIdInURL={parentIdInURL}
           onChange={changeStorageAndResetTab}
+          // if editing or creating a new storage unit, don't show row and column fields since they don't have coordinates
+          showRowAndColumnFields={!createStorageMode}
         />
       ) : (
         <Tabs selectedIndex={activeTab} onSelect={setActiveTab}>
@@ -179,7 +181,7 @@ export function StorageLinkerField({
         <AssignedStorage
           readOnly={true}
           value={value}
-          isParentStorageUnit={parentStorageUnitUUID !== undefined}
+          showRowAndColumnFields={parentStorageUnitUUID === undefined} // if displaying the parent storage unit, don't show row and column fields
         />
       )}
       disableLabelClick={true}

--- a/packages/dina-ui/components/storage/StorageUnitForm.tsx
+++ b/packages/dina-ui/components/storage/StorageUnitForm.tsx
@@ -218,6 +218,7 @@ export function StorageUnitFormFields({
           targetType="storage-unit"
           parentIdInURL={parentIdInURL}
           parentStorageUnitUUID={initialValues.id}
+          createStorageMode={true}
         />
       )}
       {readOnly && (

--- a/packages/dina-ui/pages/collection/material-sample/view.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/view.tsx
@@ -423,6 +423,9 @@ export function MaterialSampleViewPage({ router }: WithRouterProps) {
                             customName={formatMessage(
                               "field_parentStorageUnit"
                             )}
+                            parentStorageUnitUUID={
+                              materialSample.storageUnit.parentStorageUnit.id
+                            }
                           />
                         </div>
                       )}


### PR DESCRIPTION
-changed location field in material sample view to no longer show row and column
-removed row and column fields from storage unit edit screen when adding a child storage unit