### PR TITLE
Support #37566 - Enable Turbopack for NextJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dina-ui-monorepo",
-  "license": "SEE LICENSE FILE",
+  "license": "MIT",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/common-ui/lib/classification/TaxonomyTree.tsx
+++ b/packages/common-ui/lib/classification/TaxonomyTree.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
 import * as echarts from "echarts";
-import "./TaxonomyTree.css";
 import { useApiClient } from "..";
 import useVocabularyOptions from "../../../dina-ui/components/collection/useVocabularyOptions";
 import { DinaMessage } from "../../../dina-ui/intl/dina-ui-intl";

--- a/packages/common-ui/lib/global-search/GlobalSearch.tsx
+++ b/packages/common-ui/lib/global-search/GlobalSearch.tsx
@@ -1,6 +1,5 @@
 import { useState, FormEvent, useEffect } from "react";
 import { useIntl } from "react-intl";
-import "./global-search.css";
 
 export interface GlobalSearchProps {
   /** Callback function when search is submitted */

--- a/packages/common-ui/lib/notification/NotificationCard.tsx
+++ b/packages/common-ui/lib/notification/NotificationCard.tsx
@@ -1,7 +1,6 @@
 import { useState, memo } from "react";
 import moment from "moment";
 import { Notification } from "./types";
-import "./notification.css";
 
 export interface NotificationCardProps {
   notification: Notification;

--- a/packages/common-ui/lib/notification/UserNotification.tsx
+++ b/packages/common-ui/lib/notification/UserNotification.tsx
@@ -3,7 +3,6 @@ import { FaBell, FaCheck } from "react-icons/fa";
 import { useNotification } from "./useNotification";
 import { NotificationCard } from "./NotificationCard";
 import { CommonMessage } from "../intl/common-ui-intl";
-import "./notification.css";
 
 export interface UserNotificationProps {
   /**

--- a/packages/common-ui/lib/settings-button/SettingsButton.tsx
+++ b/packages/common-ui/lib/settings-button/SettingsButton.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef } from "react";
-import "./SettingsButton.css"; // For styling
 
 interface SettingsButtonProps {
   menuItems: JSX.Element[];

--- a/packages/dina-ui/next.config.js
+++ b/packages/dina-ui/next.config.js
@@ -1,5 +1,3 @@
- 
-
 // SSR polyfills:
 require("setimmediate");
 CustomEvent = require("custom-event");
@@ -24,9 +22,10 @@ const nextConfig = {
     "react-dnd-html5-backend"
   ],
   output: "export",
-  outputFileTracingRoot: path.join(__dirname)
+  outputFileTracingRoot: path.join(__dirname, "../.."),
+  turbopack: {
+    root: path.join(__dirname, "../..")
+  }
 };
 
 module.exports = nextConfig;
-
- 

--- a/packages/dina-ui/package.json
+++ b/packages/dina-ui/package.json
@@ -1,11 +1,10 @@
 {
   "name": "dina-ui",
-  "license": "SEE LICENSE FILE",
+  "license": "MIT",
   "version": "0.210.0",
   "scripts": {
     "build": "node --require ./next.config.js ../../node_modules/.bin/next build",
-    "dev": "next",
-    "next": "next",
+    "dev": "next --turbopack",
     "a11y-check": "pa11y-ci -j > pa11y-result.json",
     "a11y-generate-report": "pa11y-ci-reporter-html -s pa11y-result.json --destination ./pa11y-html-report"
   },

--- a/packages/dina-ui/pages/_app.tsx
+++ b/packages/dina-ui/pages/_app.tsx
@@ -33,6 +33,10 @@ import "./bootstrap-print.css";
 import "@react-awesome-query-builder/ui/css/styles.css";
 import { FileUploadProviderImpl } from "../components/object-store/file-upload/FileUploadProvider";
 import { DinaIntlProvider } from "../intl/dina-ui-intl";
+import "common-ui/lib/classification/TaxonomyTree.css";
+import "common-ui/lib/global-search/global-search.css";
+import "common-ui/lib/notification/notification.css";
+import "common-ui/lib/settings-button/SettingsButton.css";
 
 /**
  * App component that wraps every page component.


### PR DESCRIPTION
- For Turbopack to work, all global CSS needs to moved the _app.tsx.
- Added turbopack instructions since next installation is located at the root not in the package.
- Added the --turbopack option for both the dev.