### PR TITLE
Support #37952 - Controlled Vocabulary view does not display the term

### DIFF
--- a/packages/dina-ui/pages/controlled-vocabulary-item/edit.tsx
+++ b/packages/dina-ui/pages/controlled-vocabulary-item/edit.tsx
@@ -312,6 +312,13 @@ export function ControlledVocabularyItemFormLayout() {
           </div>
         </div>
       )}
+      <div className="row">
+        <TextField
+          className="col-md-6"
+          name="term"
+          link={initialValues?.term ?? ""}
+        />
+      </div>
       <MultilingualTitle />
       <MultilingualDescription />
       {readOnly && (


### PR DESCRIPTION
- Added the term text field (also displays as a link in the view)