### PR TITLE
Support #37201 - Include sequence run attachment table on results tab

### DIFF
--- a/packages/dina-ui/components/object-store/attachment-list/AttachmentsField.tsx
+++ b/packages/dina-ui/components/object-store/attachment-list/AttachmentsField.tsx
@@ -23,7 +23,7 @@ import { AttachmentReadOnlySection } from "./AttachmentReadOnlySection";
 import classNames from "classnames";
 import { KitsuResource, PersistedResource } from "kitsu";
 import { ColumnDef } from "@tanstack/react-table";
-import { FaPaperclip, FaTimes } from "react-icons/fa";
+import { FaPaperclip, FaTimes, FaUnlink } from "react-icons/fa";
 
 export interface AttachmentsFieldProps {
   name: string;
@@ -169,23 +169,27 @@ export function AttachmentsEditor({
     {
       id: "actionColumn",
       size: 0,
-      header: () => <FieldHeader name={formatMessage("remove")} />,
+      header: () => <FieldHeader name={formatMessage("actions")} />,
       cell: ({
         row: {
           original: { id: mId }
         }
       }) => (
-        <button
-          className="btn btn-dark remove-attachment"
-          onClick={() =>
-            removeMetadata(
-              mId?.replace("?include=derivatives", "") ?? "unknown"
-            )
-          }
-          type="button"
-        >
-          <DinaMessage id="remove" />
-        </button>
+        <div className="settings-button-container">
+          <button
+            className="btn btn-danger remove-attachment"
+            onClick={() =>
+              removeMetadata(
+                mId?.replace("?include=derivatives", "") ?? "unknown"
+              )
+            }
+            type="button"
+            style={{ paddingLeft: "15px", paddingRight: "15px", width: "9rem" }}
+          >
+            <FaUnlink className="me-2" />
+            <DinaMessage id="detach" />
+          </button>
+        </div>
       )
     }
   ];

--- a/packages/dina-ui/components/object-store/attachment-list/__tests__/AttachmentsField.test.tsx
+++ b/packages/dina-ui/components/object-store/attachment-list/__tests__/AttachmentsField.test.tsx
@@ -369,7 +369,7 @@ describe("AttachmentsField component", () => {
       expect(container.querySelectorAll("tbody tr").length).toEqual(2);
     });
 
-    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    const removeButtons = screen.getAllByRole("button", { name: /detach/i });
     fireEvent.click(removeButtons[0]);
 
     await waitFor(() => {

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/MolecularAnalysisResultsStep.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/MolecularAnalysisResultsStep.tsx
@@ -22,6 +22,8 @@ import { MolecularAnalysisRunItem } from "../../../types/seqdb-api/resources/mol
 import { useMolecularAnalysisRunColumns } from "../../molecular-analysis/useMolecularAnalysisRunColumns";
 import { useState } from "react";
 import { FaMagic } from "react-icons/fa";
+import { AttachmentsEditor } from "../../object-store";
+import { ResourceIdentifierObject } from "jsonapi-typescript";
 
 export interface MolecularAnalysisResultsStepProps {
   molecularAnalysisId: string;
@@ -51,7 +53,9 @@ export function MolecularAnalysisResultsStep({
     setReloadGenericMolecularAnalysisRun,
     qualityControls,
     qualityControlTypes,
-    updateExistingQualityControls
+    updateExistingQualityControls,
+    attachments,
+    setAttachments
   } = useGenericMolecularAnalysisRun({
     editMode,
     setEditMode,
@@ -93,6 +97,15 @@ export function MolecularAnalysisResultsStep({
       qualityControlTypes,
       deps: [qualityControlTypes]
     });
+
+  // Attachments saving for the Sequencing run
+  const saveAttachments = async (
+    newAttachments: ResourceIdentifierObject[]
+  ) => {
+    setAttachments(newAttachments);
+    setEditMode(true);
+    setPerformSave(true);
+  };
 
   // Display loading if network requests from hook are still loading in...
   if (loading) {
@@ -395,6 +408,23 @@ export function MolecularAnalysisResultsStep({
               </div>
             </div>
           )}
+
+          {/* Run Attachments */}
+          <div className="mt-3">
+            <DinaForm
+              initialValues={{ attachments: attachments }}
+              readOnly={!editMode}
+            >
+              <AttachmentsEditor
+                name="attachments"
+                onChange={saveAttachments}
+                value={attachments}
+                title={
+                  <DinaMessage id="molecularAnalysisRunStep_attachments" />
+                }
+              />
+            </DinaForm>
+          </div>
         </>
       ) : (
         <div className="row">

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisResultStep.test.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisResultStep.test.tsx
@@ -792,7 +792,7 @@ describe("Molecular Analysis Workflow - Step 5 - Molecular Analysis Results Step
 
       // Expect existing attachments to be shown for QC 1
       expect(
-        wrapper.getByText(TEST_METADATA_1?.originalFilename ?? "")
+        wrapper.getAllByText(TEST_METADATA_1?.originalFilename ?? "")[0]
       ).toBeInTheDocument();
       expect(
         wrapper.getByText(TEST_METADATA_2?.originalFilename ?? "")
@@ -1262,6 +1262,48 @@ describe("Molecular Analysis Workflow - Step 5 - Molecular Analysis Results Step
               type: "molecular-analysis-result"
             },
             type: "molecular-analysis-result"
+          }
+        ],
+        { apiBaseUrl: "/seqdb-api" }
+      );
+    });
+  });
+
+  describe("Sequencing Run Attachments Section", () => {
+    it("Detaches an existing run attachment", async () => {
+      const wrapper = mountWithAppContext(<TestComponentWrapper />, testCtx);
+      await waitForLoadingToDisappear();
+
+      // The run attachment (japan.jpg / TEST_METADATA_1) should be visible
+      expect(
+        wrapper.getAllByText(TEST_METADATA_1.originalFilename ?? "")[1]
+      ).toBeInTheDocument();
+
+      // Find and click the detach button for that attachment
+      const detachButtons = wrapper.getAllByRole("button", { name: /detach/i });
+      // The last detach button belongs to the run attachments table
+      userEvent.click(detachButtons[detachButtons.length - 1]);
+
+      // Trigger the save
+      await waitFor(() => {
+        expect(mockSave).toHaveBeenCalled();
+      });
+
+      // The attachment should have been saved with it removed
+      expect(mockSave).toHaveBeenCalledWith(
+        [
+          {
+            id: TEST_MOLECULAR_ANALYSIS_RUN_ID,
+            resource: {
+              id: TEST_MOLECULAR_ANALYSIS_RUN_ID,
+              relationships: {
+                attachments: {
+                  data: []
+                }
+              },
+              type: "molecular-analysis-run"
+            },
+            type: "molecular-analysis-run"
           }
         ],
         { apiBaseUrl: "/seqdb-api" }

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisRunStep.test.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/__tests__/MolecularAnalysisRunStep.test.tsx
@@ -1140,11 +1140,11 @@ describe("Molecular Analysis Workflow - Step 4 - Molecular Analysis Run Step", (
     expect(wrapper.queryByText(/edit mode: true/i)).toBeInTheDocument();
 
     // Remove all the attachments for the quality control
-    userEvent.click(wrapper.getAllByRole("button", { name: /remove/i })[0]);
+    userEvent.click(wrapper.getAllByRole("button", { name: /detach/i })[0]);
     await waitForElementToBeRemoved(
       wrapper.queryAllByText(/loading\.\.\./i)[0]
     );
-    userEvent.click(wrapper.getAllByRole("button", { name: /remove/i })[0]);
+    userEvent.click(wrapper.getAllByRole("button", { name: /detach/i })[0]);
 
     // Click the save button.
     userEvent.click(wrapper.getByRole("button", { name: /save/i }));

--- a/packages/dina-ui/components/seqdb/molecular-analysis-workflow/useGenericMolecularAnalysisRun.tsx
+++ b/packages/dina-ui/components/seqdb/molecular-analysis-workflow/useGenericMolecularAnalysisRun.tsx
@@ -452,7 +452,13 @@ export function useGenericMolecularAnalysisRun({
             );
 
             if (runQuery && (runQuery as any)?.data?.attachments) {
-              setAttachments((runQuery as any)?.data?.attachments);
+              const loadedAttachments = (runQuery as any)?.data?.attachments;
+              setAttachments(loadedAttachments);
+              // Also update the sequencingRun so the comparison works correctly
+              setSequencingRun({
+                ...run,
+                attachments: loadedAttachments
+              });
             }
           }
         }
@@ -706,23 +712,22 @@ export function useGenericMolecularAnalysisRun({
     attachments1: ResourceIdentifierObject[],
     attachments2: ResourceIdentifierObject[]
   ): boolean {
+    const normalized1 = attachments1 ?? [];
+    const normalized2 = attachments2 ?? [];
+
     // Both do not contain attachments, no changes.
-    if (!attachments1 && !attachments2) {
+    if (normalized1.length === 0 && normalized2.length === 0) {
       return false;
     }
 
     // Length or one is undefined/null, changes made.
-    if (
-      !attachments1 ||
-      !attachments2 ||
-      attachments1.length !== attachments2.length
-    ) {
+    if (normalized1.length !== normalized2.length) {
       return true;
     }
 
     // Final case is same length but different ids.
-    const ids1 = attachments1.map((a) => a.id).sort();
-    const ids2 = attachments2.map((a) => a.id).sort();
+    const ids1 = normalized1.map((a) => a.id).sort();
+    const ids2 = normalized2.map((a) => a.id).sort();
     return !_.isEqual(ids1, ids2);
   }
 

--- a/packages/dina-ui/pages/seqdb/molecular-analysis-workflow/run.tsx
+++ b/packages/dina-ui/pages/seqdb/molecular-analysis-workflow/run.tsx
@@ -155,7 +155,7 @@ export default function MolecularAnalysisWorkflowRunPage() {
       <div className="col-md-4">
         <BackToListButton entityLink="/seqdb/molecular-analysis-workflow" />
       </div>
-      {currentStep > 2 && (
+      {currentStep > 2 && !editMode && (
         <Button
           variant={"secondary"}
           className="ms-auto"


### PR DESCRIPTION
- Added sequencing run attachment section to result tab.
- Improved the look of the "Remove" button. Should be "Detach". Added icon and better styling.
- Fixed issue with Export button appearing on run tab when editing.