### PR TITLE
1780: added coordinate input widget

### DIFF
--- a/packages/dina-ui/components/collection/site/MapToggleSwitch.tsx
+++ b/packages/dina-ui/components/collection/site/MapToggleSwitch.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import Switch from "react-switch";
+
+export function MapToggleSwitch({
+  showMap,
+  onToggle,
+  formatMessage
+}: {
+  showMap: boolean;
+  onToggle: (checked: boolean) => void;
+  formatMessage: (key: string) => string;
+}) {
+  return (
+    <div className="d-flex align-items-center gap-2 mb-2">
+      <span className={showMap ? "opacity-100" : "opacity-50"}>
+        <label htmlFor="mapToggler">
+          <strong>{formatMessage("siteMap")}</strong>
+        </label>
+      </span>
+
+      <Switch onChange={onToggle} checked={showMap} id="mapToggler" />
+
+      <span className={showMap ? "opacity-50" : "opacity-100"}>
+        <label htmlFor="mapToggler">
+          <strong>{formatMessage("siteCoordinates")}</strong>
+        </label>
+      </span>
+    </div>
+  );
+}

--- a/packages/dina-ui/components/collection/site/PolygonEditorCoordinates.tsx
+++ b/packages/dina-ui/components/collection/site/PolygonEditorCoordinates.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { POLYGON_EDITOR_MODE } from "packages/dina-ui/types/geo/polygon-editor-mode.types";
+import { validatePolygon } from "packages/dina-ui/utils/geoUtils";
+import { useDinaIntl } from "packages/dina-ui/intl/dina-ui-intl";
+import type { PolygonEditorMode } from "packages/dina-ui/types/geo/polygon-editor-mode.types";
+import type { GeoPosition } from "packages/dina-ui/types/geo/geo.types";
+
+export default function PolygonEditorCoordinates({
+  coords,
+  mode,
+  onCoordsChange
+}: {
+  coords: GeoPosition[][];
+  mode: PolygonEditorMode;
+  onCoordsChange: (coords: GeoPosition[][]) => void;
+}) {
+  const { formatMessage } = useDinaIntl();
+  const [error, setError] = useState<string>("");
+
+  if (mode === POLYGON_EDITOR_MODE.VIEW)
+    return <div className="mb-4">{JSON.stringify(coords)}</div>;
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    let parsed: GeoPosition[][];
+    try {
+      parsed = JSON.parse(e.target.value);
+    } catch (_err) {
+      setError(formatMessage("invalidPolygon"));
+      return;
+    }
+
+    const isValid = validatePolygon(parsed);
+    if (isValid) {
+      onCoordsChange(parsed);
+      setError("");
+    } else {
+      setError(formatMessage("invalidPolygon"));
+    }
+  };
+
+  return (
+    <>
+      {error && <p className="text-danger fw-bold">{error}</p>}
+      <textarea
+        onChange={handleChange}
+        style={{ height: "350px" }}
+        className="border mb-4 w-100"
+      >
+        {coords.length === 0 ? "" : JSON.stringify(coords, null, 2)}
+      </textarea>
+    </>
+  );
+}

--- a/packages/dina-ui/components/collection/site/PolygonEditorCoordinates.tsx
+++ b/packages/dina-ui/components/collection/site/PolygonEditorCoordinates.tsx
@@ -18,7 +18,19 @@ export default function PolygonEditorCoordinates({
   const [error, setError] = useState<string>("");
 
   if (mode === POLYGON_EDITOR_MODE.VIEW)
-    return <div className="mb-4">{JSON.stringify(coords)}</div>;
+    return (
+      <pre
+        className="mb-4 col-md-6 border"
+        style={{
+          whiteSpace: "pre-wrap",
+          height: "350px",
+          overflowY: "auto",
+          borderRadius: "5px"
+        }}
+      >
+        {JSON.stringify(coords, null, 2)}
+      </pre>
+    );
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     let parsed: GeoPosition[][];

--- a/packages/dina-ui/components/collection/site/PolygonEditorMap.tsx
+++ b/packages/dina-ui/components/collection/site/PolygonEditorMap.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import ArcGISLoader from "../../geo/ArcGISLoader";
 import { POLYGON_EDITOR_MODE } from "packages/dina-ui/types/geo/polygon-editor-mode.types";
 import {
   getMapModules,
@@ -6,19 +7,16 @@ import {
 } from "packages/dina-ui/utils/geoUtils";
 import type { PolygonEditorMode } from "packages/dina-ui/types/geo/polygon-editor-mode.types";
 import type { GeoPosition } from "packages/dina-ui/types/geo/geo.types";
-import ArcGISLoader from "../../geo/ArcGISLoader";
-
-type Props = {
-  coords: GeoPosition[][];
-  mode?: PolygonEditorMode;
-  onCoordsChange: (coords: GeoPosition[][]) => void;
-};
 
 export default function PolygonEditorMap({
   coords,
   mode,
   onCoordsChange
-}: Props) {
+}: {
+  coords: GeoPosition[][];
+  mode?: PolygonEditorMode;
+  onCoordsChange: (coords: GeoPosition[][]) => void;
+}) {
   const mapRef = useRef<HTMLDivElement>(null);
   const sketchRef = useRef<any>(null);
   const [graphicsLayer, setGraphicsLayer] = useState<any>(null);
@@ -125,7 +123,7 @@ export default function PolygonEditorMap({
       <div
         className="mt-2 mb-4 w-100 rounded-2 overflow-hidden"
         style={{
-          height: "250px",
+          height: "350px",
           background: "#f2f2f2"
         }}
       >

--- a/packages/dina-ui/components/collection/site/SiteFormLayout.tsx
+++ b/packages/dina-ui/components/collection/site/SiteFormLayout.tsx
@@ -13,17 +13,20 @@ import {
 } from "packages/dina-ui/components";
 import { DinaMessage, useDinaIntl } from "packages/dina-ui/intl/dina-ui-intl";
 import { AllowAttachmentsConfig } from "packages/dina-ui/components/object-store";
-import type { GeoPosition } from "packages/dina-ui/types/geo/geo.types";
 import { Site } from "packages/dina-ui/types/collection-api";
-import { PolygonEditorMode } from "packages/dina-ui/types/geo/polygon-editor-mode.types";
 import PolygonEditorMap from "./PolygonEditorMap";
+import { MapToggleSwitch } from "./MapToggleSwitch";
+import PolygonEditorCoordinates from "./PolygonEditorCoordinates";
+import type { PolygonEditorMode } from "packages/dina-ui/types/geo/polygon-editor-mode.types";
+import type { GeoPosition } from "packages/dina-ui/types/geo/geo.types";
 
-type Props = {
+export default function SiteFormLayout({
+  mode,
+  attachmentsConfig
+}: {
   mode: PolygonEditorMode;
   attachmentsConfig?: AllowAttachmentsConfig;
-};
-
-export default function SiteFormLayout({ mode, attachmentsConfig }: Props) {
+}) {
   const { formatMessage } = useDinaIntl();
   const { readOnly } = useDinaFormContext();
   const [{ value }] = useField("siteGeom");
@@ -38,6 +41,8 @@ export default function SiteFormLayout({ mode, attachmentsConfig }: Props) {
       coordinates: coords
     });
   }, [coords, setFieldValue]);
+
+  const [showMap, setShowMap] = useState(true);
 
   return (
     <div>
@@ -63,16 +68,33 @@ export default function SiteFormLayout({ mode, attachmentsConfig }: Props) {
         />
       </div>
       <div className="row">
-        <div className={`col-md-6 ${coords.length === 0 && "mb-4"}`}>
-          <div className="">
-            <strong>{formatMessage("siteCoordinates")}</strong>
+        {readOnly && coords.length === 0 && (
+          <div className="col-md-6 mb-4">
+            <strong>{formatMessage("siteMap")}</strong>
           </div>
+        )}
+        <div className={readOnly && !showMap ? "col-md-12" : "col-md-6"}>
           {(!readOnly || coords.length > 0) && (
-            <PolygonEditorMap
-              coords={coords}
-              mode={mode}
-              onCoordsChange={setCoords}
-            />
+            <>
+              <MapToggleSwitch
+                showMap={showMap}
+                onToggle={setShowMap}
+                formatMessage={formatMessage}
+              />
+              {showMap ? (
+                <PolygonEditorMap
+                  coords={coords}
+                  mode={mode}
+                  onCoordsChange={setCoords}
+                />
+              ) : (
+                <PolygonEditorCoordinates
+                  coords={coords}
+                  mode={mode}
+                  onCoordsChange={setCoords}
+                />
+              )}
+            </>
           )}
         </div>
       </div>

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -1408,12 +1408,14 @@ export const DINAUI_MESSAGES_ENGLISH = {
   siteListTitle: "Site",
   siteAttachments: "Site Attachments",
   code: "Code",
-  siteCoordinates: "Site coordinates",
+  siteMap: "Site Map",
+  siteCoordinates: "Site Coordinates",
   waitingForPolygonData: "Waiting for polygon data...",
   addSite: "Add Site",
   editSite: "Edit Site",
   createOnMap: "Create on Map",
   editOnMap: "Edit on Map",
   erase: "Erase",
-  close: "Close"
+  close: "Close",
+  invalidPolygon: "The coordinates are invalid: must be number[][][] and closed"
 };

--- a/packages/dina-ui/intl/dina-ui-fr.ts
+++ b/packages/dina-ui/intl/dina-ui-fr.ts
@@ -948,6 +948,7 @@ export const DINAUI_MESSAGES_FRENCH: Partial<typeof DINAUI_MESSAGES_ENGLISH> = {
   siteListTitle: "Site",
   siteAttachments: "Pièces jointes au site",
   code: "Code",
+  siteMap: "Plan du site",
   siteCoordinates: "Coordonnées du site",
   waitingForPolygonData: "En attente des données polygonales...",
   addSite: "Ajouter un site",
@@ -955,5 +956,7 @@ export const DINAUI_MESSAGES_FRENCH: Partial<typeof DINAUI_MESSAGES_ENGLISH> = {
   createOnMap: "Créer sur la carte",
   editOnMap: "Modifier sur la carte",
   erase: "Effacer",
-  close: "Fermer"
+  close: "Fermer",
+  invalidPolygon:
+    "Les coordonnées sont invalides : elles doivent être de type nombre[][][] et fermées"
 };

--- a/packages/dina-ui/utils/geoUtils.ts
+++ b/packages/dina-ui/utils/geoUtils.ts
@@ -2,7 +2,8 @@ import { loadModules } from "esri-loader";
 import type { GeoPosition } from "packages/dina-ui/types/geo/geo.types";
 
 /**
- * Internal cached ArcGIS map modules and projection modules
+ * Internal cached ArcGIS map modules and projection modules.
+ * Once we upgrade to use @arcgis/core, we can improve type safety.
  */
 let mapModulesPromise: Promise<{
   Map: any;
@@ -38,6 +39,7 @@ export async function getMapModules() {
   return mapModulesPromise;
 }
 
+// Singleton cache
 let projectionModulesPromise: Promise<{
   Polygon: any;
   projection: any;
@@ -53,12 +55,15 @@ async function getProjectionModules() {
       "esri/geometry/Polygon",
       "esri/geometry/projection",
       "esri/geometry/SpatialReference"
-    ]).then(async ([Polygon, projection, SpatialReference]) => {
-      // Load projection engine ONCE
-      await projection.load();
-
-      return { Polygon, projection, SpatialReference };
-    });
+    ])
+      .then(async ([Polygon, projection, SpatialReference]) => {
+        await projection.load();
+        return { Polygon, projection, SpatialReference };
+      })
+      .catch((err) => {
+        projectionModulesPromise = null; // allow retry
+        throw err;
+      });
   }
 
   return projectionModulesPromise;
@@ -90,4 +95,47 @@ export async function projectPolygon3857To4326(
   }
 
   return polygon4326.rings as GeoPosition[][];
+}
+
+// An empty polygon ([]) is considered valid
+export function validatePolygon(polygon: GeoPosition[][]): boolean {
+  if (!Array.isArray(polygon)) {
+    return false;
+  }
+
+  for (let i = 0; i < polygon.length; i++) {
+    const ring = polygon[i];
+
+    if (!Array.isArray(ring) || ring.length < 4) {
+      return false;
+    }
+
+    for (const pos of ring) {
+      if (
+        !Array.isArray(pos) ||
+        pos.length !== 2 ||
+        typeof pos[0] !== "number" ||
+        typeof pos[1] !== "number" ||
+        !isFinite(pos[0]) ||
+        !isFinite(pos[1])
+      ) {
+        return false;
+      }
+
+      const [lng, lat] = pos;
+
+      if (lng < -180 || lng > 180 || lat < -90 || lat > 90) {
+        return false;
+      }
+    }
+
+    const first = ring[0];
+    const last = ring[ring.length - 1];
+
+    if (first[0] !== last[0] || first[1] !== last[1]) {
+      return false;
+    }
+  }
+
+  return true;
 }


### PR DESCRIPTION
Implemented the following features:

- Enabled polygon creation, display, and editing using coordinate input
- Added validation logic for polygon coordinates
- Ensured two-way synchronization between the map and coordinate input