### PR TITLE
fix: add organism to supportedResourceTypes

### DIFF
--- a/packages/common-ui/lib/api-client/ApiClientContext.tsx
+++ b/packages/common-ui/lib/api-client/ApiClientContext.tsx
@@ -267,6 +267,7 @@ export class ApiClientImpl implements ApiClientI {
       "object-upload",
       "metadata",
       "material-sample",
+      "organism",
       "collecting-event",
       "user",
       "storage-unit",


### PR DESCRIPTION
I think this line was missing now that the new bulk API / repository v2 is available