### PR TITLE
Support #38372 - GitHub CI dockerhub push should be block if test failure occur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,18 +87,6 @@ jobs:
             Dockerfile
             version.txt
 
-  # For testing purposes, not to be commited in.
-  debug-check:
-    name: Debug - Check Test Result
-    runs-on: ubuntu-latest
-    needs: [test-chunk]
-    if: ${{ needs.test-chunk.result == 'success' }}
-    steps:
-      - name: Show test-chunk result
-        run: |
-          echo "test-chunk result: ${{ needs.test-chunk.result }}"
-          echo "Would push run? ${{ needs.test-chunk.result == 'success' }}"
-
   push:
     name: Build Docker Image and Push to DockerHub
     needs: [build, test-chunk]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     name: Debug - Check Test Result
     runs-on: ubuntu-latest
     needs: [test-chunk]
-    if: always()
+    if: ${{ needs.test-chunk.result == 'success' }}
     steps:
       - name: Show test-chunk result
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-    needs: [test-chunk]
+    needs: [build, test-chunk]
     if: ${{ github.ref == 'refs/heads/master' && needs.test-chunk.result == 'success' }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,23 @@ jobs:
             Dockerfile
             version.txt
 
+  # For testing purposes, not to be commited in.
+  debug-check:
+    name: Debug - Check Test Result
+    runs-on: ubuntu-latest
+    needs: [test-chunk]
+    if: always()
+    steps:
+      - name: Show test-chunk result
+        run: |
+          echo "test-chunk result: ${{ needs.test-chunk.result }}"
+          echo "Would push run? ${{ needs.test-chunk.result == 'success' }}"
+
   push:
     name: Build Docker Image and Push to DockerHub
-    needs: [build]
+    needs: [build, test-chunk]
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' && needs.test-chunk.result == 'success' }}
 
     steps:
       - name: Download artifacts from build job
@@ -125,7 +137,8 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: [test-chunk]
+    if: ${{ github.ref == 'refs/heads/master' && needs.test-chunk.result == 'success' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/packages/common-ui/lib/date/__tests__/DateView.test.tsx
+++ b/packages/common-ui/lib/date/__tests__/DateView.test.tsx
@@ -9,7 +9,7 @@ describe("DateView component", () => {
 
     // Displayed date:
     expect(
-      wrapper.getByText(/2020\-11\-12, 4:46:35 p\.m\./i)
+      wrapper.getByText(/2020\-11\-12, 4:46:31 p\.m\./i)
     ).toBeInTheDocument();
   });
 

--- a/packages/common-ui/lib/date/__tests__/DateView.test.tsx
+++ b/packages/common-ui/lib/date/__tests__/DateView.test.tsx
@@ -9,7 +9,7 @@ describe("DateView component", () => {
 
     // Displayed date:
     expect(
-      wrapper.getByText(/2020\-11\-12, 4:46:31 p\.m\./i)
+      wrapper.getByText(/2020\-11\-12, 4:46:35 p\.m\./i)
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
- Added "test-chunk" to needs block for each of those job
- Added condition to only proceed if all jobs in matrix are successful.
- Added a debugging job just for testing purposes.