### PR TITLE
Bug #38033 fix records added graph

### DIFF
--- a/packages/dina-ui/components/collection/charts/RecordsAddedChart.tsx
+++ b/packages/dina-ui/components/collection/charts/RecordsAddedChart.tsx
@@ -65,8 +65,8 @@ export default function RecordsAddedChart({
     {
       key: "last-3-months",
       label: "Last 3 Months",
-      interval: "week",
-      format: "yyyy-ww",
+      interval: "day",
+      format: "yyyy-MM-dd",
       getDates: () => {
         const now = new Date();
         const start = new Date(
@@ -99,6 +99,20 @@ export default function RecordsAddedChart({
       }
     },
     {
+      key: "this-year",
+      label: "This Year",
+      interval: "month",
+      format: "yyyy-MM",
+      getDates: () => {
+        const now = new Date();
+        const start = new Date(now.getFullYear(), 0, 1);
+        return {
+          start: start.toISOString().split("T")[0],
+          end: now.toISOString().split("T")[0]
+        };
+      }
+    },
+    {
       key: "last-year",
       label: "Last Year",
       interval: "month",
@@ -110,20 +124,6 @@ export default function RecordsAddedChart({
           now.getMonth(),
           now.getDate()
         );
-        return {
-          start: start.toISOString().split("T")[0],
-          end: now.toISOString().split("T")[0]
-        };
-      }
-    },
-    {
-      key: "this-year",
-      label: "This Year",
-      interval: "month",
-      format: "yyyy-MM",
-      getDates: () => {
-        const now = new Date();
-        const start = new Date(now.getFullYear(), 0, 1);
         return {
           start: start.toISOString().split("T")[0],
           end: now.toISOString().split("T")[0]
@@ -143,11 +143,13 @@ export default function RecordsAddedChart({
   ];
 
   const buildQuery = () => {
-    const query = inputQuery ?? {
-      bool: {
-        must: []
-      }
-    };
+    const query = inputQuery
+      ? structuredClone(inputQuery)
+      : {
+          bool: {
+            must: []
+          }
+        };
 
     if (dateRange.start || dateRange.end) {
       const rangeFilter: any = {
@@ -462,7 +464,7 @@ export default function RecordsAddedChart({
             <DinaMessage id="dateRangeHeaderByYear" />
           </Dropdown.Header>
           <Dropdown.Item
-            eventKey="year-to-date"
+            eventKey="this-year"
             active={selectedPreset === "this-year"}
           >
             <DinaMessage id="dateRangeThisYearDropdown" />

--- a/packages/dina-ui/components/collection/charts/RecordsAddedChart.tsx
+++ b/packages/dina-ui/components/collection/charts/RecordsAddedChart.tsx
@@ -3,6 +3,7 @@ import { useApiClient } from "common-ui";
 import ReactECharts from "echarts-for-react";
 import { DinaMessage } from "../../../intl/dina-ui-intl";
 import { Dropdown, DropdownButton, Card } from "react-bootstrap";
+import _ from "lodash";
 interface RecordsAddedChartProps {
   inputQuery?: any;
 }
@@ -131,7 +132,17 @@ export default function RecordsAddedChart({
       }
     },
     {
-      key: "all-time",
+      key: "all-time-month",
+      label: "All Time",
+      interval: "month",
+      format: "yyyy-MM",
+      getDates: () => ({
+        start: undefined,
+        end: undefined
+      })
+    },
+    {
+      key: "all-time-year",
       label: "All Time",
       interval: "year",
       format: "yyyy",
@@ -144,7 +155,7 @@ export default function RecordsAddedChart({
 
   const buildQuery = () => {
     const query = inputQuery
-      ? structuredClone(inputQuery)
+      ? _.cloneDeep(inputQuery)
       : {
           bool: {
             must: []
@@ -427,7 +438,7 @@ export default function RecordsAddedChart({
 
           <Dropdown.Divider />
           <Dropdown.Header>
-            <DinaMessage id="dateRangeHeaderRecent" />
+            <DinaMessage id="dateRangeHeaderByDay" />
           </Dropdown.Header>
           <Dropdown.Item
             eventKey="last-7-days"
@@ -442,27 +453,24 @@ export default function RecordsAddedChart({
             <DinaMessage id="dateRangeLast30DaysDropdown" />
           </Dropdown.Item>
 
-          <Dropdown.Divider />
-          <Dropdown.Header>
-            <DinaMessage id="dateRangeHeaderByMonth" />
-          </Dropdown.Header>
           <Dropdown.Item
             eventKey="last-3-months"
             active={selectedPreset === "last-3-months"}
           >
             <DinaMessage id="dateRangeLast3MonthsDropdown" />
           </Dropdown.Item>
+
+          <Dropdown.Divider />
+
+          <Dropdown.Header>
+            <DinaMessage id="dateRangeHeaderByMonth" />
+          </Dropdown.Header>
           <Dropdown.Item
             eventKey="last-6-months"
             active={selectedPreset === "last-6-months"}
           >
             <DinaMessage id="dateRangeLast6MonthsDropdown" />
           </Dropdown.Item>
-
-          <Dropdown.Divider />
-          <Dropdown.Header>
-            <DinaMessage id="dateRangeHeaderByYear" />
-          </Dropdown.Header>
           <Dropdown.Item
             eventKey="this-year"
             active={selectedPreset === "this-year"}
@@ -475,11 +483,20 @@ export default function RecordsAddedChart({
           >
             <DinaMessage id="dateRangeLastYearDropdown" />
           </Dropdown.Item>
+          <Dropdown.Item
+            eventKey="all-time-month"
+            active={selectedPreset === "all-time-month"}
+          >
+            <DinaMessage id="dateRangeAllTimeDropdown" />
+          </Dropdown.Item>
 
           <Dropdown.Divider />
+          <Dropdown.Header>
+            <DinaMessage id="dateRangeHeaderByYear" />
+          </Dropdown.Header>
           <Dropdown.Item
-            eventKey="all-time"
-            active={selectedPreset === "all-time"}
+            eventKey="all-time-year"
+            active={selectedPreset === "all-time-year"}
           >
             <DinaMessage id="dateRangeAllTimeDropdown" />
           </Dropdown.Item>

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -215,7 +215,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   dateRangeThisYearDropdown: "This Year",
   dateRangeAllTimeDropdown: "All Time",
   dateRangeHeaderRealTime: "Real-time",
-  dateRangeHeaderRecent: "Recent",
+  dateRangeHeaderByDay: "By Day",
   dateRangeHeaderByMonth: "By Month",
   dateRangeHeaderByYear: "By Year",
   decimalLatLong: "Decimal Lat/Long",


### PR DESCRIPTION
**Date Range Preset Improvements:**

* Reorganized and renamed date presets: "last-3-months" now uses a daily interval, "this-year" and "last-year" are swapped and have corrected start dates, and two new presets "all-time-month" and "all-time-year" are introduced for "All Time" filtering by month and year. [[1]](diffhunk://#diff-988e37332165b3ef5d58f65f72b48e21a53ae746bd0a7f5270339b7bd48ac3a6L68-R70) [[2]](diffhunk://#diff-988e37332165b3ef5d58f65f72b48e21a53ae746bd0a7f5270339b7bd48ac3a6L102-R145)
* Updated dropdown menu to match new presets, including correct ordering, new headers ("By Day", "By Month", "By Year"), and new items for "All Time" month and year intervals. [[1]](diffhunk://#diff-988e37332165b3ef5d58f65f72b48e21a53ae746bd0a7f5270339b7bd48ac3a6L428-R441) [[2]](diffhunk://#diff-988e37332165b3ef5d58f65f72b48e21a53ae746bd0a7f5270339b7bd48ac3a6L443-R475) [[3]](diffhunk://#diff-988e37332165b3ef5d58f65f72b48e21a53ae746bd0a7f5270339b7bd48ac3a6R486-R499)

**Query Handling:**

* Improved query construction by deep cloning the input query using lodash to prevent mutation of the original object.
* Added lodash import to support deep cloning.

**UI Label Updates:**

* Changed English translation for the "Recent" header to "By Day" for better clarity in the dropdown.