### PR TITLE
36911 acSubType set null when acDcType changes

### DIFF
--- a/packages/dina-ui/components/object-store/metadata/MetadataForm.tsx
+++ b/packages/dina-ui/components/object-store/metadata/MetadataForm.tsx
@@ -29,8 +29,25 @@ import {
 } from "../../../pages/object-store/metadata/edit";
 import { ReactNode, Ref } from "react";
 import { InputResource } from "kitsu";
-import { FormikProps } from "formik";
+import { connect, FormikProps } from "formik";
 import MetadataBadges from "./MetadataBadges";
+
+// When the acDcType is changed, the acSubType needs to be cleared
+const DcTypeSelectorComponent = connect(({ formik }) => {
+  const { setFieldValue } = formik;
+
+  return (
+    <SelectField
+      name="dcType"
+      className="col-md-6"
+      options={DCTYPE_OPTIONS}
+      onChange={(selectedDcType) => {
+        setFieldValue("dcType", selectedDcType);
+        setFieldValue("acSubtype", null);
+      }}
+    />
+  );
+});
 
 export interface MetadataFormProps {
   metadata?: InputResource<Metadata>;
@@ -112,11 +129,7 @@ export function MetadataForm({
           />
         </div>
         <div className="row">
-          <SelectField
-            className="col-md-6"
-            name="dcType"
-            options={DCTYPE_OPTIONS}
-          />
+          <DcTypeSelectorComponent />
           <Field name="dcType">
             {({ field: { value: dcType } }) => (
               <ResourceSelectField<ObjectSubtype>

--- a/packages/dina-ui/components/object-store/metadata/useMetadata.tsx
+++ b/packages/dina-ui/components/object-store/metadata/useMetadata.tsx
@@ -211,7 +211,7 @@ export function useMetadataSave({
 
     // Before checking the difference, we need to parse some fields.
     preprocessed.acSubtype =
-      (preprocessed as any)?.acSubtype?.acSubtype ?? undefined;
+      (preprocessed as any)?.acSubtype?.acSubtype ?? null;
     preprocessed.xmpRightsWebStatement =
       (preprocessed as any)?.license?.url ?? "";
     delete preprocessed.license;


### PR DESCRIPTION
Form now clears selection for acSubType when acDcType changes

Request body now containrs acSubType set to null when no value is selected, or automatically cleared