### PR TITLE
Support #37953 create extensible tab view for query page

### DIFF
--- a/packages/common-ui/lib/index.ts
+++ b/packages/common-ui/lib/index.ts
@@ -119,6 +119,7 @@ export * from "./table/StringArrayCell";
 export * from "./table/DateCell";
 export * from "./table/BooleanCell";
 export * from "./list-page/QueryPage";
+export * from "./list-page/tabs/tabs";
 export * from "./table/QueryTable";
 export * from "./column-selector/ColumnSelector";
 export * from "./column-selector/ColumnSelectorList";

--- a/packages/common-ui/lib/intl/common-ui-en.ts
+++ b/packages/common-ui/lib/intl/common-ui-en.ts
@@ -209,5 +209,6 @@ export const COMMON_UI_MESSAGES_ENGLISH = {
   topMatches: "Top Matches",
   permissionError:
     "You don't have permissions to delete all of these selected records.",
-  deleteSuccess: "Successfully deleted {count} records."
+  deleteSuccess: "Successfully deleted {count} records.",
+  listView: "List"
 };

--- a/packages/common-ui/lib/intl/common-ui-en.ts
+++ b/packages/common-ui/lib/intl/common-ui-en.ts
@@ -210,5 +210,6 @@ export const COMMON_UI_MESSAGES_ENGLISH = {
   permissionError:
     "You don't have permissions to delete all of these selected records.",
   deleteSuccess: "Successfully deleted {count} records.",
-  listView: "List"
+  listView: "List",
+  galleryView: "Gallery"
 };

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -727,13 +727,6 @@ export function QueryPage<TData extends KitsuResource>({
     router?.query?.queryTree
   ]);
 
-  // If column selector is disabled, the loading spinner should be turned off.
-  useEffect(() => {
-    if (!enableColumnSelector) {
-      setColumnSelectorLoading(false);
-    }
-  }, [enableColumnSelector]);
-
   /**
    * Used for selection mode only.
    *
@@ -1150,7 +1143,23 @@ export function QueryPage<TData extends KitsuResource>({
       setIsFullScreen,
       CheckBoxField: SelectCheckBox,
       CheckBoxHeader: SelectCheckBoxHeader,
-      query: elasticSearchQuery
+      query: elasticSearchQuery,
+      enableColumnSelector,
+      uniqueName,
+      indexMap,
+      dynamicFieldMapping,
+      onDisplayedColumnsChange,
+      excludedRelationshipTypes,
+      mandatoryDisplayedColumns,
+      nonExportableColumns,
+      bulkEditPath,
+      bulkDeleteButtonProps,
+      dataExportProps,
+      bulkSplitPath,
+      attachSelectedButtonsProps,
+      error,
+      singleEditPath,
+      indexName
     };
   }, [
     viewMode,
@@ -1173,7 +1182,23 @@ export function QueryPage<TData extends KitsuResource>({
     setIsFullScreen,
     SelectCheckBox,
     SelectCheckBoxHeader,
-    elasticSearchQuery
+    elasticSearchQuery,
+    enableColumnSelector,
+    uniqueName,
+    indexMap,
+    dynamicFieldMapping,
+    onDisplayedColumnsChange,
+    excludedRelationshipTypes,
+    mandatoryDisplayedColumns,
+    nonExportableColumns,
+    bulkEditPath,
+    bulkDeleteButtonProps,
+    dataExportProps,
+    bulkSplitPath,
+    attachSelectedButtonsProps,
+    error,
+    singleEditPath,
+    indexName
   ]);
 
   /**

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -881,17 +881,9 @@ export function QueryPage<TData extends KitsuResource>({
     defaultAvailableItems: selectedResources ?? []
   });
 
-  const computedReactTableProps =
-    typeof reactTableProps === "function"
-      ? reactTableProps(
-          searchResults as PersistedResource<TData>[],
-          SelectCheckBox
-        )
-      : reactTableProps;
-
   const resolvedReactTableProps: Partial<ReactTableProps<TData>> = {
     sort: sortingRules,
-    ...computedReactTableProps
+    ...reactTableProps
   };
 
   // Columns generated for the search results.

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -19,6 +19,7 @@ import {
 import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
 import { useIntl } from "react-intl";
 import { v4 as uuidv4 } from "uuid";
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import {
   ColumnSelectorMemo,
   FormikButton,
@@ -111,6 +112,44 @@ export const getGroupStorageKey = (indexName: string): string => {
 
   return `${indexName}_groupStorage`;
 };
+
+/**
+ * Props for the individual tab components used in the QueryPage. Each tab will receive all props,
+ * but does not have to use all of them.
+ */
+export interface QueryPageTabProps<TData extends KitsuResource> {
+  data: TData[];
+  loading: boolean;
+  totalRecords: number;
+  columns: TableColumn<TData>[];
+  displayedColumns: TableColumn<TData>[];
+  pageSize: number;
+  pageOffset: number;
+  sortingRules: SortingState;
+  onPageChange: (newPage: number) => void;
+  onPageSizeChange: (newPageSize: number) => void;
+  onSortingChange: (newSort: ColumnSort[]) => void;
+  reactTableProps?: Partial<ReactTableProps<TData>>;
+  rowStyling?: (row: Row<TData>) => CSSProperties | undefined;
+  isFullScreen?: boolean;
+  setIsFullScreen?: (value: boolean) => void;
+  query?: any; // elastic search query
+  // Allow additional custom props
+  [key: string]: any;
+}
+
+/**
+ * Configuration for tabs in the QueryPage. Each tab will have its own component and
+ * can be used to display the same data in different ways or to
+ * display different subsets of data based on the same query.
+ */
+export interface QueryPageTabConfig<TData extends KitsuResource> {
+  id: string;
+  labelKey: string; // For i18n
+  component: React.ComponentType<QueryPageTabProps<TData>>;
+  // Optional: Tab-specific configuration
+  config?: any;
+}
 
 export interface QueryPageProps<TData extends KitsuResource> {
   /**
@@ -321,6 +360,17 @@ export interface QueryPageProps<TData extends KitsuResource> {
    * Default is true.
    */
   enableColumnSelector?: boolean;
+
+  /**
+   * Optional tabs configuration. If provided, the results will be rendered
+   * in tabs instead of a single table.
+   */
+  tabs?: QueryPageTabConfig<TData>[];
+
+  /**
+   * Default active tab (if tabs are provided)
+   */
+  defaultTab?: string;
 }
 
 /**
@@ -333,6 +383,7 @@ export interface QueryPageProps<TData extends KitsuResource> {
  * * Filtering using ElasticSearch Indexing
  * * Saved Searches
  * * Column Selector
+ * * Multiple View Tabs
  */
 export function QueryPage<TData extends KitsuResource>({
   indexName,
@@ -366,7 +417,9 @@ export function QueryPage<TData extends KitsuResource>({
   enableDnd = false,
   onSelect,
   onDeselect,
-  enableColumnSelector = true
+  enableColumnSelector = true,
+  tabs,
+  defaultTab
 }: QueryPageProps<TData>) {
   // Loading state
   const [loading, setLoading] = useState<boolean>(true);
@@ -457,6 +510,18 @@ export function QueryPage<TData extends KitsuResource>({
 
   // Fullscreen state
   const [isFullScreen, setIsFullScreen] = useState(false);
+
+  // Active tab index
+  const defaultTabIndex = useMemo(() => {
+    if (!tabs || tabs.length === 0) return 0;
+    const index = tabs.findIndex((tab) => tab.id === defaultTab);
+    return index >= 0 ? index : 0;
+  }, [tabs, defaultTab]);
+
+  const [activeTabIndex, setActiveTabIndex] = useLocalStorage<number>(
+    `${uniqueName}-active-tab-index`,
+    defaultTabIndex
+  );
 
   const defaultGroups = useMemo(() => {
     return { group: groups };
@@ -1032,6 +1097,97 @@ export function QueryPage<TData extends KitsuResource>({
     }
   }
 
+  /**
+   * Renders the default table view (MemoizedReactTable)
+   */
+  const renderDefaultTableView = () => (
+    <MemoizedReactTable
+      columns={columnsResults as any}
+      data={
+        (viewMode
+          ? customViewFields
+            ? searchResults
+            : selectedResources
+          : searchResults) ?? []
+      }
+      loading={loading || columnSelectorLoading}
+      manualPagination={viewMode && selectedResources?.length ? false : true}
+      pageSize={pageSize}
+      pageCount={totalRecords ? Math.ceil(totalRecords / pageSize) : 0}
+      page={pageOffset / pageSize}
+      onPageChange={onPageChanged}
+      onPageSizeChange={onPageSizeChanged}
+      manualSorting={viewMode && selectedResources?.length ? false : true}
+      onSortingChange={onSortChange}
+      sort={sortingRules}
+      {...resolvedReactTableProps}
+      className="-striped react-table-overflow"
+      rowStyling={rowStyling}
+      showPagination={true}
+      showPaginationTop={true}
+      smallPaginationButtons={selectionMode}
+      enableFullscreen={true}
+      isFullscreen={isFullScreen}
+      setIsFullscreen={setIsFullScreen}
+    />
+  );
+
+  /**
+   * Common props to pass to all tab components
+   */
+  const commonTabProps: Omit<QueryPageTabProps<TData>, keyof any> = {
+    data:
+      viewMode && selectedResources?.length ? selectedResources : searchResults,
+    loading: loading || columnSelectorLoading,
+    totalRecords,
+    columns: columnsResults,
+    displayedColumns,
+    pageSize,
+    pageOffset,
+    sortingRules,
+    onPageChange: onPageChanged,
+    onPageSizeChange: onPageSizeChanged,
+    onSortingChange: onSortChange,
+    reactTableProps: resolvedReactTableProps,
+    rowStyling,
+    isFullScreen,
+    setIsFullScreen,
+    query: elasticSearchQuery
+  };
+
+  /**
+   * Renders tabs using react-tabs
+   */
+  const renderTabsContent = () => {
+    if (!tabs || tabs.length === 0) {
+      return renderDefaultTableView();
+    }
+
+    return (
+      <Tabs
+        selectedIndex={activeTabIndex}
+        onSelect={(index) => setActiveTabIndex(index)}
+      >
+        <TabList>
+          {tabs.map((tab) => (
+            <Tab key={tab.id}>
+              <CommonMessage id={tab.labelKey as any} />
+            </Tab>
+          ))}
+        </TabList>
+
+        {tabs.map((tab) => {
+          const TabComponent = tab.component;
+          return (
+            <TabPanel key={tab.id}>
+              <TabComponent {...commonTabProps} {...tab.config} />
+            </TabPanel>
+          );
+        })}
+      </Tabs>
+    );
+  };
+
   // Generate the key for the DINA form. It should only be generated once.
   const formKey = useMemo(() => uuidv4(), []);
 
@@ -1171,24 +1327,27 @@ export function QueryPage<TData extends KitsuResource>({
         >
           <div className="row">
             <div className={selectionMode ? "col-5" : "col-12"}>
-              <div className="d-flex align-items-end">
-                <span id="queryPageCount">
-                  {/* Loading indicator when total is not calculated yet. */}
-                  {loading || columnSelectorLoading ? (
-                    <></>
-                  ) : (
-                    <CommonMessage
-                      id="tableTotalCount"
-                      values={{ totalCount: formatNumber(totalRecords) }}
-                    />
-                  )}
-                </span>
+              <div className="d-flex align-items-end justify-content-between">
+                <div className="d-flex align-items-end">
+                  <span id="queryPageCount">
+                    {/* Loading indicator when total is not calculated yet. */}
+                    {loading || columnSelectorLoading ? (
+                      <></>
+                    ) : (
+                      <CommonMessage
+                        id="tableTotalCount"
+                        values={{ totalCount: formatNumber(totalRecords) }}
+                      />
+                    )}
+                  </span>
 
-                {/* Multi sort tooltip - Only shown if it's possible to sort */}
-                {resolvedReactTableProps.enableMultiSort && (
-                  <MultiSortTooltip />
-                )}
+                  {/* Multi sort tooltip - Only shown if it's possible to sort */}
+                  {resolvedReactTableProps.enableMultiSort && (
+                    <MultiSortTooltip />
+                  )}
+                </div>
               </div>
+
               {error && (
                 <div
                   className="alert alert-danger"
@@ -1213,6 +1372,7 @@ export function QueryPage<TData extends KitsuResource>({
                   </button>
                 </div>
               )}
+
               {loading || columnSelectorLoading ? (
                 <div
                   className={
@@ -1223,47 +1383,9 @@ export function QueryPage<TData extends KitsuResource>({
                   <LoadingSpinner loading={true} />
                 </div>
               ) : (
-                <MemoizedReactTable
-                  // Column and data props
-                  columns={columnsResults as any}
-                  data={
-                    (viewMode
-                      ? customViewFields
-                        ? searchResults
-                        : selectedResources
-                      : searchResults) ?? []
-                  }
-                  // Loading Table props
-                  loading={loading || columnSelectorLoading}
-                  // Pagination props
-                  manualPagination={
-                    viewMode && selectedResources?.length ? false : true
-                  }
-                  pageSize={pageSize}
-                  pageCount={
-                    totalRecords ? Math.ceil(totalRecords / pageSize) : 0
-                  }
-                  page={pageOffset / pageSize}
-                  onPageChange={onPageChanged}
-                  onPageSizeChange={onPageSizeChanged}
-                  // Sorting props
-                  manualSorting={
-                    viewMode && selectedResources?.length ? false : true
-                  }
-                  onSortingChange={onSortChange}
-                  sort={sortingRules}
-                  // Table customization props
-                  {...resolvedReactTableProps}
-                  className="-striped react-table-overflow"
-                  rowStyling={rowStyling}
-                  showPagination={true}
-                  showPaginationTop={true}
-                  smallPaginationButtons={selectionMode}
-                  enableFullscreen={true}
-                  isFullscreen={isFullScreen}
-                  setIsFullscreen={setIsFullScreen}
-                />
+                renderTabsContent()
               )}
+
               <div className="mt-2">
                 {/* Loading indicator when total is not calculated yet. */}
                 {loading || columnSelectorLoading ? (

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -1164,15 +1164,10 @@ export function QueryPage<TData extends KitsuResource>({
     pageSize,
     pageOffset,
     sortingRules,
-    onPageChanged,
-    onPageSizeChanged,
-    onSortChange,
     resolvedReactTableProps,
     rowStyling,
     isFullScreen,
     setIsFullScreen,
-    SelectCheckBox,
-    SelectCheckBoxHeader,
     elasticSearchQuery
   ]);
 

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -134,6 +134,7 @@ export interface QueryPageTabProps<TData extends KitsuResource> {
   isFullScreen?: boolean;
   setIsFullScreen?: (value: boolean) => void;
   query?: any; // elastic search query
+  CheckBoxField: React.ComponentType<CheckBoxFieldProps<TData>>;
   // Allow additional custom props
   [key: string]: any;
 }
@@ -1135,25 +1136,53 @@ export function QueryPage<TData extends KitsuResource>({
   /**
    * Common props to pass to all tab components
    */
-  const commonTabProps: Omit<QueryPageTabProps<TData>, keyof any> = {
-    data:
-      viewMode && selectedResources?.length ? selectedResources : searchResults,
-    loading: loading || columnSelectorLoading,
+  const commonTabProps: QueryPageTabProps<TData> = useMemo(() => {
+    return {
+      data:
+        viewMode && selectedResources?.length
+          ? selectedResources
+          : searchResults,
+      loading: loading || columnSelectorLoading,
+      totalRecords,
+      columns: columnsResults,
+      displayedColumns,
+      pageSize,
+      pageOffset,
+      sortingRules,
+      onPageChange: onPageChanged,
+      onPageSizeChange: onPageSizeChanged,
+      onSortingChange: onSortChange,
+      reactTableProps: resolvedReactTableProps,
+      rowStyling,
+      isFullScreen,
+      setIsFullScreen,
+      CheckBoxField: SelectCheckBox,
+      CheckBoxHeader: SelectCheckBoxHeader,
+      query: elasticSearchQuery
+    };
+  }, [
+    viewMode,
+    selectedResources,
+    searchResults,
+    loading,
+    columnSelectorLoading,
     totalRecords,
-    columns: columnsResults,
+    columnsResults,
     displayedColumns,
     pageSize,
     pageOffset,
     sortingRules,
-    onPageChange: onPageChanged,
-    onPageSizeChange: onPageSizeChanged,
-    onSortingChange: onSortChange,
-    reactTableProps: resolvedReactTableProps,
+    onPageChanged,
+    onPageSizeChanged,
+    onSortChange,
+    resolvedReactTableProps,
     rowStyling,
     isFullScreen,
     setIsFullScreen,
-    query: elasticSearchQuery
-  };
+    SelectCheckBox,
+    SelectCheckBoxHeader,
+    elasticSearchQuery
+  ]);
 
   /**
    * Renders tabs using react-tabs

--- a/packages/common-ui/lib/list-page/QueryPage.tsx
+++ b/packages/common-ui/lib/list-page/QueryPage.tsx
@@ -727,6 +727,13 @@ export function QueryPage<TData extends KitsuResource>({
     router?.query?.queryTree
   ]);
 
+  // If column selector is disabled, the loading spinner should be turned off.
+  useEffect(() => {
+    if (!enableColumnSelector) {
+      setColumnSelectorLoading(false);
+    }
+  }, [enableColumnSelector]);
+
   /**
    * Used for selection mode only.
    *
@@ -1143,23 +1150,7 @@ export function QueryPage<TData extends KitsuResource>({
       setIsFullScreen,
       CheckBoxField: SelectCheckBox,
       CheckBoxHeader: SelectCheckBoxHeader,
-      query: elasticSearchQuery,
-      enableColumnSelector,
-      uniqueName,
-      indexMap,
-      dynamicFieldMapping,
-      onDisplayedColumnsChange,
-      excludedRelationshipTypes,
-      mandatoryDisplayedColumns,
-      nonExportableColumns,
-      bulkEditPath,
-      bulkDeleteButtonProps,
-      dataExportProps,
-      bulkSplitPath,
-      attachSelectedButtonsProps,
-      error,
-      singleEditPath,
-      indexName
+      query: elasticSearchQuery
     };
   }, [
     viewMode,
@@ -1182,23 +1173,7 @@ export function QueryPage<TData extends KitsuResource>({
     setIsFullScreen,
     SelectCheckBox,
     SelectCheckBoxHeader,
-    elasticSearchQuery,
-    enableColumnSelector,
-    uniqueName,
-    indexMap,
-    dynamicFieldMapping,
-    onDisplayedColumnsChange,
-    excludedRelationshipTypes,
-    mandatoryDisplayedColumns,
-    nonExportableColumns,
-    bulkEditPath,
-    bulkDeleteButtonProps,
-    dataExportProps,
-    bulkSplitPath,
-    attachSelectedButtonsProps,
-    error,
-    singleEditPath,
-    indexName
+    elasticSearchQuery
   ]);
 
   /**

--- a/packages/common-ui/lib/list-page/__mocks__/QueryPageMocks.ts
+++ b/packages/common-ui/lib/list-page/__mocks__/QueryPageMocks.ts
@@ -270,3 +270,31 @@ export const mockResponses = {
       }
     }
 };
+
+export const mockResponsesTabs = {
+  "search-api/search-ws/search": {
+    data: {
+      hits: {
+        total: { value: 2 },
+        hits: [
+          {
+            _id: "test-1",
+            _source: {
+              id: "test-1",
+              type: "test-resource",
+              name: "Resource 1"
+            }
+          },
+          {
+            _id: "test-2",
+            _source: {
+              id: "test-2",
+              type: "test-resource",
+              name: "Resource 2"
+            }
+          }
+        ]
+      }
+    }
+  }
+};

--- a/packages/common-ui/lib/list-page/__tests__/QueryPage.test.tsx
+++ b/packages/common-ui/lib/list-page/__tests__/QueryPage.test.tsx
@@ -4,11 +4,15 @@ import {
   mountWithAppContext,
   waitForLoadingToDisappear
 } from "common-ui";
-
-import { mockResponses } from "../__mocks__/QueryPageMocks";
+import { mockResponses, mockResponsesTabs } from "../__mocks__/QueryPageMocks";
 import { waitFor } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import MaterialSampleListPage from "../../../../dina-ui/pages/collection/material-sample/list";
+import "@testing-library/jest-dom";
+import { QueryPage } from "common-ui";
+import { KitsuResource } from "kitsu";
+import React from "react";
+import { QueryPageTabProps } from "../QueryPage";
 
 const mockGet = jest.fn<any, any>(async (path) => {
   return mockResponses[path] ?? { data: [] };
@@ -142,6 +146,435 @@ describe("QueryPage test", () => {
     // Verify router.reload() is called at the very end
     await waitFor(() => {
       expect(mockReload).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+interface TestResource extends KitsuResource {
+  id: string;
+  name: string;
+}
+
+// Simple mock tab components
+const Tab1 = ({ data }: QueryPageTabProps<TestResource>) => (
+  <div data-testid="tab-1-content">Tab 1 - {data?.length || 0} items</div>
+);
+
+const Tab2 = ({ data }: QueryPageTabProps<TestResource>) => (
+  <div data-testid="tab-2-content">Tab 2 - {data?.length || 0} items</div>
+);
+
+describe("QueryPage test", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPost.mockImplementationOnce(async (path) => mockResponses[path]);
+    localStorage.clear();
+  });
+  it("Render QueryPage for material-samples", async () => {
+    const component = mountWithAppContext(
+      <DinaForm initialValues={{}}>
+        <MaterialSampleListPage />
+      </DinaForm>,
+      testCtx
+    );
+    const reactTable = await component.findByTestId("ReactTable");
+    expect(reactTable).toBeInTheDocument();
+    expect(reactTable.querySelectorAll("table tbody tr").length).toBe(2);
+    expect(
+      reactTable.querySelectorAll("table tbody tr")[0].getAttribute("style")
+    ).toBeNull();
+    expect(
+      reactTable.querySelectorAll("table tbody tr")[1].getAttribute("style")
+    ).toEqual("opacity: 0.4;");
+  });
+
+  it("Bulk Delete button works for material-samples", async () => {
+    const wrapper = mountWithAppContext(
+      <DinaForm initialValues={{}}>
+        <MaterialSampleListPage />
+      </DinaForm>,
+      testCtx
+    );
+    await waitForLoadingToDisappear();
+
+    const reactTable = await wrapper.findByTestId("ReactTable");
+    expect(reactTable).toBeInTheDocument();
+
+    // Click the "Select All" checkbox to select all items
+    userEvent.click(
+      wrapper.getByRole("checkbox", {
+        name: /check all/i
+      })
+    );
+
+    // Click the Bulk Delete button
+    userEvent.click(
+      wrapper.getByRole("button", {
+        name: /delete selected/i
+      })
+    );
+
+    await waitForLoadingToDisappear();
+    await waitFor(() => {
+      expect(wrapper.getByText(/delete selected \(2\)/i)).toBeInTheDocument();
+    });
+    userEvent.click(wrapper.getByRole("button", { name: /yes/i }));
+    await waitForLoadingToDisappear();
+
+    // Verify both material samples are deleted
+    expect(mockDelete).toHaveBeenNthCalledWith(
+      1,
+      "/collection-api/material-sample/074e745e-7ef1-449c-965a-9a4dc754391f"
+    );
+    expect(mockDelete).toHaveBeenNthCalledWith(
+      2,
+      "/collection-api/material-sample/7c2b6795-02bb-4edd-97af-589527ef3e7f"
+    );
+
+    // Verify that only one storage unit usage was deleted (since only one has an attached storage unit)
+    expect(mockDoOperations).lastCalledWith(
+      [
+        {
+          op: "DELETE",
+          path: "storage-unit-usage/01919485-ed65-7a79-9080-91445b897ef4"
+        }
+      ],
+      {
+        apiBaseUrl: "/collection-api"
+      }
+    );
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByText(/records have been successfully deleted\./i)
+      ).toBeInTheDocument();
+    });
+
+    // Click the "Close" button.
+    userEvent.click(wrapper.getByRole("button", { name: /close/i }));
+
+    // Verify router.reload() is called at the very end
+    await waitFor(() => {
+      expect(mockReload).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+const COLUMNS = [
+  {
+    id: "name",
+    header: "Name",
+    accessorKey: "name"
+  }
+];
+
+describe("QueryPage Tab Functionality", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPost.mockImplementationOnce(async (path) => mockResponsesTabs[path]);
+    localStorage.clear();
+  });
+
+  describe("Without Tabs", () => {
+    it("Should render normal table when tabs are not provided", async () => {
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-list"
+            columns={COLUMNS as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      expect(component.queryByRole("tablist")).not.toBeInTheDocument();
+      expect(component.getByTestId("ReactTable")).toBeInTheDocument();
+    });
+
+    it("Should not render tab navigation when tabs array is empty", async () => {
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-list"
+            columns={COLUMNS as any}
+            tabs={[]}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      expect(component.queryByRole("tablist")).not.toBeInTheDocument();
+      expect(component.getByTestId("ReactTable")).toBeInTheDocument();
+    });
+  });
+
+  describe("Tab Rendering", () => {
+    it("Should render all tabs when provided", async () => {
+      const tabs = [
+        { id: "tab1", labelKey: "listView", component: Tab1 },
+        { id: "tab2", labelKey: "galleryView", component: Tab2 }
+      ];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-tabs-list"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      expect(component.getByRole("tablist")).toBeInTheDocument();
+      expect(component.getByRole("tab", { name: /list/i })).toBeInTheDocument();
+      expect(
+        component.getByRole("tab", { name: /gallery/i })
+      ).toBeInTheDocument();
+    });
+
+    it("Should render single tab", async () => {
+      const tabs = [{ id: "tab1", labelKey: "listView", component: Tab1 }];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-single-tab-list"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      expect(component.getByRole("tablist")).toBeInTheDocument();
+      expect(component.getByRole("tab", { name: /list/i })).toBeInTheDocument();
+      expect(component.getByTestId("tab-1-content")).toBeInTheDocument();
+    });
+  });
+
+  describe("Default Tab Selection", () => {
+    it("Should display first tab by default", async () => {
+      const tabs = [
+        { id: "tab1", labelKey: "listView", component: Tab1 },
+        { id: "tab2", labelKey: "galleryView", component: Tab2 }
+      ];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-default-first-tab"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      const firstTab = component.getByRole("tab", { name: /list/i });
+
+      expect(firstTab).toHaveClass("react-tabs__tab--selected");
+      expect(component.getByTestId("tab-1-content")).toBeInTheDocument();
+      expect(component.queryByTestId("tab-2-content")).not.toBeInTheDocument();
+    });
+
+    it("Should display specified default tab", async () => {
+      const tabs = [
+        { id: "tab1", labelKey: "listView", component: Tab1 },
+        { id: "tab2", labelKey: "galleryView", component: Tab2 }
+      ];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-default-tab2"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+            defaultTab="tab2"
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      const secondTab = component.getByRole("tab", { name: /gallery/i });
+      expect(secondTab).toHaveClass("react-tabs__tab--selected");
+      expect(component.getByTestId("tab-2-content")).toBeInTheDocument();
+      expect(component.queryByTestId("tab-1-content")).not.toBeInTheDocument();
+    });
+
+    it("Should fall back to first tab if invalid default tab is specified", async () => {
+      const tabs = [
+        { id: "tab1", labelKey: "listView", component: Tab1 },
+        { id: "tab2", labelKey: "galleryView", component: Tab2 }
+      ];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-invalid-default-tab"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+            defaultTab="invalid-tab"
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      const firstTab = component.getByRole("tab", { name: /list/i });
+
+      expect(firstTab).toHaveClass("react-tabs__tab--selected");
+      expect(component.getByTestId("tab-1-content")).toBeInTheDocument();
+    });
+  });
+
+  describe("Tab Clicking", () => {
+    it("Should switch to tab 2 when clicked", async () => {
+      const tabs = [
+        { id: "tab1", labelKey: "listView", component: Tab1 },
+        { id: "tab2", labelKey: "galleryView", component: Tab2 }
+      ];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-click-tab2"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      expect(component.getByTestId("tab-1-content")).toBeInTheDocument();
+
+      const tab2Button = component.getByRole("tab", { name: /gallery/i });
+      userEvent.click(tab2Button);
+
+      await waitFor(() => {
+        expect(tab2Button).toHaveClass("react-tabs__tab--selected");
+        expect(component.getByTestId("tab-2-content")).toBeInTheDocument();
+        expect(
+          component.queryByTestId("tab-1-content")
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("Should switch between tabs multiple times", async () => {
+      const tabs = [
+        { id: "tab1", labelKey: "listView", component: Tab1 },
+        { id: "tab2", labelKey: "galleryView", component: Tab2 }
+      ];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-multiple-clicks"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      const tab2Button = component.getByRole("tab", { name: /gallery/i });
+      userEvent.click(tab2Button);
+
+      await waitFor(() => {
+        expect(component.getByTestId("tab-2-content")).toBeInTheDocument();
+      });
+
+      const tab1Button = component.getByRole("tab", { name: /list/i });
+      userEvent.click(tab1Button);
+
+      await waitFor(() => {
+        expect(component.getByTestId("tab-1-content")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Tab Props Passing", () => {
+    it("Should pass data to tab component", async () => {
+      const tabs = [{ id: "tab1", labelKey: "listView", component: Tab1 }];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-data-passing"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      expect(component.getByTestId("tab-1-content")).toHaveTextContent(
+        "Tab 1 - 2 items"
+      );
+    });
+  });
+
+  describe("Tab Persistence", () => {
+    it("Should persist selected tab in localStorage", async () => {
+      const tabs = [
+        { id: "tab1", labelKey: "listView", component: Tab1 },
+        { id: "tab2", labelKey: "galleryView", component: Tab2 }
+      ];
+
+      const component = mountWithAppContext(
+        <DinaForm initialValues={{}}>
+          <QueryPage<TestResource>
+            indexName="test_index"
+            uniqueName="test-persistence"
+            columns={COLUMNS as any}
+            tabs={tabs as any}
+          />
+        </DinaForm>,
+        testCtx
+      );
+
+      await waitForLoadingToDisappear();
+
+      const tab2Button = component.getByRole("tab", { name: /gallery/i });
+      userEvent.click(tab2Button);
+
+      await waitFor(() => {
+        expect(component.getByTestId("tab-2-content")).toBeInTheDocument();
+      });
+
+      const storedTabIndex = localStorage.getItem(
+        "test-persistence-active-tab-index"
+      );
+      expect(storedTabIndex).toBe("1");
     });
   });
 });

--- a/packages/common-ui/lib/list-page/tabs/tabs.tsx
+++ b/packages/common-ui/lib/list-page/tabs/tabs.tsx
@@ -3,19 +3,8 @@ import { Metadata } from "../../../../dina-ui/types/objectstore-api/resources/Me
 import { MemoizedReactTable } from "../QueryPageTable";
 import { QueryPageTabProps } from "../QueryPage";
 import { StoredObjectGallery } from "../../../../dina-ui/components/object-store";
-import React, { Component, useEffect, useMemo, useState } from "react";
+import React, { Component, useMemo } from "react";
 import { KitsuResource } from "kitsu";
-import { ColumnSelectorMemo } from "../../..";
-import { MultiSortTooltip } from "../MultiSortTooltip";
-import {
-  AttachSelectedButton,
-  BulkDeleteButton,
-  BulkEditButton,
-  BulkSplitButton,
-  DataExportButton
-} from "../../list-page-layout/bulk-buttons";
-import { CommonMessage } from "../../intl/common-ui-intl";
-import { useIntl } from "react-intl";
 
 export function ListViewTab<TData extends KitsuResource>({
   data,
@@ -27,125 +16,24 @@ export function ListViewTab<TData extends KitsuResource>({
   onPageChange,
   onPageSizeChange,
   onSortingChange,
-  sortingRules,
-  enableColumnSelector,
-  uniqueName,
-  indexMap,
-  dynamicFieldMapping,
-  displayedColumns,
-  onDisplayedColumnsChange,
-  excludedRelationshipTypes,
-  mandatoryDisplayedColumns,
-  nonExportableColumns,
-  bulkEditPath,
-  bulkDeleteButtonProps,
-  dataExportProps,
-  bulkSplitPath,
-  attachSelectedButtonsProps,
-  error,
-  enableMultiSort,
-  singleEditPath,
-  query,
-  indexName
+  sortingRules
 }: QueryPageTabProps<TData>) {
-  const { formatNumber } = useIntl();
-
-  const [columnSelectorLoading, setColumnSelectorLoading] =
-    useState<boolean>(true);
-
-  // If column selector is disabled, the loading spinner should be turned off.
-  useEffect(() => {
-    if (!enableColumnSelector) {
-      setColumnSelectorLoading(false);
-    }
-  }, [enableColumnSelector]);
   return (
-    <div>
-      {enableColumnSelector && (
-        <ColumnSelectorMemo
-          uniqueName={uniqueName}
-          exportMode={false}
-          indexMapping={indexMap}
-          dynamicFieldsMappingConfig={dynamicFieldMapping}
-          displayedColumns={displayedColumns as any}
-          setDisplayedColumns={onDisplayedColumnsChange as any}
-          defaultColumns={columns as any}
-          setColumnSelectorLoading={setColumnSelectorLoading}
-          excludedRelationshipTypes={excludedRelationshipTypes}
-          mandatoryDisplayedColumns={mandatoryDisplayedColumns}
-          nonExportableColumns={nonExportableColumns}
-        />
-      )}
-      {bulkEditPath && (
-        <BulkEditButton
-          pathname={bulkEditPath}
-          singleEditPathName={singleEditPath}
-        />
-      )}
-      {bulkDeleteButtonProps && <BulkDeleteButton {...bulkDeleteButtonProps} />}
-      {dataExportProps && (
-        <DataExportButton
-          pathname={dataExportProps.dataExportPath}
-          entityLink={dataExportProps.entityLink}
-          totalRecords={totalRecords}
-          query={query}
-          uniqueName={uniqueName}
-          columns={columns}
-          dynamicFieldMapping={dynamicFieldMapping}
-          indexName={indexName}
-        />
-      )}
-      {bulkSplitPath && <BulkSplitButton pathname={bulkSplitPath} />}
-      {attachSelectedButtonsProps && (
-        <AttachSelectedButton {...attachSelectedButtonsProps} />
-      )}
-      <div className="d-flex align-items-end justify-content-between">
-        <div className="d-flex align-items-end">
-          <span id="queryPageCount">
-            {/* Loading indicator when total is not calculated yet. */}
-            {loading || columnSelectorLoading ? (
-              <></>
-            ) : (
-              <CommonMessage
-                id="tableTotalCount"
-                values={{ totalCount: formatNumber(totalRecords) }}
-              />
-            )}
-          </span>
-
-          {/* Multi sort tooltip - Only shown if it's possible to sort */}
-          {enableMultiSort && <MultiSortTooltip />}
-        </div>
-      </div>
-
-      {error && (
-        <div
-          className="alert alert-danger"
-          style={{
-            whiteSpace: "pre-line"
-          }}
-        >
-          <p>
-            {error.errors?.map((e) => e.detail).join("\n") ?? String(error)}
-          </p>
-        </div>
-      )}
-      <MemoizedReactTable
-        columns={columns as any}
-        data={data}
-        loading={loading || columnSelectorLoading}
-        manualPagination={true}
-        pageSize={pageSize}
-        pageCount={Math.ceil(totalRecords / pageSize)}
-        page={pageOffset / pageSize}
-        onPageChange={onPageChange}
-        onPageSizeChange={onPageSizeChange}
-        manualSorting={true}
-        onSortingChange={onSortingChange}
-        sort={sortingRules}
-        className="-striped react-table-overflow"
-      />
-    </div>
+    <MemoizedReactTable
+      columns={columns as any}
+      data={data}
+      loading={loading}
+      manualPagination={true}
+      pageSize={pageSize}
+      pageCount={Math.ceil(totalRecords / pageSize)}
+      page={pageOffset / pageSize}
+      onPageChange={onPageChange}
+      onPageSizeChange={onPageSizeChange}
+      manualSorting={true}
+      onSortingChange={onSortingChange}
+      sort={sortingRules}
+      className="-striped react-table-overflow"
+    />
   );
 }
 

--- a/packages/common-ui/lib/list-page/tabs/tabs.tsx
+++ b/packages/common-ui/lib/list-page/tabs/tabs.tsx
@@ -1,9 +1,12 @@
-import { MaterialSample } from "../../../../dina-ui/types/collection-api/resources/MaterialSample";
+import { Metadata } from "../../../../dina-ui/types/objectstore-api/resources/Metadata";
+
 import { MemoizedReactTable } from "../QueryPageTable";
 import { QueryPageTabProps } from "../QueryPage";
+import { StoredObjectGallery } from "../../../../dina-ui/components/object-store";
+import React, { Component, useMemo } from "react";
+import { KitsuResource } from "kitsu";
 
-// ListViewTab.tsx
-export const ListViewTab: React.FC<QueryPageTabProps<MaterialSample>> = ({
+export function ListViewTab<TData extends KitsuResource>({
   data,
   loading,
   columns,
@@ -14,7 +17,7 @@ export const ListViewTab: React.FC<QueryPageTabProps<MaterialSample>> = ({
   onPageSizeChange,
   onSortingChange,
   sortingRules
-}) => {
+}: QueryPageTabProps<TData>) {
   return (
     <MemoizedReactTable
       columns={columns as any}
@@ -29,6 +32,81 @@ export const ListViewTab: React.FC<QueryPageTabProps<MaterialSample>> = ({
       manualSorting={true}
       onSortingChange={onSortingChange}
       sort={sortingRules}
+      className="-striped react-table-overflow"
+    />
+  );
+}
+
+export const GalleryViewTab: React.FC<QueryPageTabProps<Metadata>> = ({
+  data,
+  loading,
+  columns,
+  pageSize,
+  pageOffset,
+  totalRecords,
+  onPageChange,
+  onPageSizeChange,
+  onSortingChange,
+  sortingRules,
+  CheckBoxField,
+  previewMetadata,
+  setPreviewMetadata
+}) => {
+  const HIGHLIGHT_COLOR = "rgb(222, 252, 222)";
+
+  const TBodyGallery = useMemo(
+    () =>
+      class ReusedTBodyComponent extends Component {
+        public static innerComponent;
+        public render() {
+          return ReusedTBodyComponent.innerComponent;
+        }
+      },
+    []
+  );
+
+  const resolveGalleryProps = () => {
+    TBodyGallery.innerComponent = (
+      <StoredObjectGallery
+        CheckBoxField={CheckBoxField}
+        metadatas={(data as any) ?? []}
+        previewMetadataId={previewMetadata?.id as any}
+        onSelectPreviewMetadata={setPreviewMetadata}
+      />
+    );
+
+    return {
+      TbodyComponent: TBodyGallery,
+      getTrProps: (_, rowInfo) => {
+        if (rowInfo) {
+          const metadata: Metadata = rowInfo.original;
+          return {
+            style: {
+              background: metadata.id === previewMetadata?.id && HIGHLIGHT_COLOR
+            }
+          };
+        }
+        return {};
+      },
+      enableSorting: true,
+      enableMultiSort: true
+    };
+  };
+  return (
+    <MemoizedReactTable
+      columns={columns as any}
+      data={data}
+      loading={loading}
+      manualPagination={true}
+      pageSize={pageSize}
+      pageCount={Math.ceil(totalRecords / pageSize)}
+      page={pageOffset / pageSize}
+      onPageChange={onPageChange}
+      onPageSizeChange={onPageSizeChange}
+      manualSorting={true}
+      sort={sortingRules}
+      onSortingChange={onSortingChange}
+      {...resolveGalleryProps()}
       className="-striped react-table-overflow"
     />
   );

--- a/packages/common-ui/lib/list-page/tabs/tabs.tsx
+++ b/packages/common-ui/lib/list-page/tabs/tabs.tsx
@@ -1,0 +1,35 @@
+import { MaterialSample } from "../../../../dina-ui/types/collection-api/resources/MaterialSample";
+import { MemoizedReactTable } from "../QueryPageTable";
+import { QueryPageTabProps } from "../QueryPage";
+
+// ListViewTab.tsx
+export const ListViewTab: React.FC<QueryPageTabProps<MaterialSample>> = ({
+  data,
+  loading,
+  columns,
+  pageSize,
+  pageOffset,
+  totalRecords,
+  onPageChange,
+  onPageSizeChange,
+  onSortingChange,
+  sortingRules
+}) => {
+  return (
+    <MemoizedReactTable
+      columns={columns as any}
+      data={data}
+      loading={loading}
+      manualPagination={true}
+      pageSize={pageSize}
+      pageCount={Math.ceil(totalRecords / pageSize)}
+      page={pageOffset / pageSize}
+      onPageChange={onPageChange}
+      onPageSizeChange={onPageSizeChange}
+      manualSorting={true}
+      onSortingChange={onSortingChange}
+      sort={sortingRules}
+      className="-striped react-table-overflow"
+    />
+  );
+};

--- a/packages/common-ui/lib/list-page/tabs/tabs.tsx
+++ b/packages/common-ui/lib/list-page/tabs/tabs.tsx
@@ -3,8 +3,19 @@ import { Metadata } from "../../../../dina-ui/types/objectstore-api/resources/Me
 import { MemoizedReactTable } from "../QueryPageTable";
 import { QueryPageTabProps } from "../QueryPage";
 import { StoredObjectGallery } from "../../../../dina-ui/components/object-store";
-import React, { Component, useMemo } from "react";
+import React, { Component, useEffect, useMemo, useState } from "react";
 import { KitsuResource } from "kitsu";
+import { ColumnSelectorMemo } from "../../..";
+import { MultiSortTooltip } from "../MultiSortTooltip";
+import {
+  AttachSelectedButton,
+  BulkDeleteButton,
+  BulkEditButton,
+  BulkSplitButton,
+  DataExportButton
+} from "../../list-page-layout/bulk-buttons";
+import { CommonMessage } from "../../intl/common-ui-intl";
+import { useIntl } from "react-intl";
 
 export function ListViewTab<TData extends KitsuResource>({
   data,
@@ -16,24 +27,125 @@ export function ListViewTab<TData extends KitsuResource>({
   onPageChange,
   onPageSizeChange,
   onSortingChange,
-  sortingRules
+  sortingRules,
+  enableColumnSelector,
+  uniqueName,
+  indexMap,
+  dynamicFieldMapping,
+  displayedColumns,
+  onDisplayedColumnsChange,
+  excludedRelationshipTypes,
+  mandatoryDisplayedColumns,
+  nonExportableColumns,
+  bulkEditPath,
+  bulkDeleteButtonProps,
+  dataExportProps,
+  bulkSplitPath,
+  attachSelectedButtonsProps,
+  error,
+  enableMultiSort,
+  singleEditPath,
+  query,
+  indexName
 }: QueryPageTabProps<TData>) {
+  const { formatNumber } = useIntl();
+
+  const [columnSelectorLoading, setColumnSelectorLoading] =
+    useState<boolean>(true);
+
+  // If column selector is disabled, the loading spinner should be turned off.
+  useEffect(() => {
+    if (!enableColumnSelector) {
+      setColumnSelectorLoading(false);
+    }
+  }, [enableColumnSelector]);
   return (
-    <MemoizedReactTable
-      columns={columns as any}
-      data={data}
-      loading={loading}
-      manualPagination={true}
-      pageSize={pageSize}
-      pageCount={Math.ceil(totalRecords / pageSize)}
-      page={pageOffset / pageSize}
-      onPageChange={onPageChange}
-      onPageSizeChange={onPageSizeChange}
-      manualSorting={true}
-      onSortingChange={onSortingChange}
-      sort={sortingRules}
-      className="-striped react-table-overflow"
-    />
+    <div>
+      {enableColumnSelector && (
+        <ColumnSelectorMemo
+          uniqueName={uniqueName}
+          exportMode={false}
+          indexMapping={indexMap}
+          dynamicFieldsMappingConfig={dynamicFieldMapping}
+          displayedColumns={displayedColumns as any}
+          setDisplayedColumns={onDisplayedColumnsChange as any}
+          defaultColumns={columns as any}
+          setColumnSelectorLoading={setColumnSelectorLoading}
+          excludedRelationshipTypes={excludedRelationshipTypes}
+          mandatoryDisplayedColumns={mandatoryDisplayedColumns}
+          nonExportableColumns={nonExportableColumns}
+        />
+      )}
+      {bulkEditPath && (
+        <BulkEditButton
+          pathname={bulkEditPath}
+          singleEditPathName={singleEditPath}
+        />
+      )}
+      {bulkDeleteButtonProps && <BulkDeleteButton {...bulkDeleteButtonProps} />}
+      {dataExportProps && (
+        <DataExportButton
+          pathname={dataExportProps.dataExportPath}
+          entityLink={dataExportProps.entityLink}
+          totalRecords={totalRecords}
+          query={query}
+          uniqueName={uniqueName}
+          columns={columns}
+          dynamicFieldMapping={dynamicFieldMapping}
+          indexName={indexName}
+        />
+      )}
+      {bulkSplitPath && <BulkSplitButton pathname={bulkSplitPath} />}
+      {attachSelectedButtonsProps && (
+        <AttachSelectedButton {...attachSelectedButtonsProps} />
+      )}
+      <div className="d-flex align-items-end justify-content-between">
+        <div className="d-flex align-items-end">
+          <span id="queryPageCount">
+            {/* Loading indicator when total is not calculated yet. */}
+            {loading || columnSelectorLoading ? (
+              <></>
+            ) : (
+              <CommonMessage
+                id="tableTotalCount"
+                values={{ totalCount: formatNumber(totalRecords) }}
+              />
+            )}
+          </span>
+
+          {/* Multi sort tooltip - Only shown if it's possible to sort */}
+          {enableMultiSort && <MultiSortTooltip />}
+        </div>
+      </div>
+
+      {error && (
+        <div
+          className="alert alert-danger"
+          style={{
+            whiteSpace: "pre-line"
+          }}
+        >
+          <p>
+            {error.errors?.map((e) => e.detail).join("\n") ?? String(error)}
+          </p>
+        </div>
+      )}
+      <MemoizedReactTable
+        columns={columns as any}
+        data={data}
+        loading={loading || columnSelectorLoading}
+        manualPagination={true}
+        pageSize={pageSize}
+        pageCount={Math.ceil(totalRecords / pageSize)}
+        page={pageOffset / pageSize}
+        onPageChange={onPageChange}
+        onPageSizeChange={onPageSizeChange}
+        manualSorting={true}
+        onSortingChange={onSortingChange}
+        sort={sortingRules}
+        className="-striped react-table-overflow"
+      />
+    </div>
   );
 }
 

--- a/packages/dina-ui/page-tests/object-store/object/__tests__/list.test.tsx
+++ b/packages/dina-ui/page-tests/object-store/object/__tests__/list.test.tsx
@@ -275,11 +275,19 @@ describe("Metadata List Page", () => {
 
     await waitFor(() => {
       // Renders initially with the table view:
-      expect(wrapper.getByRole("radio", { name: /table/i })).toBeChecked();
+      expect(
+        wrapper.getByRole("tab", {
+          name: /list/i
+        })
+      ).toBeInTheDocument();
     });
 
     // Switch to gallery view.
-    userEvent.click(wrapper.getByRole("radio", { name: /gallery/i }));
+    userEvent.click(
+      wrapper.getByRole("tab", {
+        name: /gallery/i
+      })
+    );
 
     await waitFor(
       () => {

--- a/packages/dina-ui/pages/collection/material-sample/list.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/list.tsx
@@ -12,9 +12,7 @@ import {
   QueryPage,
   SimpleSearchFilterBuilder,
   stringArrayCell,
-  useApiClient,
-  QueryPageTabConfig,
-  ListViewTab
+  useApiClient
 } from "common-ui";
 import { PersistedResource } from "kitsu";
 import Link from "next/link";
@@ -529,14 +527,6 @@ export default function MaterialSampleListPage() {
     return undefined;
   };
 
-  const MATERIAL_SAMPLE_TABS: QueryPageTabConfig<MaterialSample>[] = [
-    {
-      id: "list",
-      labelKey: "listView",
-      component: ListViewTab
-    }
-  ];
-
   return (
     <div>
       <Head title={formatMessage("materialSampleListTitle")} />
@@ -583,8 +573,6 @@ export default function MaterialSampleListPage() {
             entityLink: "/collection/material-sample"
           }}
           bulkSplitPath="/collection/material-sample/bulk-split"
-          tabs={MATERIAL_SAMPLE_TABS}
-          defaultTab="list"
         />
       </main>
       <Footer />

--- a/packages/dina-ui/pages/collection/material-sample/list.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/list.tsx
@@ -27,7 +27,8 @@ import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import { MaterialSample } from "../../../types/collection-api";
 import { MdOutlineLibraryAdd } from "react-icons/md";
 import { MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID } from "../../../../dina-ui/components/controlled-vocabulary/controlledVocabularyItemUtils";
-
+import { QueryPageTabConfig } from "../../../../common-ui/lib/list-page/QueryPage";
+import { ListViewTab } from "../../../../common-ui/lib/list-page/tabs/tabs";
 export const MATERIAL_SAMPLE_NON_EXPORTABLE_COLUMNS: string[] = [
   "selectColumn",
   "assemblages.",
@@ -527,6 +528,14 @@ export default function MaterialSampleListPage() {
     return undefined;
   };
 
+  const MATERIAL_SAMPLE_TABS: QueryPageTabConfig<MaterialSample>[] = [
+    {
+      id: "list",
+      labelKey: "listView",
+      component: ListViewTab
+    }
+  ];
+
   return (
     <div>
       <Head title={formatMessage("materialSampleListTitle")} />
@@ -573,6 +582,8 @@ export default function MaterialSampleListPage() {
             entityLink: "/collection/material-sample"
           }}
           bulkSplitPath="/collection/material-sample/bulk-split"
+          tabs={MATERIAL_SAMPLE_TABS}
+          defaultTab="list"
         />
       </main>
       <Footer />

--- a/packages/dina-ui/pages/collection/material-sample/list.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/list.tsx
@@ -12,7 +12,9 @@ import {
   QueryPage,
   SimpleSearchFilterBuilder,
   stringArrayCell,
-  useApiClient
+  useApiClient,
+  QueryPageTabConfig,
+  ListViewTab
 } from "common-ui";
 import { PersistedResource } from "kitsu";
 import Link from "next/link";
@@ -27,8 +29,7 @@ import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import { MaterialSample } from "../../../types/collection-api";
 import { MdOutlineLibraryAdd } from "react-icons/md";
 import { MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID } from "../../../../dina-ui/components/controlled-vocabulary/controlledVocabularyItemUtils";
-import { QueryPageTabConfig } from "../../../../common-ui/lib/list-page/QueryPage";
-import { ListViewTab } from "../../../../common-ui/lib/list-page/tabs/tabs";
+
 export const MATERIAL_SAMPLE_NON_EXPORTABLE_COLUMNS: string[] = [
   "selectColumn",
   "assemblages.",

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -1,4 +1,3 @@
-import { useLocalStorage } from "@rehooks/local-storage";
 import {
   dateCell,
   FieldHeader,
@@ -14,18 +13,13 @@ import {
   DynamicFieldsMappingConfig,
   TableColumn
 } from "../../../../common-ui/lib/list-page/types";
-import { Component, useMemo, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Footer, Head, Nav, ThumbnailCell } from "../../../components";
-import {
-  MetadataPreview,
-  StoredObjectGallery
-} from "../../../components/object-store";
+import { MetadataPreview } from "../../../components/object-store";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import { Metadata } from "../../../types/objectstore-api";
 import Offcanvas from "react-bootstrap/Offcanvas";
 import { FaFileArrowUp } from "react-icons/fa6";
-
-type MetadataListLayoutType = "TABLE" | "GALLERY";
 
 export const OBJECT_STORE_NON_EXPORTABLE_COLUMNS: string[] = [
   "selectColumn",
@@ -34,10 +28,6 @@ export const OBJECT_STORE_NON_EXPORTABLE_COLUMNS: string[] = [
   "viewDetails",
   "imageLink."
 ];
-
-const LIST_LAYOUT_STORAGE_KEY = "metadata-list-layout";
-
-const HIGHLIGHT_COLOR = "rgb(222, 252, 222)";
 
 export const dynamicFieldMappingForMetadata: DynamicFieldsMappingConfig = {
   fields: [
@@ -59,9 +49,6 @@ export const dynamicFieldMappingForMetadata: DynamicFieldsMappingConfig = {
 
 export default function MetadataListPage() {
   const { formatMessage } = useDinaIntl();
-
-  const [listLayoutType, setListLayoutType] =
-    useLocalStorage<MetadataListLayoutType>(LIST_LAYOUT_STORAGE_KEY);
 
   const [screenWidth, setScreenWidth] = useState(window.innerWidth);
 
@@ -196,19 +183,6 @@ export default function MetadataListPage() {
     }
   ];
 
-  // Workaround to make sure react-table doesn't unmount TBodyComponent
-  // when MetadataListPage is re-rendered:
-  const TBodyGallery = useMemo(
-    () =>
-      class ReusedTBodyComponent extends Component {
-        public static innerComponent;
-        public render() {
-          return ReusedTBodyComponent.innerComponent;
-        }
-      },
-    []
-  );
-
   const OBJECT_STORE_TABS: QueryPageTabConfig<Metadata>[] = [
     {
       id: "list",
@@ -237,12 +211,7 @@ export default function MetadataListPage() {
               <DinaMessage id="objectListTitle" />
             </h1>
           </div>
-          <div className="list-inline-item">
-            <ListLayoutSelector
-              onChange={(newValue) => setListLayoutType(newValue)}
-              value={listLayoutType ?? undefined}
-            />
-          </div>
+          <div className="list-inline-item"></div>
           <div className="list-inline-item float-end">
             <Link
               href="/object-store/upload"
@@ -285,36 +254,6 @@ export default function MetadataListPage() {
                     id: "xmpMetadataDate"
                   }
                 ]}
-                reactTableProps={(responseData, CheckBoxField) => {
-                  TBodyGallery.innerComponent = (
-                    <StoredObjectGallery
-                      CheckBoxField={CheckBoxField}
-                      metadatas={(responseData as any) ?? []}
-                      previewMetadataId={previewMetadata?.id as any}
-                      onSelectPreviewMetadata={setPreviewMetadata}
-                    />
-                  );
-
-                  return {
-                    TbodyComponent:
-                      listLayoutType === "GALLERY" ? TBodyGallery : undefined,
-                    getTrProps: (_, rowInfo) => {
-                      if (rowInfo) {
-                        const metadata: Metadata = rowInfo.original;
-                        return {
-                          style: {
-                            background:
-                              metadata.id === previewMetadata?.id &&
-                              HIGHLIGHT_COLOR
-                          }
-                        };
-                      }
-                      return {};
-                    },
-                    enableSorting: true,
-                    enableMultiSort: true
-                  };
-                }}
                 tabs={OBJECT_STORE_TABS}
                 defaultTab="list"
               />
@@ -344,36 +283,6 @@ export default function MetadataListPage() {
         </div>
       </main>
       <Footer />
-    </div>
-  );
-}
-
-function ListLayoutSelector({ value = "TABLE", onChange }) {
-  const items = [
-    {
-      layoutType: "TABLE",
-      message: <DinaMessage id="metadataListTableLayout" />
-    },
-    {
-      layoutType: "GALLERY",
-      message: <DinaMessage id="metadataListGalleryLayout" />
-    }
-  ];
-
-  return (
-    <div className="list-layout-selector list-inline">
-      {items.map(({ message, layoutType }) => (
-        <div className="list-inline-item" key={layoutType}>
-          <label>
-            <input
-              type="radio"
-              checked={value === layoutType}
-              onChange={() => onChange(layoutType)}
-            />
-            {message}
-          </label>
-        </div>
-      ))}
     </div>
   );
 }

--- a/packages/dina-ui/pages/object-store/object/list.tsx
+++ b/packages/dina-ui/pages/object-store/object/list.tsx
@@ -4,7 +4,10 @@ import {
   FieldHeader,
   LoadingSpinner,
   QueryPage,
-  stringArrayCell
+  QueryPageTabConfig,
+  stringArrayCell,
+  ListViewTab,
+  GalleryViewTab
 } from "common-ui";
 import Link from "next/link";
 import {
@@ -206,6 +209,23 @@ export default function MetadataListPage() {
     []
   );
 
+  const OBJECT_STORE_TABS: QueryPageTabConfig<Metadata>[] = [
+    {
+      id: "list",
+      labelKey: "listView",
+      component: ListViewTab
+    },
+    {
+      id: "gallery",
+      labelKey: "galleryView",
+      component: GalleryViewTab,
+      config: {
+        previewMetadata,
+        setPreviewMetadata
+      }
+    }
+  ];
+
   return (
     <div>
       <Head title={formatMessage("objectListTitle")} />
@@ -295,6 +315,8 @@ export default function MetadataListPage() {
                     enableMultiSort: true
                   };
                 }}
+                tabs={OBJECT_STORE_TABS}
+                defaultTab="list"
               />
             </div>
           </div>


### PR DESCRIPTION
* Added support for multiple view tabs in `QueryPage` via new `tabs` and `defaultTab` props, allowing configuration of different views for search results.
* Implemented tab rendering logic using `react-tabs`, including tab selection state persistence and passing common props to each tab component. 
* Exported new tab components (`ListViewTab`, `GalleryViewTab`) and their configuration types for use in other pages. 
* Added new English messages for "List" and "Gallery" view labels to support i18n in the tabbed interface.
* Refactored the object store metadata list page to use the new tabbed interface, removing legacy layout state and gallery view logic. 
* Updated tests to interact with the new tabbed UI, checking for tabs instead of radio buttons.
* Added mock responses for tabbed views to support testing of the new interface.