### PR TITLE
Support 33917 allow to set parent or detach parent on material sample

### DIFF
--- a/packages/common-ui/lib/index.ts
+++ b/packages/common-ui/lib/index.ts
@@ -103,6 +103,7 @@ export * from "./custom-query-view/CustomQueryPageView";
 export * from "./formik-connected/ControlledVocabularySelectField";
 export * from "./formik-connected/FieldExtensionSelectField";
 export * from "./search/useSearch";
+export * from "./search/useSearchWsCustomQuery";
 export * from "./search/useAutocompleteSearchButFallbackToRsqlApiSearch";
 export * from "./util/useIsMounted";
 export * from "./table/EditableTable";

--- a/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
+++ b/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
@@ -17,14 +17,18 @@ interface SearchWsResponse {
 
 export interface SearchWsCustomQueryOptions {
   indexName: string;
+  // search query string, used as an argument for the query if the query is a function
   searchQuery?: string;
-  query: any | ((searchQuery: string) => any);
+  //function that takes the search query as an argument
+  query: (searchQuery: string) => any;
   size?: number;
 }
 
 export interface DoSearchWsParams {
   indexName: string;
+  // function to generate the query based on the search query, which is passed as an argument. The search query is optional and can be an empty string if not needed for the query.
   queryBuilder: (searchQuery: string) => any;
+  // search query string, used as an argument for the queryBuilder if it is a function
   searchQuery?: string;
   size?: number;
 }
@@ -88,8 +92,15 @@ export function useSearchWsCustomQuery<TData extends KitsuResource>({
   return { loading, response };
 }
 
-/** Executes a search-ws/search query and returns deserialized resources. */
-export async function doSearchWsSearch<TData extends KitsuResource>(
+/**
+ * Does the search against the search-ws/search API and returns deserialized resources.
+ * @param axios axios instance to use for the request
+ * @param indexName index to search against
+ * @param queryBuilder function to generate the query based on the search query, which is passed as an argument. The search query is optional and can be an empty string if not needed for the query.
+ * @param searchQuery search query string, used as an argument for the queryBuilder if it is a function
+ * @returns deserialized resources returned from the search API
+ */
+async function doSearchWsSearch<TData extends KitsuResource>(
   axios: Pick<AxiosInstance, "post">,
   { indexName, queryBuilder, searchQuery = "", size = 20 }: DoSearchWsParams
 ): Promise<PersistedResource<TData>[]> {

--- a/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
+++ b/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
@@ -101,7 +101,7 @@ async function doSearchWsSearch<TData extends KitsuResource>(
   axios: Pick<AxiosInstance, "post">,
   { indexName, queryBuilder, searchQuery = "", size = 20 }: DoSearchWsParams
 ): Promise<PersistedResource<TData>[]> {
-  const query = queryBuilder(searchQuery);
+  const query = queryBuilder(searchQuery.toLowerCase());
 
   if (!query) {
     return [];

--- a/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
+++ b/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
@@ -27,7 +27,7 @@ export interface SearchWsCustomQueryOptions {
 export interface DoSearchWsParams {
   indexName: string;
   // function to generate the query based on the search query, which is passed as an argument. The search query is optional and can be an empty string if not needed for the query.
-  queryBuilder: (searchQuery: string) => any;
+  queryBuilder: (searchQuery?: string) => any;
   // search query string, used as an argument for the queryBuilder if it is a function
   searchQuery?: string;
   size?: number;
@@ -62,13 +62,10 @@ export function useSearchWsCustomQuery<TData extends KitsuResource>({
     async function fetchSearchResults() {
       setLoading(true);
       try {
-        const builtQuery =
-          typeof query === "function" ? query(searchQuery ?? "") : query;
-
         const results = await doSearchWsSearch<TData>(apiClient.axios, {
           indexName,
-          queryBuilder: () => builtQuery,
-          searchQuery: searchQuery ?? "",
+          queryBuilder: query,
+          searchQuery: searchQuery,
           size
         });
 

--- a/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
+++ b/packages/common-ui/lib/search/useSearchWsCustomQuery.ts
@@ -1,0 +1,126 @@
+import { useApiClient } from "common-ui";
+import { AxiosInstance } from "axios";
+import { KitsuResource, PersistedResource } from "kitsu";
+import { deserialise } from "kitsu-core";
+import { useEffect, useState } from "react";
+import _ from "lodash";
+
+interface SearchWsHit {
+  _source?: any;
+}
+
+interface SearchWsResponse {
+  hits?: {
+    hits?: SearchWsHit[];
+  };
+}
+
+export interface SearchWsCustomQueryOptions {
+  indexName: string;
+  searchQuery?: string;
+  query: any | ((searchQuery: string) => any);
+  size?: number;
+}
+
+export interface DoSearchWsParams {
+  indexName: string;
+  queryBuilder: (searchQuery: string) => any;
+  searchQuery?: string;
+  size?: number;
+}
+
+/**
+ * Custom hook to execute a search-ws/search query and return deserialized resources, used as custom query for ResourceSelectFieldCustomQuery.
+ * The query can be a static object or a function that takes the search query as an argument.
+ * The search is executed whenever the search query changes.
+ * The results are returned as deserialized resources.
+ * @param param0
+ * @returns
+ */
+export function useSearchWsCustomQuery<TData extends KitsuResource>({
+  indexName,
+  searchQuery,
+  query,
+  size = 20
+}: SearchWsCustomQueryOptions): {
+  loading?: boolean;
+  response?: { data: PersistedResource<TData>[] };
+} {
+  const { apiClient } = useApiClient();
+  const [loading, setLoading] = useState(false);
+  const [response, setResponse] = useState<
+    { data: PersistedResource<TData>[] } | undefined
+  >(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSearchResults() {
+      setLoading(true);
+      try {
+        const builtQuery =
+          typeof query === "function" ? query(searchQuery ?? "") : query;
+
+        const results = await doSearchWsSearch<TData>(apiClient.axios, {
+          indexName,
+          queryBuilder: () => builtQuery,
+          searchQuery: searchQuery ?? "",
+          size
+        });
+
+        if (!cancelled) {
+          setResponse({ data: results });
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchSearchResults();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, indexName, searchQuery, size]);
+
+  return { loading, response };
+}
+
+/** Executes a search-ws/search query and returns deserialized resources. */
+export async function doSearchWsSearch<TData extends KitsuResource>(
+  axios: Pick<AxiosInstance, "post">,
+  { indexName, queryBuilder, searchQuery = "", size = 20 }: DoSearchWsParams
+): Promise<PersistedResource<TData>[]> {
+  const query = queryBuilder(searchQuery);
+
+  if (!query) {
+    return [];
+  }
+
+  const searchResponse = await axios.post<SearchWsResponse>(
+    "search-api/search-ws/search",
+    { query, size },
+    { params: { indexName } }
+  );
+
+  const docs = _.compact(
+    (searchResponse.data?.hits?.hits ?? []).map((hit) => {
+      const source = hit?._source;
+      if (!source) {
+        return undefined;
+      }
+      return source;
+    })
+  );
+
+  const data = await Promise.all(
+    docs.map(async (doc) => {
+      const deserialized = await deserialise(doc as any);
+      return deserialized.data as PersistedResource<TData>;
+    })
+  );
+
+  return data;
+}

--- a/packages/dina-ui/components/bulk-edit/__tests__/BulkEditTabWarning.test.tsx
+++ b/packages/dina-ui/components/bulk-edit/__tests__/BulkEditTabWarning.test.tsx
@@ -8,6 +8,30 @@ import { MaterialSampleBulkEditor } from "../../bulk-material-sample/MaterialSam
 import _ from "lodash";
 import { fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { useSearchWsCustomQuery } from "../../../../common-ui/lib/search/useSearchWsCustomQuery";
+
+/**
+ * Reusable mock block for tests that render components using `useSearchWsCustomQuery`.
+ * Copy this block into other test files to avoid real search-ws API calls.
+ */
+jest.mock("../../../../common-ui/lib/search/useSearchWsCustomQuery", () => {
+  const actual = jest.requireActual(
+    "../../../../common-ui/lib/search/useSearchWsCustomQuery"
+  );
+  return {
+    ...actual,
+    useSearchWsCustomQuery: jest
+      .fn()
+      .mockReturnValue({ loading: false, response: { data: [] } })
+  };
+});
+
+function mockUseSearchWsResults(data: any[] = []) {
+  (useSearchWsCustomQuery as jest.Mock).mockReturnValue({
+    loading: false,
+    response: { data }
+  });
+}
 
 const mockGet = jest.fn<any, any>(async (path) => {
   switch (path) {
@@ -183,7 +207,10 @@ const SAMPLES_WITH_SAME_DETERMINATIONS: InputResource<MaterialSample>[] = [
 ];
 
 describe("BulkEditTabWarning", () => {
-  beforeEach(jest.clearAllMocks);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSearchWsResults();
+  });
 
   it("Shows the warning when there are multiple determination values in the individual samples.", async () => {
     const wrapper = mountWithAppContext(

--- a/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
+++ b/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
@@ -13,6 +13,30 @@ import { BulkNavigatorTab } from "../BulkEditNavigator";
 import { useBulkEditTab } from "../useBulkEditTab";
 import { fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { useSearchWsCustomQuery } from "../../../../common-ui/lib/search/useSearchWsCustomQuery";
+
+/**
+ * Reusable mock block for tests that render components using `useSearchWsCustomQuery`.
+ * Copy this block into other test files to avoid real search-ws API calls.
+ */
+jest.mock("../../../../common-ui/lib/search/useSearchWsCustomQuery", () => {
+  const actual = jest.requireActual(
+    "../../../../common-ui/lib/search/useSearchWsCustomQuery"
+  );
+  return {
+    ...actual,
+    useSearchWsCustomQuery: jest
+      .fn()
+      .mockReturnValue({ loading: false, response: { data: [] } })
+  };
+});
+
+function mockUseSearchWsResults(data: any[] = []) {
+  (useSearchWsCustomQuery as jest.Mock).mockReturnValue({
+    loading: false,
+    response: { data }
+  });
+}
 
 const mockSubmitOverride = jest.fn();
 
@@ -192,7 +216,10 @@ const testCtx = {
 };
 
 describe("Material sample bulk edit tab", () => {
-  beforeEach(jest.clearAllMocks);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSearchWsResults();
+  });
 
   it("Without changing any fields, overrides nothing", async () => {
     const wrapper = mountWithAppContext(<BulkEditTab />, testCtx);

--- a/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
+++ b/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
@@ -89,6 +89,25 @@ function BulkEditTab({ baseSample }: BulkEditTabProps) {
     <div>
       {bulkEditTab.content(true)}
       <button
+        className="set-parent"
+        type="button"
+        onClick={() => {
+          const formik = bulkEditFormRef.current;
+          if (formik) {
+            formik.setValues({
+              ...formik.values,
+              parentMaterialSample: {
+                id: "parent-1",
+                type: "material-sample",
+                materialSampleName: "Parent Sample"
+              }
+            });
+          }
+        }}
+      >
+        Set Parent
+      </button>
+      <button
         className="get-overrides"
         type="button"
         onClick={async () => {
@@ -219,6 +238,28 @@ describe("Material sample bulk edit tab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseSearchWsResults();
+  });
+
+  it("assigns a new parent sample via bulk edit", async () => {
+    const wrapper = mountWithAppContext(<BulkEditTab />, testCtx);
+
+    await waitFor(() =>
+      expect(
+        wrapper.getByRole("button", { name: /get overrides/i })
+      ).toBeInTheDocument()
+    );
+
+    // Set the parent on the bulk edit form programmatically
+    fireEvent.click(wrapper.getByRole("button", { name: /set parent/i }));
+
+    // Request overrides and assert parent is present
+    fireEvent.click(wrapper.getByRole("button", { name: /get overrides/i }));
+
+    await waitFor(() => expect(mockSubmitOverride).toHaveBeenCalled());
+
+    const overridden = mockSubmitOverride.mock.calls[0][0];
+    expect(overridden.parentMaterialSample).toBeDefined();
+    expect(overridden.parentMaterialSample.id).toEqual("parent-1");
   });
 
   it("Without changing any fields, overrides nothing", async () => {

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
@@ -33,6 +33,31 @@ import {
   TEST_FORM_TEMPLATE_COMPONENTS_DISABLED,
   TEST_MATERIAL_SAMPLES_MULTIPLE_VALUES
 } from "../__mocks__/MaterialSampleBulkMocks";
+import { useSearchWsCustomQuery } from "../../../../common-ui/lib/search/useSearchWsCustomQuery";
+
+/**
+ * Reusable mock block for tests that render components using `useSearchWsCustomQuery`.
+ * Parent sample searches should return an empty result set.
+ */
+jest.mock("../../../../common-ui/lib/search/useSearchWsCustomQuery", () => {
+  const actual = jest.requireActual(
+    "../../../../common-ui/lib/search/useSearchWsCustomQuery"
+  );
+  return {
+    ...actual,
+    useSearchWsCustomQuery: jest.fn()
+  };
+});
+
+function mockSearchWsQueryResults() {
+  (useSearchWsCustomQuery as jest.Mock).mockImplementation((options) => {
+    if (options?.indexName === "dina_material_sample_index") {
+      return { loading: false, response: { data: [] } };
+    }
+
+    return { loading: false, response: { data: [] } };
+  });
+}
 
 const mockGet = jest.fn<any, any>(async (path, params) => {
   switch (path) {
@@ -485,6 +510,7 @@ describe("MaterialSampleBulkEditor", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
+    mockSearchWsQueryResults();
   });
 
   it("Bulk creates material samples.", async () => {

--- a/packages/dina-ui/components/collection/ParentSelectSection.tsx
+++ b/packages/dina-ui/components/collection/ParentSelectSection.tsx
@@ -1,0 +1,133 @@
+import {
+  DinaFormSection,
+  ResourceSelectFieldCustomQuery,
+  ResourceSelectFieldCustomQueryProps,
+  useDinaFormContext,
+  useSearchWsCustomQuery
+} from "common-ui";
+import { HierarchyItem, MaterialSample } from "../../types/collection-api";
+import { DinaMessage } from "../../intl/dina-ui-intl";
+import _ from "lodash";
+
+/**
+ * Generates query-generating function to search by material sample name or id and exclude descendants.
+ * @param currentHierarchyItem the current hierarchy item, used to determine the rank and id for excluding descendants. If not provided, no items will be excluded.
+ * @returns options for ResourceSelectFieldCustomQuery to search for parent material samples, excluding descendants of the current hierarchy item.
+ */
+function getCustomQueryOptions(
+  currentHierarchyItem?: HierarchyItem
+): ResourceSelectFieldCustomQueryProps<MaterialSample>["customQueryOptions"] {
+  return (searchQuery) => ({
+    indexName: "dina_material_sample_index",
+    searchQuery, // search term
+    query: (value: string) => ({
+      // function to generate the query based on the search term
+      bool: {
+        ...(value
+          ? {
+              should: [
+                {
+                  wildcard: {
+                    "data.attributes.materialSampleName": `*${value}*`
+                  }
+                },
+                {
+                  wildcard: {
+                    "data.id": `*${value}*`
+                  }
+                }
+              ],
+              minimum_should_match: 1
+            }
+          : { must: [{ match_all: {} }] }),
+        ...(currentHierarchyItem
+          ? {
+              must_not: [
+                {
+                  nested: {
+                    path: "data.attributes.hierarchy",
+                    query: {
+                      term: {
+                        "data.attributes.hierarchy.uuid":
+                          currentHierarchyItem.uuid
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          : {})
+      }
+    })
+  });
+}
+
+export interface ParentSelectSectionProps {
+  resourcePath?: string;
+  classNames?: string;
+  filterList?: (item: MaterialSample) => boolean;
+  currentHierarchyItem?: HierarchyItem;
+}
+
+/**
+ * Renders a section with a parent select field. Excludes the current material sample
+ * and its descendants from the parent select options. The parent select field is only
+ * rendered if the form is not read-only. Uses elasticsearch for custom query.
+ * @param classNames optional additional class names for the section container
+ * @param filterList optional function to further filter the parent select options
+ * @param currentHierarchyItem the current hierarchy item, used to determine which items to exclude from the parent select options. If not provided, no items will be excluded.
+ * @returns Parent select field.
+ */
+export function ParentSelectSection({
+  classNames,
+  currentHierarchyItem
+}: ParentSelectSectionProps) {
+  const { readOnly } = useDinaFormContext();
+
+  return readOnly ? undefined : (
+    <div className={`${classNames} row`}>
+      <DinaFormSection horizontal="flex">
+        <div className="d-flex flex-row gap-1">
+          <ParentSelectField
+            currentHierarchyItem={currentHierarchyItem}
+            className="flex-grow-1 mb-2"
+          />
+        </div>
+      </DinaFormSection>
+    </div>
+  );
+}
+
+interface ParentSelectFieldProps {
+  resourcePath?: string;
+  currentHierarchyItem?: HierarchyItem;
+  className?: string;
+}
+
+function ParentSelectField({
+  resourcePath = "collection-api/material-sample",
+  currentHierarchyItem,
+  className
+}: ParentSelectFieldProps) {
+  const { readOnly } = useDinaFormContext();
+
+  return (
+    <DinaFormSection horizontal={"flex"} readOnly={readOnly}>
+      <ResourceSelectFieldCustomQuery<MaterialSample>
+        name="parentMaterialSample"
+        useCustomQuery={useSearchWsCustomQuery}
+        customQueryOptions={getCustomQueryOptions(currentHierarchyItem)}
+        filter={() => ({})}
+        readOnlyLink="/collection/material-sample/view?id="
+        model={resourcePath}
+        className={"parent-material-sample-field " + (className || "")}
+        optionLabel={(sample) => sample.materialSampleName || sample.id}
+        hideLabel={readOnly}
+        removeLabel={readOnly}
+        removeBottomMargin={true}
+        disableTemplateCheckbox={true}
+        label={<DinaMessage id="parentMaterialSample" />}
+      />
+    </DinaFormSection>
+  );
+}

--- a/packages/dina-ui/components/collection/ParentSelectSection.tsx
+++ b/packages/dina-ui/components/collection/ParentSelectSection.tsx
@@ -4,26 +4,26 @@ import {
   ResourceSelectFieldCustomQuery,
   ResourceSelectFieldCustomQueryProps,
   useDinaFormContext,
-  useSearchWsCustomQuery
+  useSearchWsCustomQuery,
+  useBulkEditTabContext
 } from "common-ui";
-import { HierarchyItem, MaterialSample } from "../../types/collection-api";
+import { MaterialSample } from "../../types/collection-api";
 import { DinaMessage } from "../../intl/dina-ui-intl";
 import _ from "lodash";
 import { FaDna } from "react-icons/fa";
 
 /**
  * Generates query-generating function to search by material sample name or id and exclude descendants.
- * @param currentHierarchyItem the current hierarchy item, used to determine the rank and id for excluding descendants. If not provided, no items will be excluded.
+ * @param currentHierarchyIds list of ids to exclude from search results (the current material sample(s) and its descendants). If undefined, no items will be excluded.
  * @returns options for ResourceSelectFieldCustomQuery to search for parent material samples, excluding descendants of the current hierarchy item.
  */
 function getCustomQueryOptions(
-  currentHierarchyItem?: HierarchyItem
+  currentHierarchyIds?: String[]
 ): ResourceSelectFieldCustomQueryProps<MaterialSample>["customQueryOptions"] {
   return (searchQuery) => ({
     indexName: "dina_material_sample_index",
-    searchQuery, // search term
+    searchQuery,
     query: (value: string) => ({
-      // function to generate the query based on the search term
       bool: {
         ...(value
           ? {
@@ -42,16 +42,17 @@ function getCustomQueryOptions(
               minimum_should_match: 1
             }
           : { must: [{ match_all: {} }] }),
-        ...(currentHierarchyItem
+        ...(currentHierarchyIds?.length
           ? {
               must_not: [
                 {
                   nested: {
                     path: "data.attributes.hierarchy",
                     query: {
-                      term: {
-                        "data.attributes.hierarchy.uuid":
-                          currentHierarchyItem.uuid
+                      bool: {
+                        should: currentHierarchyIds.map((id) => ({
+                          term: { "data.attributes.hierarchy.uuid": id }
+                        }))
                       }
                     }
                   }
@@ -67,8 +68,6 @@ function getCustomQueryOptions(
 export interface ParentSelectSectionProps {
   resourcePath?: string;
   classNames?: string;
-  filterList?: (item: MaterialSample) => boolean;
-  currentHierarchyItem?: HierarchyItem;
   enableCollectingEvent?: boolean;
 }
 
@@ -77,13 +76,11 @@ export interface ParentSelectSectionProps {
  * and its descendants from the parent select options. The parent select field is only
  * rendered if the form is not read-only. Uses elasticsearch for custom query.
  * @param classNames optional additional class names for the section container
- * @param currentHierarchyItem the current hierarchy item, used to determine which items to exclude from the parent select options. If not provided, no items will be excluded.
  * @param enableCollectingEvent disables parent select field when collecting event is enabled.
  * @returns Parent select field.
  */
 export function ParentSelectSection({
   classNames,
-  currentHierarchyItem,
   enableCollectingEvent
 }: ParentSelectSectionProps) {
   const { readOnly } = useDinaFormContext();
@@ -93,7 +90,6 @@ export function ParentSelectSection({
       <DinaFormSection horizontal="flex">
         <div className="d-flex flex-row gap-1">
           <ParentSelectField
-            currentHierarchyItem={currentHierarchyItem}
             enableCollectingEvent={enableCollectingEvent}
             className="flex-grow-1 mb-2"
           />
@@ -105,24 +101,38 @@ export function ParentSelectSection({
 
 interface ParentSelectFieldProps {
   resourcePath?: string;
-  currentHierarchyItem?: HierarchyItem;
   className?: string;
   enableCollectingEvent?: boolean;
 }
 
 function ParentSelectField({
   resourcePath = "collection-api/material-sample",
-  currentHierarchyItem,
-  className,
-  enableCollectingEvent
+  enableCollectingEvent,
+  className
 }: ParentSelectFieldProps) {
-  const { readOnly } = useDinaFormContext();
+  const { readOnly, initialValues } = useDinaFormContext();
+  const currentHierarchyItemId = initialValues?.hierarchy?.find(
+    (item) => item.rank === 1
+  )?.uuid; // find the hierarchy item with rank 1 (the material sample itself) from form initial values to determine which items to exclude from parent select options
+  const bulkEditCtx = useBulkEditTabContext();
+
+  const currentHierarchyIds: String[] | undefined = bulkEditCtx
+    ? bulkEditCtx.resourceHooks.map(
+        (hook) =>
+          (
+            hook.formRef.current?.initialValues as MaterialSample
+          )?.hierarchy?.find((item) => item.rank === 1)?.uuid
+      ) // find the hierarchy item with rank 1 (the material sample itself) for each resource in bulk edit context
+    : currentHierarchyItemId
+    ? [currentHierarchyItemId]
+    : undefined; // if not in bulk edit context, use the current hierarchy item id if available, otherwise undefined
+
   return (
     <DinaFormSection horizontal={"flex"} readOnly={readOnly}>
       <ResourceSelectFieldCustomQuery<MaterialSample>
         name="parentMaterialSample"
         useCustomQuery={useSearchWsCustomQuery}
-        customQueryOptions={getCustomQueryOptions(currentHierarchyItem)}
+        customQueryOptions={getCustomQueryOptions(currentHierarchyIds)}
         filter={() => ({})}
         readOnlyLink="/collection/material-sample/view?id="
         model={resourcePath}

--- a/packages/dina-ui/components/collection/ParentSelectSection.tsx
+++ b/packages/dina-ui/components/collection/ParentSelectSection.tsx
@@ -9,7 +9,6 @@ import {
 } from "common-ui";
 import { MaterialSample } from "../../types/collection-api";
 import { DinaMessage } from "../../intl/dina-ui-intl";
-import _ from "lodash";
 import { FaDna } from "react-icons/fa";
 
 /**
@@ -17,8 +16,8 @@ import { FaDna } from "react-icons/fa";
  * @param currentHierarchyIds list of ids to exclude from search results (the current material sample(s) and its descendants). If undefined, no items will be excluded.
  * @returns options for ResourceSelectFieldCustomQuery to search for parent material samples, excluding descendants of the current hierarchy item.
  */
-function getCustomQueryOptions(
-  currentHierarchyIds?: String[]
+export function getCustomQueryOptions(
+  currentHierarchyIds?: string[]
 ): ResourceSelectFieldCustomQueryProps<MaterialSample>["customQueryOptions"] {
   return (searchQuery) => ({
     indexName: "dina_material_sample_index",
@@ -116,7 +115,7 @@ function ParentSelectField({
   )?.uuid; // find the hierarchy item with rank 1 (the material sample itself) from form initial values to determine which items to exclude from parent select options
   const bulkEditCtx = useBulkEditTabContext();
 
-  const currentHierarchyIds: String[] | undefined = bulkEditCtx
+  const currentHierarchyIds: string[] | undefined = bulkEditCtx
     ? bulkEditCtx.resourceHooks.map(
         (hook) =>
           (

--- a/packages/dina-ui/components/collection/ParentSelectSection.tsx
+++ b/packages/dina-ui/components/collection/ParentSelectSection.tsx
@@ -33,8 +33,25 @@ export function getCustomQueryOptions(
                   }
                 },
                 {
-                  wildcard: {
-                    "data.id": `*${value}*`
+                  bool: {
+                    must: [
+                      {
+                        wildcard: {
+                          "data.id": `*${value}*`
+                        }
+                      },
+                      {
+                        bool: {
+                          must_not: [
+                            {
+                              exists: {
+                                field: "data.attributes.materialSampleName"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
                   }
                 }
               ],

--- a/packages/dina-ui/components/collection/ParentSelectSection.tsx
+++ b/packages/dina-ui/components/collection/ParentSelectSection.tsx
@@ -1,5 +1,6 @@
 import {
   DinaFormSection,
+  Tooltip,
   ResourceSelectFieldCustomQuery,
   ResourceSelectFieldCustomQueryProps,
   useDinaFormContext,
@@ -8,6 +9,7 @@ import {
 import { HierarchyItem, MaterialSample } from "../../types/collection-api";
 import { DinaMessage } from "../../intl/dina-ui-intl";
 import _ from "lodash";
+import { FaDna } from "react-icons/fa";
 
 /**
  * Generates query-generating function to search by material sample name or id and exclude descendants.
@@ -67,6 +69,7 @@ export interface ParentSelectSectionProps {
   classNames?: string;
   filterList?: (item: MaterialSample) => boolean;
   currentHierarchyItem?: HierarchyItem;
+  enableCollectingEvent?: boolean;
 }
 
 /**
@@ -74,13 +77,14 @@ export interface ParentSelectSectionProps {
  * and its descendants from the parent select options. The parent select field is only
  * rendered if the form is not read-only. Uses elasticsearch for custom query.
  * @param classNames optional additional class names for the section container
- * @param filterList optional function to further filter the parent select options
  * @param currentHierarchyItem the current hierarchy item, used to determine which items to exclude from the parent select options. If not provided, no items will be excluded.
+ * @param enableCollectingEvent disables parent select field when collecting event is enabled.
  * @returns Parent select field.
  */
 export function ParentSelectSection({
   classNames,
-  currentHierarchyItem
+  currentHierarchyItem,
+  enableCollectingEvent
 }: ParentSelectSectionProps) {
   const { readOnly } = useDinaFormContext();
 
@@ -90,6 +94,7 @@ export function ParentSelectSection({
         <div className="d-flex flex-row gap-1">
           <ParentSelectField
             currentHierarchyItem={currentHierarchyItem}
+            enableCollectingEvent={enableCollectingEvent}
             className="flex-grow-1 mb-2"
           />
         </div>
@@ -102,15 +107,16 @@ interface ParentSelectFieldProps {
   resourcePath?: string;
   currentHierarchyItem?: HierarchyItem;
   className?: string;
+  enableCollectingEvent?: boolean;
 }
 
 function ParentSelectField({
   resourcePath = "collection-api/material-sample",
   currentHierarchyItem,
-  className
+  className,
+  enableCollectingEvent
 }: ParentSelectFieldProps) {
   const { readOnly } = useDinaFormContext();
-
   return (
     <DinaFormSection horizontal={"flex"} readOnly={readOnly}>
       <ResourceSelectFieldCustomQuery<MaterialSample>
@@ -126,7 +132,16 @@ function ParentSelectField({
         removeLabel={readOnly}
         removeBottomMargin={true}
         disableTemplateCheckbox={true}
-        label={<DinaMessage id="parentMaterialSample" />}
+        isDisabled={enableCollectingEvent}
+        label={
+          <span>
+            <FaDna className="me-2" />
+            <DinaMessage id="parentMaterialSample" />
+            {enableCollectingEvent && (
+              <Tooltip id="parentMaterialSampleDisabledTooltip" />
+            )}
+          </span>
+        }
       />
     </DinaFormSection>
   );

--- a/packages/dina-ui/components/collection/__tests__/ParentSelectSection.test.ts
+++ b/packages/dina-ui/components/collection/__tests__/ParentSelectSection.test.ts
@@ -1,0 +1,34 @@
+import { getCustomQueryOptions } from "../ParentSelectSection";
+
+describe("getCustomQueryOptions", () => {
+  it("filters out descendants of all bulk-edited samples", () => {
+    const bulkEditedSampleIds = ["sample-1", "sample-2", "sample-3"];
+
+    const options = getCustomQueryOptions(bulkEditedSampleIds)("abc");
+    const query = options.query("abc");
+
+    expect(query.bool.must_not).toEqual([
+      {
+        nested: {
+          path: "data.attributes.hierarchy",
+          query: {
+            bool: {
+              should: [
+                { term: { "data.attributes.hierarchy.uuid": "sample-1" } },
+                { term: { "data.attributes.hierarchy.uuid": "sample-2" } },
+                { term: { "data.attributes.hierarchy.uuid": "sample-3" } }
+              ]
+            }
+          }
+        }
+      }
+    ]);
+  });
+
+  it("does not add descendant exclusion when no sample ids are provided", () => {
+    const options = getCustomQueryOptions(undefined)("abc");
+    const query = options.query("abc") as any;
+
+    expect(query.bool.must_not).toBeUndefined();
+  });
+});

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -428,10 +428,6 @@ export function MaterialSampleForm({
     ...formSectionPairs
   ]);
 
-  const currentHierarchyItem = initialValues?.hierarchy?.find(
-    (item) => item.uuid === initialValues?.id
-  );
-
   const formLayout = (
     <div className="d-md-flex">
       <div style={{ minWidth: "20rem", maxWidth: "20rem" }}>
@@ -480,7 +476,6 @@ export function MaterialSampleForm({
                   <CollectionSelectSection resourcePath="collection-api/collection" />
                   <ProjectSelectSection resourcePath="collection-api/project" />
                   <ParentSelectSection
-                    currentHierarchyItem={currentHierarchyItem}
                     enableCollectingEvent={
                       dataComponentState.enableCollectingEvent
                     }

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -481,6 +481,9 @@ export function MaterialSampleForm({
                   <ProjectSelectSection resourcePath="collection-api/project" />
                   <ParentSelectSection
                     currentHierarchyItem={currentHierarchyItem}
+                    enableCollectingEvent={
+                      dataComponentState.enableCollectingEvent
+                    }
                   />
                   <AssemblageSelectSection resourcePath="collection-api/assemblage" />
                   <NotPubliclyReleasableSection />

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -10,6 +10,8 @@ import {
   DinaFormSection,
   FieldSet,
   LoadingSpinner,
+  ResourceSelectField,
+  SimpleSearchFilterBuilder,
   SubmitButton
 } from "common-ui";
 import { Fragment, ReactNode, Ref, useContext } from "react";
@@ -479,6 +481,28 @@ export function MaterialSampleForm({
                   <TagsAndRestrictionsSection
                     resourcePath="collection-api/material-sample"
                     indexName="dina_material_sample_index"
+                  />
+                  <ResourceSelectField<MaterialSample>
+                    name="parentMaterialSample"
+                    filter={(searchValue) => {
+                      let fb = SimpleSearchFilterBuilder.create().searchFilter(
+                        "materialSampleName",
+                        searchValue
+                      );
+                      for (const hierarchyItem of initialValues.hierarchy ??
+                        []) {
+                        fb = fb.where(
+                          `hierarchy.uuid`,
+                          "NEQ",
+                          hierarchyItem.uuid
+                        );
+                      }
+                      return fb.build();
+                    }}
+                    optionLabel={(option) =>
+                      option.materialSampleName || option.id
+                    }
+                    model="collection-api/material-sample"
                   />
                 </div>
               </div>

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -10,8 +10,6 @@ import {
   DinaFormSection,
   FieldSet,
   LoadingSpinner,
-  ResourceSelectField,
-  SimpleSearchFilterBuilder,
   SubmitButton
 } from "common-ui";
 import { Fragment, ReactNode, Ref, useContext } from "react";
@@ -65,6 +63,7 @@ import { RestrictionField } from "./RestrictionField";
 import { CollectionSelectSection } from "../CollectionSelectSection";
 import { ShowParentAttributesField } from "./ShowParentAttributesField";
 import { SaveAndCopyToNextSuccessAlert } from "../SaveAndCopyToNextSuccessAlert";
+import { ParentSelectSection } from "../ParentSelectSection";
 
 export interface VisibleManagedAttributesConfig {
   materialSample?: string[];
@@ -429,6 +428,10 @@ export function MaterialSampleForm({
     ...formSectionPairs
   ]);
 
+  const currentHierarchyItem = initialValues?.hierarchy?.find(
+    (item) => item.uuid === initialValues?.id
+  );
+
   const formLayout = (
     <div className="d-md-flex">
       <div style={{ minWidth: "20rem", maxWidth: "20rem" }}>
@@ -476,33 +479,14 @@ export function MaterialSampleForm({
                 <div className="col-md-8">
                   <CollectionSelectSection resourcePath="collection-api/collection" />
                   <ProjectSelectSection resourcePath="collection-api/project" />
+                  <ParentSelectSection
+                    currentHierarchyItem={currentHierarchyItem}
+                  />
                   <AssemblageSelectSection resourcePath="collection-api/assemblage" />
                   <NotPubliclyReleasableSection />
                   <TagsAndRestrictionsSection
                     resourcePath="collection-api/material-sample"
                     indexName="dina_material_sample_index"
-                  />
-                  <ResourceSelectField<MaterialSample>
-                    name="parentMaterialSample"
-                    filter={(searchValue) => {
-                      let fb = SimpleSearchFilterBuilder.create().searchFilter(
-                        "materialSampleName",
-                        searchValue
-                      );
-                      for (const hierarchyItem of initialValues.hierarchy ??
-                        []) {
-                        fb = fb.where(
-                          `hierarchy.uuid`,
-                          "NEQ",
-                          hierarchyItem.uuid
-                        );
-                      }
-                      return fb.build();
-                    }}
-                    optionLabel={(option) =>
-                      option.materialSampleName || option.id
-                    }
-                    model="collection-api/material-sample"
                   />
                 </div>
               </div>

--- a/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
+++ b/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
@@ -380,6 +380,61 @@ describe("Material Sample Edit Page", () => {
     ]);
   });
 
+  it("Assigns a parent material sample and saves the relationship", async () => {
+    // Mock the search-ws results to return a single parent sample option.
+    mockUseSearchWsResults([
+      {
+        id: "parent-1",
+        type: "material-sample",
+        materialSampleName: "parent-sample-name"
+      }
+    ]);
+
+    const wrapper = mountWithAppContext(
+      <MaterialSampleForm onSaved={mockOnSaved} />,
+      testCtx
+    );
+
+    await waitFor(() => expect(wrapper.container).toBeInTheDocument());
+
+    // Find the parent select field container and its combobox input.
+    const parentField = wrapper.container.querySelector(
+      ".parent-material-sample-field"
+    );
+    if (!parentField) {
+      fail("Parent select field not found in form.");
+    }
+
+    const combo = within(parentField as any).getByRole("combobox");
+
+    // Open the dropdown and type to trigger the custom query (debounced in component).
+    userEvent.click(combo);
+    userEvent.type(combo, "parent");
+
+    // Select the mocked parent option.
+    const option = await within(parentField as any).findByText(
+      /parent-sample-name/i
+    );
+    userEvent.click(option);
+
+    screen.logTestingPlaygroundURL();
+
+    // Save the form.
+    userEvent.click(wrapper.getByRole("button", { name: /save/i }));
+
+    // Expect save to be called and include the parentMaterialSample relationship.
+    await waitFor(() => expect(mockSave).toHaveBeenCalled());
+
+    const firstCallSaves = mockSave.mock.calls[0][0];
+    // The save payloads are arrays of save objects; find the material-sample save.
+    const msSave = firstCallSaves.find(
+      (s: any) => s.type === "material-sample"
+    );
+    expect(msSave).toBeDefined();
+    expect(msSave.resource.parentMaterialSample).toBeDefined();
+    expect(msSave.resource.parentMaterialSample.id).toEqual("parent-1");
+  });
+
   it("Submits a new material-sample linked to an existing CollectingEvent.", async () => {
     const wrapper = mountWithAppContext(
       <MaterialSampleForm onSaved={mockOnSaved} />,

--- a/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
+++ b/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import { useSearchWsCustomQuery } from "../../../../../common-ui/lib/search/useSearchWsCustomQuery";
 
 // Mock out the dynamic component, which should only be rendered in the browser
 jest.mock("next/dynamic", () => () => {
@@ -22,6 +23,29 @@ jest.mock("next/dynamic", () => () => {
     return <div>Mock dynamic component</div>;
   };
 });
+
+/**
+ * Reusable mock block for tests that render components using `useSearchWsCustomQuery`.
+ * Copy this block into other test files to avoid real search-ws API calls.
+ */
+jest.mock("../../../../../common-ui/lib/search/useSearchWsCustomQuery", () => {
+  const actual = jest.requireActual(
+    "../../../../../common-ui/lib/search/useSearchWsCustomQuery"
+  );
+  return {
+    ...actual,
+    useSearchWsCustomQuery: jest
+      .fn()
+      .mockReturnValue({ loading: false, response: { data: [] } })
+  };
+});
+
+function mockUseSearchWsResults(data: unknown[] = []) {
+  (useSearchWsCustomQuery as jest.Mock).mockReturnValue({
+    loading: false,
+    response: { data }
+  });
+}
 
 function testCollectionEvent(): Partial<CollectingEvent> {
   return {
@@ -271,6 +295,7 @@ const mockFetchResponse = (data) => {
 describe("Material Sample Edit Page", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSearchWsResults();
 
     window.fetch = jest
       .fn()

--- a/packages/dina-ui/components/collection/material-sample/useMaterialSample.tsx
+++ b/packages/dina-ui/components/collection/material-sample/useMaterialSample.tsx
@@ -1114,6 +1114,13 @@ export function useMaterialSampleSave({
               ? _.pick(msDiffWithOrganisms.storageUnitUsage, "id", "type")
               : null
           }
+        }),
+        ...(msDiffWithOrganisms.parentMaterialSample && {
+          parentMaterialSample: {
+            data: msDiffWithOrganisms.parentMaterialSample?.id
+              ? _.pick(msDiffWithOrganisms.parentMaterialSample, "id", "type")
+              : null
+          }
         })
       }
     };

--- a/packages/dina-ui/intl/dina-ui-en.ts
+++ b/packages/dina-ui/intl/dina-ui-en.ts
@@ -1453,5 +1453,7 @@ export const DINAUI_MESSAGES_ENGLISH = {
   exportRequestSubmittedMessage:
     "Your export is being processed. You will receive a notification when it's ready to download.",
   resetView: "Reset View",
-  saveAsImage: "Save as Image"
+  saveAsImage: "Save as Image",
+  parentMaterialSampleDisabledTooltip:
+    "Material Sample can only have a single link to one of the following relationships: Parent Material Sample or a collecting event."
 };

--- a/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
@@ -22,6 +22,30 @@ import {
 } from "../../../../types/collection-api";
 import { fireEvent, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { useSearchWsCustomQuery } from "../../../../../common-ui/lib/search/useSearchWsCustomQuery";
+
+/**
+ * Reusable mock block for tests that render components using `useSearchWsCustomQuery`.
+ * Copy this block into other test files to avoid real search-ws API calls.
+ */
+jest.mock("../../../../../common-ui/lib/search/useSearchWsCustomQuery", () => {
+  const actual = jest.requireActual(
+    "../../../../../common-ui/lib/search/useSearchWsCustomQuery"
+  );
+  return {
+    ...actual,
+    useSearchWsCustomQuery: jest
+      .fn()
+      .mockReturnValue({ loading: false, response: { data: [] } })
+  };
+});
+
+function mockUseSearchWsResults(data: unknown[] = []) {
+  (useSearchWsCustomQuery as jest.Mock).mockReturnValue({
+    loading: false,
+    response: { data }
+  });
+}
 const mockOnSaved = jest.fn();
 
 const TEST_GROUP_1 = {
@@ -1778,7 +1802,10 @@ const expected = {
 };
 
 describe("Form template edit page", () => {
-  beforeEach(jest.clearAllMocks);
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSearchWsResults();
+  });
 
   it("Renders the blank template edit page", async () => {
     const { wrapper } = await mountForm();

--- a/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
+++ b/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
@@ -5,6 +5,7 @@ import { mountWithAppContext } from "common-ui";
 import { fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
+import { useSearchWsCustomQuery } from "../../../../../common-ui/lib/search/useSearchWsCustomQuery";
 
 // Mock out the dynamic component, which should only be rendered in the browser
 jest.mock("next/dynamic", () => () => {
@@ -12,6 +13,29 @@ jest.mock("next/dynamic", () => () => {
     return <div>Mock dynamic component</div>;
   };
 });
+
+/**
+ * Reusable mock block for tests that render components using `useSearchWsCustomQuery`.
+ * Copy this block into other test files to avoid real search-ws API calls.
+ */
+jest.mock("../../../../../common-ui/lib/search/useSearchWsCustomQuery", () => {
+  const actual = jest.requireActual(
+    "../../../../../common-ui/lib/search/useSearchWsCustomQuery"
+  );
+  return {
+    ...actual,
+    useSearchWsCustomQuery: jest
+      .fn()
+      .mockReturnValue({ loading: false, response: { data: [] } })
+  };
+});
+
+function mockUseSearchWsResults(data: unknown[] = []) {
+  (useSearchWsCustomQuery as jest.Mock).mockReturnValue({
+    loading: false,
+    response: { data }
+  });
+}
 
 const mockPush = jest.fn();
 
@@ -45,12 +69,11 @@ const testCtx = {
 };
 
 describe("MaterialSampleBulkCreatePage", () => {
-  beforeEach(jest.clearAllMocks);
-
   beforeEach(() => {
     // Set the deault group selection:
     writeStorage(DEFAULT_GROUP_STORAGE_KEY, "aafc");
     jest.clearAllMocks();
+    mockUseSearchWsResults();
   });
 
   it("Can click the 'previous' button to go back to the previous step", async () => {


### PR DESCRIPTION
- Added a new custom query-based parent material sample select field to the material sample form and bulk edit workflows.  
-  Dropdown filters out all descendants and current sample.
- Dropdown is disabled if collecting event section is active. 
- Added a reusable custom hook for use in elasticsearch-backed resource select fields
- Added unit tests for assigning a parent to a sample
-  Added mocks for new field's api requests

Note: During testing I checked to see what would happen if I assigned a parent sample's child as it's parent, it ended up deleting both samples.
 