### PR TITLE
Bug #38400 - Can't Add column for other identifiers tube ID

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
@@ -1,7 +1,7 @@
 import Kitsu, { GetParams, KitsuResource } from "kitsu";
 import _ from "lodash";
 import { FaCheckSquare, FaRegSquare } from "react-icons/fa";
-import { FieldHeader, dateCell } from "..";
+import { FieldHeader, SimpleSearchFilterBuilder, dateCell } from "..";
 import { VocabularyFieldHeader } from "../../../../packages/dina-ui/components";
 import { useDinaIntl } from "@dina-ui/intl/dina-ui-intl";
 import { FieldExtensionSearchStates } from "../list-page/query-builder/query-builder-value-types/QueryBuilderFieldExtensionSearch";
@@ -1179,7 +1179,10 @@ async function getControlledVocabularyColumn<TData extends KitsuResource>(
 ): Promise<TableColumn<TData> | undefined> {
   // API request params:
   const params = {
-    page: { limit: 1 }
+    page: { limit: 1 },
+    filter: SimpleSearchFilterBuilder.create<ControlledVocabularyItem>()
+      .where("uuid", "EQ", controlledVocabularyKey)
+      .build()
   };
 
   // Figure out API endpoint using the dynamicFieldsMappingConfig.

--- a/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
+++ b/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "@testing-library/react";
-import { MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID } from "@dina-ui/components/controlled-vocabulary/controlledVocabularyItemUtils";
 import {
   collectPathValues,
   generateColumnPath,
@@ -136,7 +135,7 @@ describe("ColumnSelectorUtils", () => {
               label: "otherIdentifiers",
               component: "MATERIAL_SAMPLE",
               path: "data.attributes.identifiers",
-              apiEndpoint: `collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=${MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID}&filter[dinaComponent][EQ]=MATERIAL_SAMPLE`
+              apiEndpoint: `collection-api/controlled-vocabulary-item`
             },
             value: "data.attributes.identifiers",
             distinctTerm: false,
@@ -162,7 +161,7 @@ describe("ColumnSelectorUtils", () => {
               label: "otherIdentifiers",
               component: "MATERIAL_SAMPLE",
               path: "included.attributes.identifiers",
-              apiEndpoint: `collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=${MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID}&filter[dinaComponent][EQ]=MATERIAL_SAMPLE`
+              apiEndpoint: `collection-api/controlled-vocabulary-item`
             },
             parentName: "parentMaterialSample",
             parentPath: "included",

--- a/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderIdentifierSearch.test.tsx
+++ b/packages/common-ui/lib/list-page/query-builder/query-builder-value-types/__tests__/QueryBuilderIdentifierSearch.test.tsx
@@ -1,4 +1,3 @@
-import { MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID } from "@dina-ui/components/controlled-vocabulary/controlledVocabularyItemUtils";
 import { transformIdentifierToDSL } from "../QueryBuilderIdentifierSearch";
 
 interface TestValueStructure {
@@ -184,7 +183,7 @@ describe("QueryBuilderIdentifierSearch", () => {
                         label: "otherIdentifiers",
                         component: "MATERIAL_SAMPLE",
                         path: "data.attributes.identifiers",
-                        apiEndpoint: `collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=${MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID}&filter[dinaComponent][EQ]=MATERIAL_SAMPLE`
+                        apiEndpoint: `collection-api/controlled-vocabulary-item`
                       },
                       hideField: true,
                       value: "data.attributes.identifiers",
@@ -237,7 +236,7 @@ describe("QueryBuilderIdentifierSearch", () => {
                         path: "included.attributes.identifiers",
                         referencedBy: "parentMaterialSample",
                         referencedType: "material-sample",
-                        apiEndpoint: `collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=${MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID}&filter[dinaComponent][EQ]=MATERIAL_SAMPLE`
+                        apiEndpoint: `collection-api/controlled-vocabulary-item`
                       } as any,
                       hideField: true,
                       parentName: "parentMaterialSample",

--- a/packages/dina-ui/pages/collection/material-sample/list.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/list.tsx
@@ -32,7 +32,6 @@ import { Footer, GroupSelectField, Head, Nav } from "../../../components";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import { MaterialSample } from "../../../types/collection-api";
 import { MdOutlineLibraryAdd } from "react-icons/md";
-import { MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID } from "../../../components/controlled-vocabulary/controlledVocabularyItemUtils";
 export const MATERIAL_SAMPLE_NON_EXPORTABLE_COLUMNS: string[] = [
   "selectColumn",
   "assemblages.",
@@ -242,7 +241,7 @@ export const dynamicFieldMappingForMaterialSample: DynamicFieldsMappingConfig =
         label: "otherIdentifiers",
         component: "MATERIAL_SAMPLE",
         path: "data.attributes.identifiers",
-        apiEndpoint: `collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=${MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID}&filter[dinaComponent][EQ]=MATERIAL_SAMPLE`
+        apiEndpoint: `collection-api/controlled-vocabulary-item`
       },
 
       // Preparation - Managed Attributes
@@ -372,7 +371,7 @@ export const dynamicFieldMappingForMaterialSample: DynamicFieldsMappingConfig =
         label: "otherIdentifiers",
         component: "MATERIAL_SAMPLE",
         path: "included.attributes.identifiers",
-        apiEndpoint: `collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=${MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID}&filter[dinaComponent][EQ]=MATERIAL_SAMPLE`,
+        apiEndpoint: `collection-api/controlled-vocabulary-item`,
         referencedBy: "parentMaterialSample",
         referencedType: "material-sample"
       },


### PR DESCRIPTION
- Updated network request, only worked if one identifier exists, now filters properly for the specific identifier.
- Updated tests.