### PR TITLE
Support #38583 - Add typescript error check in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           yarn install
 
+      - name: Check for Typescript Errors
+        run: |
+          npx tsc --noEmit
+
       - name: Build UI project
         run: |
           yarn workspace dina-ui build

--- a/packages/dina-ui/components/object-store/file-upload/__tests__/FileUploader.test.tsx
+++ b/packages/dina-ui/components/object-store/file-upload/__tests__/FileUploader.test.tsx
@@ -15,9 +15,6 @@ const mockGet = jest.fn(async (path) => {
   }
 });
 
-// Add a temporary intentional error to any .ts/.tsx file
-const _test: string = 123; // Type 'number' is not assignable to type 'string'
-
 const mockCtx = {
   apiClient: {
     get: mockGet

--- a/packages/dina-ui/components/object-store/file-upload/__tests__/FileUploader.test.tsx
+++ b/packages/dina-ui/components/object-store/file-upload/__tests__/FileUploader.test.tsx
@@ -15,6 +15,9 @@ const mockGet = jest.fn(async (path) => {
   }
 });
 
+// Add a temporary intentional error to any .ts/.tsx file
+const _test: string = 123; // Type 'number' is not assignable to type 'string'
+
 const mockCtx = {
   apiClient: {
     get: mockGet


### PR DESCRIPTION
- Added the step, the nextjs build actually runs this but only shows one error on failure, having this command before will display all errors which is helpful.