### PR TITLE
Support #36817 - RSQL error on generate workbook template page

### DIFF
--- a/packages/common-ui/lib/util/__tests__/SimpleSearchFilterBuilder.test.ts
+++ b/packages/common-ui/lib/util/__tests__/SimpleSearchFilterBuilder.test.ts
@@ -53,6 +53,36 @@ describe("SimpleSearchFilterBuilder", () => {
     });
   });
 
+  describe(".whereIn()", () => {
+    it("should add an IN filter when values are provided", () => {
+      const filter = SimpleSearchFilterBuilder.create<ManagedAttribute>()
+        .whereIn("group", ["group1", "group2"])
+        .build();
+      expect(filter).toEqual({ group: { IN: "group1,group2" } });
+    });
+
+    it("should add an IN filter when one value is provided", () => {
+      const filter = SimpleSearchFilterBuilder.create<ManagedAttribute>()
+        .whereIn("group", ["group1"])
+        .build();
+      expect(filter).toEqual({ group: { IN: "group1" } });
+    });
+
+    it("should not add a filter when the values array is empty", () => {
+      const filter = SimpleSearchFilterBuilder.create<ManagedAttribute>()
+        .whereIn("group", [])
+        .build();
+      expect(filter).toEqual({});
+    });
+
+    it("should not add a filter when the values are undefined", () => {
+      const filter = SimpleSearchFilterBuilder.create<ManagedAttribute>()
+        .whereIn("group", undefined)
+        .build();
+      expect(filter).toEqual({});
+    });
+  });
+
   describe(".searchFilter()", () => {
     it("should add an ILIKE filter when a valid value is provided", () => {
       const filter = SimpleSearchFilterBuilder.create<ManagedAttribute>()

--- a/packages/common-ui/lib/util/simpleSearchFilterBuilder.ts
+++ b/packages/common-ui/lib/util/simpleSearchFilterBuilder.ts
@@ -54,6 +54,26 @@ export class SimpleSearchFilterBuilder<T extends Record<string, any>> {
   }
 
   /**
+   * Adds a filter for a specific field using the IN operator.
+   *
+   * If undefined or empty array, this filter is not provided.
+   *
+   * @param field The field to filter on.
+   * @param values The array of values to include in the filter.
+   * @returns The updated FilterBuilder instance.
+   */
+  public whereIn<K extends keyof T>(
+    field: K | "uuid",
+    values?: Array<T[K] | string>
+  ): this {
+    if (values && values.length) {
+      // Convert to comma-separated list:
+      this.filter[String(field)] = { IN: values.join(",") } as any;
+    }
+    return this;
+  }
+
+  /**
    * Generates a search filter.
    * e.g. .searchFilter('name', 'test') results in { name: { ILIKE: "%test%" }}
    */

--- a/packages/dina-ui/pages/workbook/generator.tsx
+++ b/packages/dina-ui/pages/workbook/generator.tsx
@@ -11,7 +11,8 @@ import {
   ListPageLayout,
   dateCell,
   LoadingSpinner,
-  ColumnDefinition
+  ColumnDefinition,
+  SimpleSearchFilterBuilder
 } from "common-ui";
 import { DinaMessage, useDinaIntl } from "../../intl/dina-ui-intl";
 import { Alert, Button, Card, Form } from "react-bootstrap";
@@ -313,9 +314,11 @@ export function WorkbookTemplateGenerator() {
         <Card>
           <Card.Body>
             <ListPageLayout
-              additionalFilters={{
-                rsql: `acSubtype.acSubtype=='IMPORT TEMPLATE';bucket=in=(${groupNames})`
-              }}
+              additionalFilters={SimpleSearchFilterBuilder.create()
+                // acSubtype is a ObjectSubtype, which contains the 'acSubtype' field.
+                .where("acSubtype.acSubtype", "EQ", "IMPORT TEMPLATE")
+                .whereIn("bucket", groupNames)
+                .build()}
               id="data-export-list"
               queryTableProps={{
                 columns: TABLE_COLUMNS,


### PR DESCRIPTION
- whereIn added to simpleSearchFilterBuilder to make it easier to generate IN searches.
- Added test coverage for whereIn().
- Fixed RSQL to use the simple filter builder.