### PR TITLE
Support #38301 - Add userIdentifier filter when retrieving notifications

### DIFF
--- a/packages/common-ui/lib/notification/__tests__/UserNotification.test.tsx
+++ b/packages/common-ui/lib/notification/__tests__/UserNotification.test.tsx
@@ -493,6 +493,11 @@ describe("UserNotification", () => {
       // (This is implicitly tested through the component rendering)
       expect(mockGet).toHaveBeenCalledWith("user-api/notification", {
         page: { limit: 100 },
+        filter: {
+          userIdentifier: {
+            EQ: ""
+          }
+        },
         sort: "-createdOn"
       });
     });

--- a/packages/common-ui/lib/notification/__tests__/useNotification.test.tsx
+++ b/packages/common-ui/lib/notification/__tests__/useNotification.test.tsx
@@ -95,6 +95,11 @@ describe("useNotification", () => {
       await waitFor(() => {
         expect(mockGet).toHaveBeenCalledWith("user-api/notification", {
           page: { limit: 100 },
+          filter: {
+            userIdentifier: {
+              EQ: "test-user-id"
+            }
+          },
           sort: "-createdOn"
         });
       });

--- a/packages/common-ui/lib/notification/useNotification.ts
+++ b/packages/common-ui/lib/notification/useNotification.ts
@@ -4,6 +4,7 @@ import { useApiClient } from "../api-client/ApiClientContext";
 import { Notification, NotificationUpdatePayload } from "./types";
 import { Operation } from "../api-client/operations-types";
 import { useAccount } from "../account/AccountProvider";
+import { SimpleSearchFilterBuilder } from "../util/simpleSearchFilterBuilder";
 
 export interface UseNotificationParams {
   /**
@@ -54,7 +55,10 @@ export function useNotification({
       "user-api/notification",
       {
         page: { limit: 100 },
-        sort: "-createdOn"
+        sort: "-createdOn",
+        filter: SimpleSearchFilterBuilder.create<Notification>()
+          .where("userIdentifier", "EQ", userId ?? "")
+          .build()
       }
     );
 


### PR DESCRIPTION
- Added the filter for the notification request.
- Updated test coverage.