### PR TITLE
Upgrade ESRI js library #1721

### DIFF
--- a/packages/dina-ui/components/collection/event-map/CollectingEventMap.tsx
+++ b/packages/dina-ui/components/collection/event-map/CollectingEventMap.tsx
@@ -1,3 +1,4 @@
+import "./arcgis-config";
 import { useGraphic, useMap } from "esri-loader-hooks";
 import Head from "next/head";
 import React from "react";
@@ -58,7 +59,7 @@ export function CollectingEventMap({
     <div style={{ height: 800 }} ref={ref}>
       <Head>
         <link
-          href="https://js.arcgis.com/4.21/esri/themes/dark/main.css"
+          href="https://js.arcgis.com/4.29/esri/themes/dark/main.css"
           rel="stylesheet"
         />
       </Head>

--- a/packages/dina-ui/components/collection/event-map/arcgis-config.ts
+++ b/packages/dina-ui/components/collection/event-map/arcgis-config.ts
@@ -1,0 +1,6 @@
+import { setDefaultOptions } from "esri-loader";
+
+setDefaultOptions({
+  version: "4.29",
+  css: true
+});


### PR DESCRIPTION
dina-ui uses esri-loader-hooks. Since v4.29 is the last “safe” version of the ArcGIS JS API compatible with esri-loader and esri-loader-hooks, we upgraded the API to v4.29.

There is no need to change the package versions, as they already work with v4.29.