### PR TITLE
Support #38204 - First iteration of the system status page

### DIFF
--- a/packages/dina-ui/components/button-bar/nav/nav.tsx
+++ b/packages/dina-ui/components/button-bar/nav/nav.tsx
@@ -724,12 +724,22 @@ function NavDinaManagementDropdown({ formatMessage }) {
           </Link>
           <Link
             href="/export/report-template/upload"
-            onKeyDown={onKeyDownLastItem}
+            onKeyDown={onKeyDown}
             passHref={true}
             legacyBehavior
           >
             <NavDropdown.Item role="menuitem">
               <DinaMessage id="reportTemplateUpload" />
+            </NavDropdown.Item>
+          </Link>
+          <Link
+            href="/admin/system-info"
+            onKeyDown={onKeyDownLastItem}
+            passHref={true}
+            legacyBehavior
+          >
+            <NavDropdown.Item role="menuitem">
+              <DinaMessage id="systemInfoTitle" />
             </NavDropdown.Item>
           </Link>
         </>

--- a/packages/dina-ui/components/system-info/ModuleCard.tsx
+++ b/packages/dina-ui/components/system-info/ModuleCard.tsx
@@ -104,7 +104,14 @@ export function ModuleCard({ module }: { module: ApiModule }) {
         {module.errorMessage && (
           <div className="alert alert-danger d-flex align-items-start gap-2 py-2 px-2 mb-0 small">
             <FaExclamationTriangle className="mt-1 flex-shrink-0" size={12} />
-            {module.errorMessage}
+            <div>
+              {(module.errorStatus || module.errorStatusText) && (
+                <div className="fw-bold">
+                  {module.errorStatus} {module.errorStatusText}
+                </div>
+              )}
+              {module.errorMessage}
+            </div>
           </div>
         )}
 

--- a/packages/dina-ui/components/system-info/ModuleCard.tsx
+++ b/packages/dina-ui/components/system-info/ModuleCard.tsx
@@ -1,0 +1,191 @@
+import { ApiModule, ModuleStatus } from "../../types/system-info/SystemInfo";
+import { Badge } from "react-bootstrap";
+import {
+  FaCheckCircle,
+  FaTimesCircle,
+  FaLink,
+  FaExclamationTriangle,
+  FaInfoCircle,
+  FaExclamationCircle
+} from "react-icons/fa";
+
+const STATUS_CONFIG: Record<
+  ModuleStatus,
+  {
+    label: string;
+    badgeBg: string;
+    borderColor: string;
+    headerBg: string;
+    icon: JSX.Element;
+  }
+> = {
+  online: {
+    label: "Online",
+    badgeBg: "success",
+    borderColor: "#198754",
+    headerBg: "#d1e7dd",
+    icon: <FaCheckCircle />
+  },
+  offline: {
+    label: "Offline",
+    badgeBg: "danger",
+    borderColor: "#dc3545",
+    headerBg: "#f8d7da",
+    icon: <FaTimesCircle />
+  }
+};
+
+function MicroLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-muted text-uppercase" style={{ fontSize: "0.7rem" }}>
+      {children}
+    </div>
+  );
+}
+
+function EnabledBadge({ enabled }: { enabled: boolean }) {
+  return enabled ? (
+    <Badge bg="success" className="fw-normal">
+      Enabled
+    </Badge>
+  ) : (
+    <Badge bg="secondary" className="fw-normal">
+      Disabled
+    </Badge>
+  );
+}
+
+/**
+ * Used to display each module's status and info on the System Info page.
+ * The card's styling and content will adapt based on the module's status and available info.
+ *
+ * Layout is AI assisted.
+ */
+export function ModuleCard({ module }: { module: ApiModule }) {
+  const cfg = STATUS_CONFIG[module.status];
+
+  const hasModuleInfo = module.moduleInfo && module.moduleInfo.size > 0;
+
+  return (
+    <div
+      className="card h-100 shadow-sm"
+      style={{ borderTop: `4px solid ${cfg.borderColor}` }}
+    >
+      {/* Card Header */}
+      <div
+        className="card-header d-flex align-items-center justify-content-between py-2 px-3"
+        style={{ background: cfg.headerBg }}
+      >
+        <div className="d-flex align-items-center gap-2">
+          <span className="fw-semibold">{module.apiConfig.moduleName}</span>
+        </div>
+        <div className="d-flex align-items-center gap-2">
+          <Badge
+            bg={cfg.badgeBg}
+            className="d-inline-flex align-items-center gap-1"
+          >
+            {cfg.icon} {cfg.label}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Card Body */}
+      <div className="card-body px-3 py-2 d-flex flex-column gap-2">
+        {/* Attention required badge */}
+        {module.attentionRequired && (
+          <Badge
+            bg="warning"
+            text="dark"
+            className="d-inline-flex align-items-center gap-1"
+          >
+            <FaExclamationCircle size={10} /> Attention Required
+          </Badge>
+        )}
+
+        {/* Error message */}
+        {module.errorMessage && (
+          <div className="alert alert-danger d-flex align-items-start gap-2 py-2 px-2 mb-0 small">
+            <FaExclamationTriangle className="mt-1 flex-shrink-0" size={12} />
+            {module.errorMessage}
+          </div>
+        )}
+
+        {/* Version + Endpoint */}
+        <div className="d-flex flex-wrap gap-3">
+          <div>
+            <MicroLabel>Version</MicroLabel>
+            <code className="small">{module.moduleVersion}</code>
+          </div>
+          <div className="flex-grow-1">
+            <MicroLabel>Endpoint</MicroLabel>
+            <div className="d-flex align-items-center gap-1">
+              <FaLink size={10} className="text-muted" />
+              <code className="small text-break">
+                <>
+                  {"/api/"}
+                  {module.apiConfig.apiEndpoint}
+                  {"/"}
+                </>
+              </code>
+            </div>
+          </div>
+        </div>
+
+        <hr className="my-1" />
+
+        {/* Message producer / consumer */}
+        <div className="d-flex flex-wrap gap-3">
+          {module.messageProducerEnabled !== undefined && (
+            <div>
+              <MicroLabel>Message Producer</MicroLabel>
+              <div className="d-flex align-items-center gap-1 mt-1">
+                <EnabledBadge enabled={module.messageProducerEnabled} />
+              </div>
+            </div>
+          )}
+          {module.messageConsumerEnabled !== undefined && (
+            <div>
+              <MicroLabel>Message Consumer</MicroLabel>
+              <div className="d-flex align-items-center gap-1 mt-1">
+                <EnabledBadge enabled={module.messageConsumerEnabled} />
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Module info — only rendered when extra info exists */}
+        {hasModuleInfo && (
+          <div>
+            <div className="d-inline-flex align-items-center gap-1 small text-muted mb-2">
+              <FaInfoCircle size={10} />
+              Module Info
+            </div>
+            <table className="table table-sm table-bordered mb-0 small">
+              <tbody>
+                {Array.from(module.moduleInfo!.entries()).map(
+                  ([key, value]) => (
+                    <tr key={key}>
+                      <td
+                        className="fw-semibold text-muted bg-light text-nowrap"
+                        style={{ width: "40%" }}
+                      >
+                        {key}
+                      </td>
+                      <td>
+                        {typeof value === "boolean" ? (
+                          <EnabledBadge enabled={value} />
+                        ) : (
+                          String(value)
+                        )}
+                      </td>
+                    </tr>
+                  )
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dina-ui/components/system-info/ModuleCard.tsx
+++ b/packages/dina-ui/components/system-info/ModuleCard.tsx
@@ -3,9 +3,7 @@ import { Badge } from "react-bootstrap";
 import {
   FaCheckCircle,
   FaTimesCircle,
-  FaLink,
   FaExclamationTriangle,
-  FaInfoCircle,
   FaExclamationCircle
 } from "react-icons/fa";
 
@@ -119,7 +117,6 @@ export function ModuleCard({ module }: { module: ApiModule }) {
           <div className="flex-grow-1">
             <MicroLabel>Endpoint</MicroLabel>
             <div className="d-flex align-items-center gap-1">
-              <FaLink size={10} className="text-muted" />
               <code className="small text-break">
                 <>
                   {"/api/"}
@@ -155,11 +152,8 @@ export function ModuleCard({ module }: { module: ApiModule }) {
 
         {/* Module info — only rendered when extra info exists */}
         {hasModuleInfo && (
-          <div>
-            <div className="d-inline-flex align-items-center gap-1 small text-muted mb-2">
-              <FaInfoCircle size={10} />
-              Module Info
-            </div>
+          <div className="pt-2">
+            <MicroLabel>Module Info</MicroLabel>
             <table className="table table-sm table-bordered mb-0 small">
               <tbody>
                 {Array.from(module.moduleInfo!.entries()).map(

--- a/packages/dina-ui/components/system-info/useSystemInfoCheck.ts
+++ b/packages/dina-ui/components/system-info/useSystemInfoCheck.ts
@@ -1,0 +1,79 @@
+import { useCallback, useState } from "react";
+import useSWR from "swr";
+import { ApiConfigInfo, ApiModule } from "../../types/system-info/SystemInfo";
+import { ApiInfo } from "../../types/system-info/ApiInfo";
+import { useApiClient } from "common-ui";
+
+export function useSystemInfoCheck(apiConfigs: ApiConfigInfo[]) {
+  const { apiClient } = useApiClient();
+  const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null);
+
+  const fetchAllModules = useCallback(async (): Promise<ApiModule[]> => {
+    const results = await Promise.allSettled(
+      apiConfigs.map(async (config): Promise<ApiModule> => {
+        try {
+          const response = await apiClient.get<ApiInfo>(
+            `${config.apiEndpoint}/api-info`,
+            {}
+          );
+          const apiInfo = response.data;
+          return {
+            apiConfig: config,
+            moduleVersion: apiInfo.id,
+            status: "online",
+            messageProducerEnabled: apiInfo.messageProducer ?? false,
+            messageConsumerEnabled: apiInfo.messageConsumer ?? false,
+            attentionRequired: apiInfo.attentionRequired,
+            moduleInfo: apiInfo.moduleInfo
+              ? new Map(Object.entries(apiInfo.moduleInfo))
+              : undefined
+          };
+        } catch (err: any) {
+          return {
+            apiConfig: config,
+            moduleVersion: "unknown",
+            status: "offline",
+            messageProducerEnabled: false,
+            messageConsumerEnabled: false,
+            attentionRequired: true,
+            errorMessage: err?.message ?? "Unable to reach service."
+          };
+        }
+      })
+    );
+
+    // Update the last refresh date.
+    setLastRefreshed(new Date());
+
+    return results.map((result, index) =>
+      result.status === "fulfilled"
+        ? result.value
+        : {
+            apiConfig: apiConfigs[index],
+            moduleVersion: "unknown",
+            status: "offline" as const,
+            messageProducerEnabled: false,
+            messageConsumerEnabled: false,
+            attentionRequired: true,
+            errorMessage: result.reason?.message ?? "Unexpected error."
+          }
+    );
+  }, [apiClient, apiConfigs]);
+
+  const { data, isValidating, error, mutate } = useSWR(
+    "system-info-check",
+    fetchAllModules,
+    {
+      revalidateOnFocus: false,
+      shouldRetryOnError: false
+    }
+  );
+
+  return {
+    modules: data ?? [],
+    loading: isValidating,
+    error,
+    lastRefreshed,
+    refresh: mutate
+  };
+}

--- a/packages/dina-ui/components/system-info/useSystemInfoCheck.ts
+++ b/packages/dina-ui/components/system-info/useSystemInfoCheck.ts
@@ -36,7 +36,14 @@ export function useSystemInfoCheck(apiConfigs: ApiConfigInfo[]) {
             messageProducerEnabled: false,
             messageConsumerEnabled: false,
             attentionRequired: true,
-            errorMessage: err?.message ?? "Unable to reach service."
+            errorMessage:
+              err?.cause?.data?.error ??
+              err?.message ??
+              "Unable to reach service.",
+            errorStatus: err?.cause?.status,
+            errorStatusText: err?.cause?.data?.path
+              ? `${err.cause.data.path}`
+              : err?.cause?.statusText
           };
         }
       })

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -1423,6 +1423,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   workflowsLegend: "Molecular Analysis Workflows",
   siteListTitle: "Site",
   siteAttachments: "Site Attachments",
+  systemInfoTitle: "System Information",
   code: "Code",
   siteMap: "Site Map",
   siteCoordinates: "Site Coordinates",

--- a/packages/dina-ui/pages/admin/system-info.tsx
+++ b/packages/dina-ui/pages/admin/system-info.tsx
@@ -1,62 +1,69 @@
 import PageLayout from "packages/dina-ui/components/page/PageLayout";
-import { ApiModule } from "packages/dina-ui/types/system-info/SystemInfo";
+import { ApiConfigInfo } from "packages/dina-ui/types/system-info/SystemInfo";
 import { FaSyncAlt } from "react-icons/fa";
 import { ModuleCard } from "../../components/system-info/ModuleCard";
+import { useSystemInfoCheck } from "../../components/system-info/useSystemInfoCheck";
+import { Button } from "react-bootstrap";
+import moment from "moment";
+
+/**
+ * System Info Configuration:
+ *
+ * To add a new module to the System Info page, simply add a new entry to the SYSTEM_INFO_API_CONFIG
+ * array with the module's name and API endpoint. The useSystemInfoCheck hook will automatically
+ * fetch the module's info and status based on the provided API endpoint.
+ */
+const SYSTEM_INFO_API_CONFIG: ApiConfigInfo[] = [
+  {
+    moduleName: "Collection API",
+    apiEndpoint: "collection-api"
+  },
+  {
+    moduleName: "DINA User API",
+    apiEndpoint: "user-api"
+  },
+  {
+    moduleName: "Object Store API",
+    apiEndpoint: "objectstore-api"
+  }
+];
 
 export function SystemInfo() {
-  const MOCK_MODULES: ApiModule[] = [
-    {
-      moduleVersion: "2.1.0",
-      status: "online",
-      apiConfig: {
-        moduleName: "Collection API",
-        apiEndpoint: "collection-api"
-      },
-      messageProducerEnabled: true,
-      messageConsumerEnabled: true,
-      attentionRequired: false
-    },
-    {
-      moduleVersion: "1.2.5",
-      status: "online",
-      apiConfig: {
-        moduleName: "DINA User API",
-        apiEndpoint: "user-api"
-      },
-      messageProducerEnabled: false,
-      messageConsumerEnabled: false,
-      attentionRequired: false
-    },
-    {
-      moduleVersion: "3.0.1",
-      status: "offline",
-      apiConfig: {
-        moduleName: "Object Store API",
-        apiEndpoint: "objectstore-api"
-      },
-      messageProducerEnabled: true,
-      messageConsumerEnabled: false,
-      attentionRequired: true,
-      moduleInfo: new Map<string, any>([["imageMagick", true]]),
-      errorMessage:
-        "Connection refused: Unable to reach the service. The host may be down or unreachable."
-    }
-  ];
+  // The useSystemInfoCheck hook handles fetching the status and info for all modules defined in the config.
+  const { modules, lastRefreshed, refresh, loading } = useSystemInfoCheck(
+    SYSTEM_INFO_API_CONFIG
+  );
 
-  const PAGE_LAST_REFRESHED = new Date("2026-04-22T10:30:05Z");
+  // Button to refresh the status of all modules
+  const buttonBar = (
+    <>
+      <Button
+        variant="primary"
+        className="ms-auto"
+        onClick={() => refresh()}
+        style={{ width: "10rem" }}
+        disabled={loading}
+      >
+        <FaSyncAlt className="me-2" />
+        Refresh
+      </Button>
+    </>
+  );
 
   return (
-    <PageLayout titleId="systemInfoTitle">
+    <PageLayout titleId="systemInfoTitle" buttonBarContent={buttonBar}>
       <div className="system-info-page">
         {/* Last refreshed */}
-        <div className="d-flex align-items-center gap-2 text-muted small mb-3">
-          <FaSyncAlt size={12} />
-          Last refreshed:{" "}
-          <strong>
-            {PAGE_LAST_REFRESHED.toLocaleDateString()}{" "}
-            {PAGE_LAST_REFRESHED.toLocaleTimeString()}
-          </strong>
-        </div>
+        {lastRefreshed && (
+          <div className="d-flex align-items-center gap-2 text-muted small mb-3">
+            <FaSyncAlt size={12} />
+            Last refreshed:{" "}
+            <strong>
+              {moment(lastRefreshed).fromNow()} (
+              {moment(lastRefreshed).format("YYYY-MM-DD HH:mm:ss")})
+            </strong>
+          </div>
+        )}
 
         {/* Module cards grid */}
         <div
@@ -66,7 +73,7 @@ export function SystemInfo() {
             gap: "1.25rem"
           }}
         >
-          {MOCK_MODULES.map((module) => (
+          {modules.map((module) => (
             <ModuleCard key={module.apiConfig.moduleName} module={module} />
           ))}
         </div>

--- a/packages/dina-ui/pages/admin/system-info.tsx
+++ b/packages/dina-ui/pages/admin/system-info.tsx
@@ -1,0 +1,78 @@
+import PageLayout from "packages/dina-ui/components/page/PageLayout";
+import { ApiModule } from "packages/dina-ui/types/system-info/SystemInfo";
+import { FaSyncAlt } from "react-icons/fa";
+import { ModuleCard } from "../../components/system-info/ModuleCard";
+
+export function SystemInfo() {
+  const MOCK_MODULES: ApiModule[] = [
+    {
+      moduleVersion: "2.1.0",
+      status: "online",
+      apiConfig: {
+        moduleName: "Collection API",
+        apiEndpoint: "collection-api"
+      },
+      messageProducerEnabled: true,
+      messageConsumerEnabled: true,
+      attentionRequired: false
+    },
+    {
+      moduleVersion: "1.2.5",
+      status: "online",
+      apiConfig: {
+        moduleName: "DINA User API",
+        apiEndpoint: "user-api"
+      },
+      messageProducerEnabled: false,
+      messageConsumerEnabled: false,
+      attentionRequired: false
+    },
+    {
+      moduleVersion: "3.0.1",
+      status: "offline",
+      apiConfig: {
+        moduleName: "Object Store API",
+        apiEndpoint: "objectstore-api"
+      },
+      messageProducerEnabled: true,
+      messageConsumerEnabled: false,
+      attentionRequired: true,
+      moduleInfo: new Map<string, any>([["imageMagick", true]]),
+      errorMessage:
+        "Connection refused: Unable to reach the service. The host may be down or unreachable."
+    }
+  ];
+
+  const PAGE_LAST_REFRESHED = new Date("2026-04-22T10:30:05Z");
+
+  return (
+    <PageLayout titleId="systemInfoTitle">
+      <div className="system-info-page">
+        {/* Last refreshed */}
+        <div className="d-flex align-items-center gap-2 text-muted small mb-3">
+          <FaSyncAlt size={12} />
+          Last refreshed:{" "}
+          <strong>
+            {PAGE_LAST_REFRESHED.toLocaleDateString()}{" "}
+            {PAGE_LAST_REFRESHED.toLocaleTimeString()}
+          </strong>
+        </div>
+
+        {/* Module cards grid */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+            gap: "1.25rem"
+          }}
+        >
+          {MOCK_MODULES.map((module) => (
+            <ModuleCard key={module.apiConfig.moduleName} module={module} />
+          ))}
+        </div>
+      </div>
+    </PageLayout>
+  );
+}
+
+export default SystemInfo;

--- a/packages/dina-ui/pages/admin/system-info.tsx
+++ b/packages/dina-ui/pages/admin/system-info.tsx
@@ -5,6 +5,7 @@ import { ModuleCard } from "../../components/system-info/ModuleCard";
 import { useSystemInfoCheck } from "../../components/system-info/useSystemInfoCheck";
 import { Button } from "react-bootstrap";
 import moment from "moment";
+import { useEffect, useState } from "react";
 
 /**
  * System Info Configuration:
@@ -34,12 +35,21 @@ export function SystemInfo() {
     SYSTEM_INFO_API_CONFIG
   );
 
+  // Force react refresh this component every 10 seconds to keep the module statuses up to date.
+  // This is not doing API requests every 10 seconds - the API requests are only made when the
+  // "Refresh" button is clicked.
+  const [, forceUpdate] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => forceUpdate((n) => n + 1), 10000);
+    return () => clearInterval(interval);
+  }, []);
+
   // Button to refresh the status of all modules
   const buttonBar = (
     <>
       <Button
         variant="primary"
-        className="ms-auto"
+        className="ms-auto me-3"
         onClick={() => refresh()}
         style={{ width: "10rem" }}
         disabled={loading}

--- a/packages/dina-ui/pages/admin/system-info.tsx
+++ b/packages/dina-ui/pages/admin/system-info.tsx
@@ -6,6 +6,8 @@ import { useSystemInfoCheck } from "../../components/system-info/useSystemInfoCh
 import { Button } from "react-bootstrap";
 import moment from "moment";
 import { useEffect, useState } from "react";
+import { useAccount } from "common-ui";
+import { useRouter } from "next/router";
 
 /**
  * System Info Configuration:
@@ -30,6 +32,15 @@ const SYSTEM_INFO_API_CONFIG: ApiConfigInfo[] = [
 ];
 
 export function SystemInfo() {
+  const { isAdmin } = useAccount();
+  const router = useRouter();
+
+  // Ensure the user is admin before allowing access to the page.
+  if (!isAdmin) {
+    // Route to homepage...
+    router.push("/");
+  }
+
   // The useSystemInfoCheck hook handles fetching the status and info for all modules defined in the config.
   const { modules, lastRefreshed, refresh, loading } = useSystemInfoCheck(
     SYSTEM_INFO_API_CONFIG

--- a/packages/dina-ui/pages/index.tsx
+++ b/packages/dina-ui/pages/index.tsx
@@ -277,6 +277,9 @@ export function Home() {
                       <Link href="/export/report-template/upload">
                         <DinaMessage id="reportTemplateUpload" />
                       </Link>
+                      <Link href="/admin/system-info">
+                        <DinaMessage id="systemInfoTitle" />
+                      </Link>
                     </>
                   )}
                 </Stack>

--- a/packages/dina-ui/types/system-info/ApiInfo.ts
+++ b/packages/dina-ui/types/system-info/ApiInfo.ts
@@ -1,0 +1,10 @@
+import { KitsuResource } from "kitsu";
+
+export interface ApiInfoAttributes {
+  messageProducer?: boolean;
+  messageConsumer?: boolean;
+  attentionRequired?: boolean;
+  moduleInfo?: Record<string, any>;
+}
+
+export type ApiInfo = KitsuResource & ApiInfoAttributes;

--- a/packages/dina-ui/types/system-info/SystemInfo.ts
+++ b/packages/dina-ui/types/system-info/SystemInfo.ts
@@ -1,0 +1,22 @@
+export type ModuleStatus = "online" | "offline";
+
+export interface ApiConfigInfo {
+  apiEndpoint: string;
+  moduleName: string;
+}
+
+export interface ApiModule {
+  moduleVersion: string;
+  status: ModuleStatus;
+  apiConfig: ApiConfigInfo;
+  messageProducerEnabled?: boolean;
+  messageConsumerEnabled?: boolean;
+  attentionRequired?: boolean;
+  moduleInfo?: Map<string, any>;
+  errorMessage?: string;
+}
+
+export interface SystemInfoData {
+  modules: ApiModule[];
+  pageLastRefreshed: Date;
+}

--- a/packages/dina-ui/types/system-info/SystemInfo.ts
+++ b/packages/dina-ui/types/system-info/SystemInfo.ts
@@ -14,6 +14,8 @@ export interface ApiModule {
   attentionRequired?: boolean;
   moduleInfo?: Map<string, any>;
   errorMessage?: string;
+  errorStatus?: string;
+  errorStatusText?: string;
 }
 
 export interface SystemInfoData {


### PR DESCRIPTION
- Created the SystemInfo type where it contains all the status and config structures.
- Currently just using mock data that will be replaced with the actual network calls once I get there.
- Added it to the nav bar for dina-admin only.
- Using Claude AI, the ModuleCard layout was generated with displays based on the structure.