### PR TITLE
added prop to filter out displayed columns from selector list

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelectorList.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorList.tsx
@@ -35,7 +35,8 @@ import QueryRowClassificationSearch, {
 } from "../list-page/query-builder/query-builder-value-types/QueryBuilderClassificationSearch";
 import { FaArrowRotateLeft, FaPlus } from "react-icons/fa6";
 import QueryRowImageLink, {
-  ImageLinkStates
+  ImageLinkStates,
+  SUPPORTED_DERIVATIVE_TYPES
 } from "../list-page/query-builder/query-builder-value-types/QueryBuilderImageLink";
 import { FunctionDef } from "@dina-ui/types/dina-export-api";
 
@@ -344,6 +345,27 @@ export function ColumnSelectorList<TData extends KitsuResource>({
           return false;
         }
 
+        // Special handling for imageLink dynamic fields: if all supported image types
+        // (or ORIGINAL when in export mode) are already displayed, do not show the
+        // generic imageLink option in the add-column list.
+        if (mapping.dynamicField?.type === "imageLink") {
+          const displayedImageTypes = displayedColumns
+            .map((c) =>
+              c?.columnSelectorString?.startsWith("imageLink/")
+                ? c.columnSelectorString.split("/")[1]
+                : undefined
+            )
+            .filter((v) => v !== undefined) as string[];
+
+          const neededTypes = exportMode
+            ? ["ORIGINAL"]
+            : SUPPORTED_DERIVATIVE_TYPES;
+
+          const displayedSet = new Set(displayedImageTypes);
+          const allDisplayed = neededTypes.every((t) => displayedSet.has(t));
+          if (allDisplayed) return false;
+        }
+
         if (exportMode) {
           return !(nonExportableColumns ?? []).some((id) =>
             mapping?.parentType
@@ -432,6 +454,15 @@ export function ColumnSelectorList<TData extends KitsuResource>({
               setValue={setDynamicFieldValue}
               value={dynamicFieldValue}
               exportMode={exportMode}
+              excludedImageTypes={
+                displayedColumns
+                  .map((c) =>
+                    c?.columnSelectorString?.startsWith("imageLink/")
+                      ? c.columnSelectorString.split("/")[1]
+                      : undefined
+                  )
+                  .filter((v) => v !== undefined) as string[]
+              }
             />
           )}
           <div className="mt-2 d-grid">

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderImageLink.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderImageLink.tsx
@@ -58,9 +58,7 @@ export default function QueryRowImageLink({
   const [imageLinkState, setImageLinkState] = useState<ImageLinkStates>(() =>
     value
       ? JSON.parse(value)
-      : {
-          selectedImageType: exportMode ? "ORIGINAL" : "LARGE_IMAGE"
-        }
+      : { selectedImageType: exportMode ? "ORIGINAL" : "LARGE_IMAGE" }
   );
 
   // Convert the state in this component to a value that can be stored in the Query Builder.
@@ -76,7 +74,7 @@ export default function QueryRowImageLink({
       setImageLinkState(JSON.parse(value));
     } else {
       setImageLinkState({
-        selectedImageType: "LARGE_IMAGE"
+        selectedImageType: exportMode ? "ORIGINAL" : "LARGE_IMAGE"
       });
     }
   }, []);

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderImageLink.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/QueryBuilderImageLink.tsx
@@ -24,6 +24,10 @@ interface QueryRowImageLinkProps {
    * When in export mode, only ORIGINAL type is supported.
    */
   exportMode?: boolean;
+  /**
+   * Image types that should be excluded from the selector (already displayed).
+   */
+  excludedImageTypes?: string[];
 }
 
 // Supported derivative types for the image link selection.
@@ -46,7 +50,8 @@ export interface ImageLinkStates {
 export default function QueryRowImageLink({
   value,
   setValue,
-  exportMode
+  exportMode,
+  excludedImageTypes
 }: QueryRowImageLinkProps) {
   const { formatMessage } = useIntl();
 
@@ -77,9 +82,13 @@ export default function QueryRowImageLink({
   }, []);
 
   // Generate the image type options (export mode only supports ORIGINAL)
-  const availableTypes = exportMode
+  const availableTypesBase = exportMode
     ? SUPPORTED_DERIVATIVE_TYPES.filter((t) => t === "ORIGINAL")
     : SUPPORTED_DERIVATIVE_TYPES;
+
+  const availableTypes = availableTypesBase.filter(
+    (t) => !(excludedImageTypes ?? []).includes(t)
+  );
   const imageTypeOptions = availableTypes.map<SelectOption<string>>(
     (option) => ({
       label: formatMessage({ id: "queryBuilder_imageLink_" + option }),


### PR DESCRIPTION
-in column selector, the image link field now filters out currently displayed image link columns. If all columns are displayed, image link disappears from column selector dropdown.
-fixed issue in export mode column selector, where the image link original option would not apply unless you clicked it, even though it is the only option 