### PR TITLE
38535

### DIFF
--- a/packages/dina-ui/pages/dina-user/list.tsx
+++ b/packages/dina-ui/pages/dina-user/list.tsx
@@ -64,6 +64,7 @@ export default function AgentListPage() {
         </h1>
         <ListPageLayout
           id="user-list"
+          enableInMemoryFilter={true}
           queryTableProps={{
             columns: USER_TABLE_COLUMNS,
             path: "user-api/user",


### PR DESCRIPTION
set enableInMemoryFilter to true on ListPageLayout, that enables in memory filter as the name suggests and allows client-side pagination via tanstack
