### PR TITLE
Support #38550 - Collection managed attribute view and edit pages to controlled vocabulary

### DIFF
--- a/packages/common-ui/lib/list-page/types.ts
+++ b/packages/common-ui/lib/list-page/types.ts
@@ -312,7 +312,7 @@ export interface DynamicField {
   /**
    * Endpoint where these dynamic fields can be retrieved to list.
    *
-   * Example: "collection-api/managed-attribute"
+   * Example: "collection-api/controlled-vocabulary-item"
    */
   apiEndpoint?: string;
 

--- a/packages/dina-ui/components/bulk-edit/__tests__/BulkEditTabWarning.test.tsx
+++ b/packages/dina-ui/components/bulk-edit/__tests__/BulkEditTabWarning.test.tsx
@@ -49,7 +49,7 @@ const mockGet = jest.fn<any, any>(async (path) => {
     case "collection-api/material-sample-type":
     case "collection-api/project":
     case "collection-api/material-sample":
-    case "collection-api/managed-attribute":
+    case "collection-api/controlled-vocabulary-item":
     case "objectstore-api/metadata":
     case "user-api/group":
       return { data: [] };

--- a/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
+++ b/packages/dina-ui/components/bulk-edit/__tests__/useBulkEditTab.test.tsx
@@ -126,13 +126,13 @@ function BulkEditTab({ baseSample }: BulkEditTabProps) {
 
 const mockGet = jest.fn<any, any>(async (path, params) => {
   switch (path) {
-    case "collection-api/managed-attribute":
+    case "collection-api/controlled-vocabulary-item":
       if (params?.filter?.key?.EQ === "a") {
         return {
           data: [
             {
               id: "1",
-              type: "managed-attribute",
+              type: "controlled-vocabulary-item",
               vocabularyElementType: "STRING",
               managedAttributeComponent: "MATERIAL_SAMPLE",
               key: "a",
@@ -146,7 +146,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           data: [
             {
               id: "2",
-              type: "managed-attribute",
+              type: "controlled-vocabulary-item",
               vocabularyElementType: "STRING",
               managedAttributeComponent: "MATERIAL_SAMPLE",
               key: "b",
@@ -160,7 +160,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           data: [
             {
               id: "3",
-              type: "managed-attribute",
+              type: "controlled-vocabulary-item",
               vocabularyElementType: "STRING",
               managedAttributeComponent: "MATERIAL_SAMPLE",
               key: "c",
@@ -174,7 +174,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
         data: [
           {
             id: "1",
-            type: "managed-attribute",
+            type: "controlled-vocabulary-item",
             vocabularyElementType: "STRING",
             managedAttributeComponent: "MATERIAL_SAMPLE",
             key: "a",
@@ -182,7 +182,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           },
           {
             id: "2",
-            type: "managed-attribute",
+            type: "controlled-vocabulary-item",
             vocabularyElementType: "STRING",
             managedAttributeComponent: "MATERIAL_SAMPLE",
             key: "b",
@@ -190,7 +190,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           },
           {
             id: "3",
-            type: "managed-attribute",
+            type: "controlled-vocabulary-item",
             vocabularyElementType: "STRING",
             managedAttributeComponent: "MATERIAL_SAMPLE",
             key: "c",

--- a/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
+++ b/packages/dina-ui/components/bulk-material-sample/__tests__/MaterialSampleBulkEditor.test.tsx
@@ -71,16 +71,16 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
           materialSampleName: "material-sample-500"
         }
       };
-    case "collection-api/managed-attribute":
+    case "collection-api/controlled-vocabulary-item":
       if (params?.filter?.key?.EQ === "m1") {
         return Promise.resolve({
           data: [
             {
-              type: "managed-attribute",
+              type: "controlled-vocabulary-item",
               id: "1",
               key: "m1",
               vocabularyElementType: "STRING",
-              managedAttributeComponent: "MATERIAL_SAMPLE",
+              dinaComponent: "MATERIAL_SAMPLE",
               name: "Managed Attribute 1"
             }
           ]
@@ -90,11 +90,11 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
         return Promise.resolve({
           data: [
             {
-              type: "managed-attribute",
+              type: "controlled-vocabulary-item",
               id: "2",
               key: "m2",
               vocabularyElementType: "STRING",
-              managedAttributeComponent: "MATERIAL_SAMPLE",
+              dinaComponent: "MATERIAL_SAMPLE",
               name: "Managed Attribute 2"
             }
           ]
@@ -104,11 +104,11 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
         return Promise.resolve({
           data: [
             {
-              type: "managed-attribute",
+              type: "controlled-vocabulary-item",
               id: "3",
               key: "m3",
               vocabularyElementType: "STRING",
-              managedAttributeComponent: "MATERIAL_SAMPLE",
+              dinaComponent: "MATERIAL_SAMPLE",
               name: "Managed Attribute 3"
             }
           ]
@@ -152,7 +152,7 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
       return { data: TEST_STORAGE_UNITS[2] };
     case "collection-api/form-template/cd6d8297-43a0-45c6-b44e-983db917eb11":
       return { data: TEST_FORM_TEMPLATE };
-    case "collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=019c961e-4c0d-7398-b4ae-73687826b3b5&filter[dinaComponent][EQ]=MATERIAL_SAMPLE&page[limit]=1000":
+    case "collection-api/controlled-vocabulary-item?filter[controlledVocabulary.uuid][EQ]=019c961e-4c0d-7398-b4ae-73687826b3b5&filter[dinaComponent][EQ]=MATERIAL_SAMPLE":
       return {
         data: [
           {
@@ -223,6 +223,9 @@ const mockGet = jest.fn<any, any>(async (path, params) => {
     case "collection-api/form-template":
     case "collection-api/assemblage":
     case "collection-api/extension":
+    case "collection-api/expedition":
+    case "collection-api/protocol":
+    case "collection-api/site":
       return { data: [] };
   }
 });

--- a/packages/dina-ui/components/collection/collecting-event/CollectingEventFormLayout.tsx
+++ b/packages/dina-ui/components/collection/collecting-event/CollectingEventFormLayout.tsx
@@ -412,7 +412,7 @@ export function CollectingEventFormLayout({
   const collectingEventManagedAttributesComponent = (
     <ManagedAttributesEditor
       valuesPath="managedAttributes"
-      managedAttributeApiPath="collection-api/managed-attribute"
+      managedAttributeApiPath="collection-api/controlled-vocabulary-item"
       managedAttributeComponent="COLLECTING_EVENT"
       fieldSetProps={{
         legend: <DinaMessage id="collectingEventManagedAttributes" />,
@@ -421,6 +421,7 @@ export function CollectingEventFormLayout({
       }}
       managedAttributeOrderFieldName="managedAttributesOrder"
       visibleAttributeKeys={visibleManagedAttributeKeys}
+      isControlledVocabulary={true}
     />
   );
   const geographicPlaceNameSourceComponent = (

--- a/packages/dina-ui/components/collection/collecting-event/DeterminationField.tsx
+++ b/packages/dina-ui/components/collection/collecting-event/DeterminationField.tsx
@@ -315,7 +315,7 @@ export function DeterminationField({
                     <DinaFormSection disableEditAllDelete={true}>
                       <ManagedAttributesEditor
                         valuesPath={fieldProps("managedAttributes").name}
-                        managedAttributeApiPath="collection-api/managed-attribute"
+                        managedAttributeApiPath="collection-api/controlled-vocabulary-item"
                         managedAttributeComponent="DETERMINATION"
                         attributeSelectorWidth={12}
                         fieldSetProps={{
@@ -328,6 +328,7 @@ export function DeterminationField({
                         managedAttributeOrderFieldName="determinationManagedAttributesOrder"
                         visibleAttributeKeys={visibleManagedAttributeKeys}
                         disableClearButton={true}
+                        isControlledVocabulary={true}
                       />
                     </DinaFormSection>
                   )}
@@ -336,7 +337,7 @@ export function DeterminationField({
                   <DinaFormSection disableEditAllDelete={true}>
                     <ManagedAttributesEditor
                       valuesPath={fieldProps("managedAttributes").name}
-                      managedAttributeApiPath="collection-api/managed-attribute"
+                      managedAttributeApiPath="collection-api/controlled-vocabulary-item"
                       managedAttributeComponent="DETERMINATION"
                       attributeSelectorWidth={12}
                       fieldSetProps={{
@@ -349,6 +350,7 @@ export function DeterminationField({
                       managedAttributeOrderFieldName="determinationManagedAttributesOrder"
                       visibleAttributeKeys={visibleManagedAttributeKeys}
                       disableClearButton={true}
+                      isControlledVocabulary={true}
                     />
                   </DinaFormSection>
                 )}

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleForm.tsx
@@ -394,7 +394,7 @@ export function MaterialSampleForm({
             <div className="col-md-12">
               <ManagedAttributesEditor
                 valuesPath="managedAttributes"
-                managedAttributeApiPath="collection-api/managed-attribute"
+                managedAttributeApiPath="collection-api/controlled-vocabulary-item"
                 managedAttributeComponent="MATERIAL_SAMPLE"
                 fieldSetProps={{
                   id,
@@ -405,6 +405,7 @@ export function MaterialSampleForm({
                   visibleManagedAttributeKeys?.materialSample
                 }
                 disableClearButton={true}
+                isControlledVocabulary={true}
               />
             </div>
           </div>

--- a/packages/dina-ui/components/collection/material-sample/MaterialSampleInfoSection.tsx
+++ b/packages/dina-ui/components/collection/material-sample/MaterialSampleInfoSection.tsx
@@ -121,7 +121,7 @@ export function MaterialSampleInfoSection({
           <div className="col-md-12">
             <ManagedAttributesEditor
               valuesPath="managedAttributes"
-              managedAttributeApiPath="collection-api/managed-attribute"
+              managedAttributeApiPath="collection-api/controlled-vocabulary-item"
               managedAttributeComponent="MATERIAL_SAMPLE"
               fieldSetProps={{
                 id,
@@ -130,6 +130,7 @@ export function MaterialSampleInfoSection({
               managedAttributeOrderFieldName="managedAttributesOrder"
               visibleAttributeKeys={visibleManagedAttributeKeys?.materialSample}
               disableClearButton={true}
+              isControlledVocabulary={true}
             />
           </div>
         </div>

--- a/packages/dina-ui/components/collection/material-sample/OrganismStateField.tsx
+++ b/packages/dina-ui/components/collection/material-sample/OrganismStateField.tsx
@@ -125,7 +125,7 @@ export function OrganismStateField({
         <DinaFormSection disableEditAllDelete={true}>
           <ManagedAttributesEditor
             valuesPath={fieldProps("managedAttributes").name}
-            managedAttributeApiPath="collection-api/managed-attribute"
+            managedAttributeApiPath="collection-api/controlled-vocabulary-item"
             managedAttributeComponent="ORGANISM"
             attributeSelectorWidth={12}
             fieldSetProps={{
@@ -136,6 +136,7 @@ export function OrganismStateField({
             managedAttributeOrderFieldName="organismManagedAttributesOrder"
             visibleAttributeKeys={visibleManagedAttributeKeys}
             disableClearButton={true}
+            isControlledVocabulary={true}
           />
         </DinaFormSection>
         <FieldSpy<[]> fieldName={determinationFieldProps.name}>

--- a/packages/dina-ui/components/collection/material-sample/PreparationField.tsx
+++ b/packages/dina-ui/components/collection/material-sample/PreparationField.tsx
@@ -199,7 +199,7 @@ export function PreparationField({
         <div className="col-md-12">
           <ManagedAttributesEditor
             valuesPath="preparationManagedAttributes"
-            managedAttributeApiPath="collection-api/managed-attribute"
+            managedAttributeApiPath="collection-api/controlled-vocabulary-item"
             managedAttributeComponent="PREPARATION"
             fieldSetProps={{
               id,
@@ -210,6 +210,7 @@ export function PreparationField({
             managedAttributeOrderFieldName="preparationManagedAttributesOrder"
             visibleAttributeKeys={visibleManagedAttributeKeys}
             disableClearButton={true}
+            isControlledVocabulary={true}
           />
         </div>
       </div>

--- a/packages/dina-ui/components/collection/material-sample/ShowParentAttributeTemplate.tsx
+++ b/packages/dina-ui/components/collection/material-sample/ShowParentAttributeTemplate.tsx
@@ -15,6 +15,7 @@ import {
   SHOW_PARENT_ATTRIBUTES_COMPONENT_NAME
 } from "../../../types/collection-api";
 import { MATERIAL_SAMPLE_ATTR_NAMES } from "./ShowParentAttributesField";
+import { COLLECTION_MANAGED_ATTRIBUTE_ID } from "@dina-ui/components/controlled-vocabulary/controlledVocabularyItemUtils";
 
 interface ShowParentAttributeTemplateProps {
   className?: string;
@@ -112,6 +113,11 @@ export function ShowParentAttributeTemplate({
       path: "collection-api/controlled-vocabulary-item",
       filter: SimpleSearchFilterBuilder.create<ControlledVocabularyItem>()
         .where("dinaComponent", "EQ", "ORGANISM")
+        .where(
+          "controlledVocabulary.uuid" as any,
+          "EQ",
+          COLLECTION_MANAGED_ATTRIBUTE_ID
+        )
         .build(),
       page: { limit: 1000 }
     },

--- a/packages/dina-ui/components/collection/material-sample/ShowParentAttributeTemplate.tsx
+++ b/packages/dina-ui/components/collection/material-sample/ShowParentAttributeTemplate.tsx
@@ -11,7 +11,7 @@ import { useLayoutEffect, useEffect, useMemo, useState } from "react";
 import { FaMinus, FaPlus } from "react-icons/fa";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import {
-  ManagedAttribute,
+  ControlledVocabularyItem,
   SHOW_PARENT_ATTRIBUTES_COMPONENT_NAME
 } from "../../../types/collection-api";
 import { MATERIAL_SAMPLE_ATTR_NAMES } from "./ShowParentAttributesField";
@@ -38,7 +38,7 @@ export function ShowParentAttributeTemplate({
 
   // Managed attributes loaded from the request.
   const [organismManagedAttributes, setOrganismManagedAttributes] = useState<
-    ManagedAttribute[]
+    ControlledVocabularyItem[]
   >([]);
   const [organismManagedAttributesLoaded, setOrganismManagedAttributesLoaded] =
     useState<boolean>(false);
@@ -107,11 +107,11 @@ export function ShowParentAttributeTemplate({
     };
   }
 
-  useQuery<ManagedAttribute[]>(
+  useQuery<ControlledVocabularyItem[]>(
     {
-      path: "collection-api/managed-attribute",
-      filter: SimpleSearchFilterBuilder.create<ManagedAttribute>()
-        .where("managedAttributeComponent", "EQ", "ORGANISM")
+      path: "collection-api/controlled-vocabulary-item",
+      filter: SimpleSearchFilterBuilder.create<ControlledVocabularyItem>()
+        .where("dinaComponent", "EQ", "ORGANISM")
         .build(),
       page: { limit: 1000 }
     },

--- a/packages/dina-ui/components/collection/material-sample/ShowParentMaterialSample.tsx
+++ b/packages/dina-ui/components/collection/material-sample/ShowParentMaterialSample.tsx
@@ -3,7 +3,7 @@ import { InputResource } from "kitsu";
 import _ from "lodash";
 import { DinaMessage, useDinaIntl } from "../../../intl/dina-ui-intl";
 import {
-  ManagedAttribute,
+  ControlledVocabularyItem,
   MaterialSample,
   SHOW_PARENT_ATTRIBUTES_COMPONENT_NAME
 } from "../../../types/collection-api";
@@ -26,10 +26,10 @@ export function ShowParentMaterialSample({
 
   const parentMaterialSample: MaterialSample =
     (materialSample?.parentMaterialSample ?? {}) as MaterialSample;
-  const { response: attrResp } = useQuery<ManagedAttribute[]>({
-    path: "collection-api/managed-attribute",
-    filter: SimpleSearchFilterBuilder.create<ManagedAttribute>()
-      .where("managedAttributeComponent", "EQ", "ORGANISM")
+  const { response: attrResp } = useQuery<ControlledVocabularyItem[]>({
+    path: "collection-api/controlled-vocabulary-item",
+    filter: SimpleSearchFilterBuilder.create<ControlledVocabularyItem>()
+      .where("dinaComponent", "EQ", "ORGANISM")
       .build(),
     page: { limit: 1000 }
   });

--- a/packages/dina-ui/components/collection/material-sample/ShowParentMaterialSample.tsx
+++ b/packages/dina-ui/components/collection/material-sample/ShowParentMaterialSample.tsx
@@ -8,6 +8,7 @@ import {
   SHOW_PARENT_ATTRIBUTES_COMPONENT_NAME
 } from "../../../types/collection-api";
 import { MATERIAL_SAMPLE_ATTR_NAMES } from "./ShowParentAttributesField";
+import { COLLECTION_MANAGED_ATTRIBUTE_ID } from "@dina-ui/components/controlled-vocabulary/controlledVocabularyItemUtils";
 
 interface ShowParentMaterialSampleProps {
   className?: string;
@@ -30,6 +31,11 @@ export function ShowParentMaterialSample({
     path: "collection-api/controlled-vocabulary-item",
     filter: SimpleSearchFilterBuilder.create<ControlledVocabularyItem>()
       .where("dinaComponent", "EQ", "ORGANISM")
+      .where(
+        "controlledVocabulary.uuid" as any,
+        "EQ",
+        COLLECTION_MANAGED_ATTRIBUTE_ID
+      )
       .build(),
     page: { limit: 1000 }
   });

--- a/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
+++ b/packages/dina-ui/components/collection/material-sample/__tests__/MaterialSampleForm.test.tsx
@@ -188,7 +188,7 @@ const mockGeographicSearchResults = [
 
 const mockGet = jest.fn<any, any>(async (path, params) => {
   switch (path) {
-    case "collection-api/managed-attribute":
+    case "collection-api/controlled-vocabulary-item":
       // Handle filter-based lookups used by useManagedAttributeQueries
       if (params?.filter?.key?.EQ === "attribute_1") {
         return Promise.resolve({

--- a/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
+++ b/packages/dina-ui/components/managed-attributes/ManagedAttributesEditor.tsx
@@ -18,6 +18,7 @@ import { ManagedAttributesSorter } from "./managed-attributes-custom-views/Manag
 import { ManagedAttributeFieldWithLabel } from "./ManagedAttributeField";
 import { useManagedAttributeQueries } from "./useManagedAttributeQueries";
 import _ from "lodash";
+import { COLLECTION_MANAGED_ATTRIBUTE_ID } from "../controlled-vocabulary/controlledVocabularyItemUtils";
 
 export interface ManagedAttributesEditorProps {
   /** Formik path to the ManagedAttribute values field. */
@@ -372,6 +373,13 @@ export function ManagedAttributeMultiSelect({
               : "managedAttributeComponent",
             "EQ",
             managedAttributeComponent!
+          )
+        )
+        .when(isControlledVocabulary, (builder) =>
+          builder.where(
+            "controlledVocabulary.uuid",
+            "EQ",
+            COLLECTION_MANAGED_ATTRIBUTE_ID
           )
         )
         .build(),

--- a/packages/dina-ui/components/managed-attributes/__tests__/ManagedAttributesEditor.test.tsx
+++ b/packages/dina-ui/components/managed-attributes/__tests__/ManagedAttributesEditor.test.tsx
@@ -5,6 +5,7 @@ import { mountWithAppContext } from "common-ui";
 import { ManagedAttributesEditor } from "../ManagedAttributesEditor";
 import { waitFor, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { COLLECTION_MANAGED_ATTRIBUTE_ID } from "@dina-ui/components/controlled-vocabulary/controlledVocabularyItemUtils";
 
 const EXAMPLE_MA_1 = {
   id: "1",
@@ -298,6 +299,9 @@ describe("ManagedAttributesEditor component", () => {
                 dinaComponent: {
                   EQ: "SITE"
                 },
+                "controlledVocabulary.uuid": {
+                  EQ: COLLECTION_MANAGED_ATTRIBUTE_ID
+                },
                 key: {
                   EQ: "example_attribute_1"
                 }
@@ -316,6 +320,9 @@ describe("ManagedAttributesEditor component", () => {
               filter: {
                 dinaComponent: {
                   EQ: "SITE"
+                },
+                "controlledVocabulary.uuid": {
+                  EQ: COLLECTION_MANAGED_ATTRIBUTE_ID
                 },
                 key: {
                   EQ: "example_attribute_2"

--- a/packages/dina-ui/components/managed-attributes/useManagedAttributeQueries.tsx
+++ b/packages/dina-ui/components/managed-attributes/useManagedAttributeQueries.tsx
@@ -5,6 +5,7 @@ import {
   ControlledVocabularyItem,
   ManagedAttribute
 } from "../../types/collection-api";
+import { COLLECTION_MANAGED_ATTRIBUTE_ID } from "../controlled-vocabulary/controlledVocabularyItemUtils";
 
 export interface UseBulkGetParams {
   managedAttributeApiPath: string;
@@ -63,6 +64,13 @@ export function useManagedAttributeQueries({
               )
             )
             .where("key", "EQ", key)
+            .when(isControlledVocabulary, (builder) =>
+              builder.where(
+                "controlledVocabulary.uuid",
+                "EQ",
+                COLLECTION_MANAGED_ATTRIBUTE_ID
+              )
+            )
             .build()
         }
       )

--- a/packages/dina-ui/components/revisions/revision-row-configs/material-sample-revision-configs.tsx
+++ b/packages/dina-ui/components/revisions/revision-row-configs/material-sample-revision-configs.tsx
@@ -32,7 +32,7 @@ export const MATERIAL_SAMPLE_REVISION_ROW_CONFIG: RevisionRowConfig<MaterialSamp
       }) => (
         <ManagedAttributesViewer
           values={value}
-          managedAttributeApiPath="collection-api/controlled-vocabulary-item"
+          managedAttributeApiPath="collection-api/managed-attribute"
         />
       ),
 

--- a/packages/dina-ui/components/revisions/revision-row-configs/material-sample-revision-configs.tsx
+++ b/packages/dina-ui/components/revisions/revision-row-configs/material-sample-revision-configs.tsx
@@ -32,7 +32,7 @@ export const MATERIAL_SAMPLE_REVISION_ROW_CONFIG: RevisionRowConfig<MaterialSamp
       }) => (
         <ManagedAttributesViewer
           values={value}
-          managedAttributeApiPath="collection-api/managed-attribute"
+          managedAttributeApiPath="collection-api/controlled-vocabulary-item"
         />
       ),
 

--- a/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
@@ -52,7 +52,7 @@ const mockGet = jest.fn(async (model) => {
   } else if (model === "collection-api/collecting-event") {
     return { data: [] };
   } else if (
-    model === "collection-api/managed-attribute" ||
+    model === "collection-api/controlled-vocabulary-item" ||
     model === "collection-api/collection-method"
   ) {
     return { data: [] };

--- a/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/form-template/__tests__/edit.test.tsx
@@ -87,7 +87,7 @@ const mockGet = jest.fn<any, any>(async (path) => {
     case "collection-api/vocabulary2/degreeOfEstablishment":
     case "collection-api/vocabulary2/srs":
     case "collection-api/material-sample":
-    case "collection-api/managed-attribute":
+    case "collection-api/controlled-vocabulary-item":
     case "collection-api/vocabulary2/materialSampleState":
     case "collection-api/collection":
     case "collection-api/project":

--- a/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
+++ b/packages/dina-ui/page-tests/collection/material-sample/__tests__/bulk-create.test.tsx
@@ -55,7 +55,7 @@ const mockGet = jest.fn<any, any>(async (path) => {
       };
     case "collection-api/material-sample":
     case "objectstore-api/metadata":
-    case "collection-api/managed-attribute":
+    case "collection-api/controlled-vocabulary-item":
     case "collection-api/material-sample-type":
     case "collection-api/project":
     case "collection-api/vocabulary2/materialSampleState":

--- a/packages/dina-ui/pages/collection/assemblage/edit.tsx
+++ b/packages/dina-ui/pages/collection/assemblage/edit.tsx
@@ -210,12 +210,13 @@ export function AssemblageFormLayout() {
       <MultilingualDescription />
       <ManagedAttributesEditor
         valuesPath="managedAttributes"
-        managedAttributeApiPath="collection-api/managed-attribute"
+        managedAttributeApiPath="collection-api/controlled-vocabulary-item"
         managedAttributeComponent="ASSEMBLAGE"
         fieldSetProps={{
           legend: <DinaMessage id="assemblageManagedAttributes" />
         }}
         disableClearButton={true}
+        isControlledVocabulary={true}
       />
       <AttachmentsField
         name="attachment"

--- a/packages/dina-ui/pages/managed-attribute/list.tsx
+++ b/packages/dina-ui/pages/managed-attribute/list.tsx
@@ -100,7 +100,7 @@ export default function ManagedAttributesListPage() {
 
 interface GenericManagedAttributeListViewProps {
   /**
-   * Example: "/collection-api/managed-attribute"
+   * Example: "/collection-api/controlled-vocabulary-item"
    */
   apiPath: string;
 


### PR DESCRIPTION
- Switched all ManagedAttributesEditor to use controlled vocabulary endpoint.
- Updated ShowParentattributeTemplate to use controlled vocabulary.
- Revision page endpoints updated, but still need work.
- Updated a bunch of tests.