### PR TITLE
Support #38615 - Bulk Edit throwing error with Neda lab samples

### DIFF
--- a/packages/common-ui/lib/api-client/ApiClientContext.tsx
+++ b/packages/common-ui/lib/api-client/ApiClientContext.tsx
@@ -903,11 +903,39 @@ export class CustomDinaKitsu extends Kitsu {
    */
   async get(path: string, params: GetParams = {}) {
     const { responseType, timeout, ...paramsNet } = _.omit(params, "header");
+
+    // Trim spaces from comma-separated include values
+    if (paramsNet.include) {
+      paramsNet.include = (paramsNet.include as string)
+        .split(",")
+        .map((s) => s.trim())
+        .join(",");
+    }
+
+    // Trim spaces for fields values.
+    if (paramsNet.fields) {
+      paramsNet.fields = _.mapValues(paramsNet.fields, (value) =>
+        value
+          .split(",")
+          .map((s) => s.trim())
+          .join(",")
+      );
+    }
+
+    // Trim spaces for optField values.
+    if (paramsNet.optfields) {
+      paramsNet.optfields = _.mapValues(paramsNet.optfields, (value) =>
+        value
+          .split(",")
+          .map((s) => s.trim())
+          .join(",")
+      );
+    }
+
     try {
       const { data } = await this.axios.get(path, {
         headers: { ...this.headers, ...params.header },
         params: paramsNet,
-        // paramsSerializer: (p) => query(p),
         responseType,
         timeout
       });

--- a/packages/common-ui/lib/api-client/__tests__/ApiClientContext.test.ts
+++ b/packages/common-ui/lib/api-client/__tests__/ApiClientContext.test.ts
@@ -1006,6 +1006,78 @@ describe("API client context", () => {
       });
     });
 
+    it("Sends a get request with spaces in the params for comma-separated lists should be trimmed", async () => {
+      const mockAxiosGetTrimmed = jest.fn(async () => ({
+        data: {
+          data: [
+            {
+              type: "articles",
+              id: "200",
+              attributes: {
+                title: "JSON:API paints my bikeshed!"
+              },
+              relationships: {
+                author: {
+                  data: { id: "42", type: "people" }
+                },
+                tags: {
+                  data: { id: "99", type: "tags" }
+                }
+              }
+            }
+          ],
+          included: [
+            {
+              type: "people",
+              id: "42",
+              attributes: {
+                name: "John"
+              }
+            },
+            {
+              type: "tags",
+              id: "99",
+              attributes: {
+                name: "science"
+              }
+            }
+          ]
+        }
+      }));
+
+      const mockAxios = { get: mockAxiosGetTrimmed };
+      kitsu.axios = mockAxios as any;
+
+      await kitsu.get("my-api/topic/100/articles/200", {
+        include: "author, tags",
+        fields: {
+          articles: "title, body",
+          people: "name, age"
+        },
+        optfields: {
+          articles: "title, body",
+          people: "name, age"
+        }
+      });
+
+      expect(mockAxiosGetTrimmed).lastCalledWith(
+        "my-api/topic/100/articles/200",
+        expect.objectContaining({
+          params: {
+            include: "author,tags",
+            fields: {
+              articles: "title,body",
+              people: "name,age"
+            },
+            optfields: {
+              articles: "title,body",
+              people: "name,age"
+            }
+          }
+        })
+      );
+    });
+
     it("Promotes an external single relationship stub to top level on an array response when not in included", async () => {
       mockAxiosGet.mockResolvedValue({
         data: {


### PR DESCRIPTION
- Added logic to trim include, fields and optFields before sending the request using axios.
- Added test coverage to ensure the trim is being done.