### PR TITLE
Support #38042 - Query builder should support keyword directly

### DIFF
--- a/packages/common-ui/lib/list-page/__tests__/UseElasticSearchDistinctTerm.test.tsx
+++ b/packages/common-ui/lib/list-page/__tests__/UseElasticSearchDistinctTerm.test.tsx
@@ -144,7 +144,7 @@ describe("Use Elastic Search Distinct Term Hook", () => {
               terms: { field: FIELD_NAME + ".keyword", size: 100 }
             }
           },
-          query: { terms: { "data.attributes.group.keyword": GROUPS } },
+          query: { terms: { "data.attributes.group": GROUPS } },
           size: 0
         },
         { params: { indexName: INDEX_NAME } }
@@ -185,7 +185,7 @@ describe("Use Elastic Search Distinct Term Hook", () => {
               terms: { field: FIELD_NAME, size: 100 }
             }
           },
-          query: { terms: { "data.attributes.group.keyword": GROUPS } },
+          query: { terms: { "data.attributes.group": GROUPS } },
           size: 0
         },
         { params: { indexName: INDEX_NAME } }
@@ -223,7 +223,7 @@ describe("Use Elastic Search Distinct Term Hook", () => {
         "search-api/search-ws/search",
         {
           size: 0,
-          query: { terms: { "data.attributes.group.keyword": GROUPS } },
+          query: { terms: { "data.attributes.group": GROUPS } },
           aggs: {
             included_aggregation: {
               nested: { path: "included" },

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-core-components/QueryOperatorSelector.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-core-components/QueryOperatorSelector.tsx
@@ -58,14 +58,6 @@ export function QueryOperatorSelector({
   // Some options are displayed only if it is supported.
   const operationOptions = options
     ?.filter((option) => {
-      // Only display the exact match option if keyword support exist.
-      if (
-        option.key === "exactMatch" &&
-        !selectedFieldMapping?.keywordMultiFieldSupport
-      ) {
-        return false;
-      }
-
       // Only display the infix option if it is supported in the mapping.
       if (
         option.key === "containsText" &&
@@ -92,7 +84,8 @@ export function QueryOperatorSelector({
       // Between for the text type should only be displayed if numeric keyword exists.
       if (
         option.key === "between" &&
-        selectedFieldMapping?.type === "text" &&
+        (selectedFieldMapping?.type === "text" ||
+          selectedFieldMapping?.type === "keyword") &&
         !selectedFieldMapping?.keywordNumericSupport
       ) {
         return false;

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchExport.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/QueryBuilderElasticSearchExport.tsx
@@ -401,9 +401,7 @@ export function applyGroupFilters(elasticSearchQuery: any, groups: string[]) {
           ...(elasticSearchQuery?.query?.bool?.must ?? []),
           {
             [multipleGroups ? "terms" : "term"]: {
-              "data.attributes.group.keyword": multipleGroups
-                ? groups
-                : groups[0]
+              "data.attributes.group": multipleGroups ? groups : groups[0]
             }
           }
         ]

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/__snapshots__/QueryBuilderElasticSearchExport.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-elastic-search/__tests__/__snapshots__/QueryBuilderElasticSearchExport.test.tsx.snap
@@ -1185,7 +1185,7 @@ Object {
         },
         Object {
           "terms": Object {
-            "data.attributes.group.keyword": Array [
+            "data.attributes.group": Array [
               "aafc",
               "cnc",
               "seqdb",
@@ -1236,7 +1236,7 @@ Object {
         },
         Object {
           "term": Object {
-            "data.attributes.group.keyword": "aafc",
+            "data.attributes.group": "aafc",
           },
         },
       ],

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderAutoSuggestionSearch.test.tsx
@@ -226,7 +226,7 @@ describe("QueryBuilderAutoSuggestionSearch", () => {
           },
           query: {
             terms: {
-              "data.attributes.group.keyword": ["aafc", "cnc"]
+              "data.attributes.group": ["aafc", "cnc"]
             }
           },
           size: 0

--- a/packages/common-ui/lib/list-page/useElasticSearchDistinctTerm.tsx
+++ b/packages/common-ui/lib/list-page/useElasticSearchDistinctTerm.tsx
@@ -59,11 +59,7 @@ export function useElasticSearchDistinctTerm({
     // Group needs to be queried to only show the users most used values.
     if (groups && groups.length !== 0) {
       // terms is used to be able to support multiple groups.
-      builder.query(
-        "terms",
-        "data.attributes.group.keyword",
-        _.castArray(groups)
-      );
+      builder.query("terms", "data.attributes.group", _.castArray(groups));
     }
     // If the field has a relationship type, we need to do a nested query to filter it.
     if (relationshipType) {


### PR DESCRIPTION
- Fixed issue with "Exact match" not shown for keyword type fields.
- Fixed issue with "Between" being shown for keyword type fields when it shouldn't.
- All group filters are now keyword type only.
- Fixed some tests.