### PR TITLE
Support #38622 - No content visible in organism dtermination managed attributes on list page in Material Sample

### DIFF
--- a/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
+++ b/packages/common-ui/lib/column-selector/ColumnSelectorUtils.tsx
@@ -669,13 +669,10 @@ export function getIncludedManagedAttributeColumn<TData extends KitsuResource>(
 
   const managedAttributesColumn = {
     cell: ({ row: { original } }) => {
-      const relationshipAccessor = accessorKey?.split(".");
-      relationshipAccessor?.splice(
-        1,
-        0,
-        config.referencedBy ? config.referencedBy : ""
+      const valuePath = buildRelationshipAccessorPath(
+        accessorKey,
+        config.referencedBy
       );
-      const valuePath = relationshipAccessor?.join(".");
       const value = collectPathValues(original, valuePath);
       return <>{value}</>;
     },
@@ -898,13 +895,10 @@ export function getIncludedExtensionFieldColumn(
   const accessorKey = `${config.path}.${extensionValue.id}.${extensionField.key}`;
   const extensionValuesColumn = {
     cell: ({ row: { original } }) => {
-      const relationshipAccessor = accessorKey?.split(".");
-      relationshipAccessor?.splice(
-        1,
-        0,
-        config.referencedBy ? config.referencedBy : ""
+      const valuePath = buildRelationshipAccessorPath(
+        accessorKey,
+        config.referencedBy
       );
-      const valuePath = relationshipAccessor?.join(".");
       const value = collectPathValues(original, valuePath);
       return <>{value}</>;
     },
@@ -1109,13 +1103,10 @@ export function getIncludedVocabularyColumn<TData extends KitsuResource>(
 
   const vocabularyColumn = {
     cell: ({ row: { original } }) => {
-      const relationshipAccessor = accessorKey?.split(".");
-      relationshipAccessor?.splice(
-        1,
-        0,
-        config.referencedBy ? config.referencedBy : ""
+      const valuePath = buildRelationshipAccessorPath(
+        accessorKey,
+        config.referencedBy
       );
-      const valuePath = relationshipAccessor?.join(".");
       const value = collectPathValues(original, valuePath);
       return <>{value}</>;
     },
@@ -1329,13 +1320,10 @@ export function getIncludedControlledVocabularyColumn<
 
   const controlledVocabularyColumn = {
     cell: ({ row: { original } }) => {
-      const relationshipAccessor = accessorKey?.split(".");
-      relationshipAccessor?.splice(
-        1,
-        0,
-        config.referencedBy ? config.referencedBy : ""
+      const valuePath = buildRelationshipAccessorPath(
+        accessorKey,
+        config.referencedBy
       );
-      const valuePath = relationshipAccessor?.join(".");
       const value = collectPathValues(original, valuePath);
       return <>{value}</>;
     },
@@ -1592,4 +1580,26 @@ export function FunctionFieldLabel({
   } else {
     return <></>;
   }
+}
+
+/**
+ * Builds a value path by inserting the first segment of `referencedBy` at index 1
+ * of the accessor key parts.
+ *
+ * e.g. accessorKey: "included.managedAttributes.myKey"
+ *      referencedBy: "organism.determination"
+ *      result: "included.organism.managedAttributes.myKey"
+ */
+export function buildRelationshipAccessorPath(
+  accessorKey: string,
+  referencedBy: string | undefined
+): string {
+  if (!referencedBy) {
+    return accessorKey;
+  }
+
+  const parts = accessorKey.split(".");
+  const referencedByRoot = (referencedBy ?? "").split(".")[0];
+  parts.splice(1, 0, referencedByRoot);
+  return parts.join(".");
 }

--- a/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
+++ b/packages/common-ui/lib/column-selector/__tests__/ColumnSelectorUtils.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import {
+  buildRelationshipAccessorPath,
   collectPathValues,
   generateColumnPath,
   getNestedColumn,
@@ -9,6 +10,7 @@ import {
 describe("ColumnSelectorUtils", () => {
   describe("generateColumnPath", () => {
     it("Generate managed attribute path", () => {
+      // Attribute Level:
       expect(
         generateColumnPath({
           indexMapping: {
@@ -35,6 +37,7 @@ describe("ColumnSelectorUtils", () => {
         })
       ).toEqual("managedAttribute/MATERIAL_SAMPLE/managed_attribute_key");
 
+      // Included Level
       expect(
         generateColumnPath({
           indexMapping: {
@@ -65,6 +68,40 @@ describe("ColumnSelectorUtils", () => {
       ).toEqual(
         "managedAttribute~collectingEvent/COLLECTING_EVENT/collecting_event_managed_attribute_key"
       );
+
+      // Included level 2 levels
+      expect(
+        generateColumnPath({
+          indexMapping: {
+            dynamicField: {
+              type: "managedAttribute",
+              label: "managedAttributes",
+              component: "DETERMINATION",
+              path: "included.attributes.determination.managedAttributes",
+              referencedBy: "organism.determination",
+              referencedType: "organism",
+              apiEndpoint: "collection-api/controlled-vocabulary-item"
+            },
+            parentName: "organism.determination",
+            parentPath: "included",
+            parentType: "organism",
+            value:
+              "included.attributes.determination.managedAttributes_organism.determination",
+            distinctTerm: false,
+            label: "managedAttributes",
+            path: "included.attributes.determination.managedAttributes",
+            type: "managedAttribute",
+            keywordMultiFieldSupport: false,
+            keywordNumericSupport: false,
+            optimizedPrefix: false,
+            containsSupport: false,
+            endsWithSupport: false,
+            hideField: false,
+            isReverseRelationship: false
+          },
+          dynamicFieldValue: `{"searchValue":"","selectedOperator":"exactMatch","selectedManagedAttribute":{"id":"019eefa7-c6d5-7723-8bf2-c9ab822f1f0d","type":"controlled-vocabulary-item","name":"Test","key":"test","group":"cnc","term":"Test","multilingualTitle":null,"multilingualDescription":null,"vocabularyElementType":"STRING","acceptedValues":null,"unit":null,"uriTemplate":null,"dinaComponent":"DETERMINATION","createdBy":"dina-admin","createdOn":"2026-06-22T14:06:50.538384Z","lastUpdatedOn":"2026-06-22T14:06:50.613953Z"},"selectedType":"STRING"}`
+        })
+      ).toEqual("managedAttribute~organism.determination/DETERMINATION/test");
     });
 
     it("Generate field extension path", () => {
@@ -502,6 +539,65 @@ describe("ColumnSelectorUtils", () => {
       const obj = { a: "value" };
       expect(collectPathValues(obj, "")).toBe(obj);
     });
+
+    // Organism Determination test (complex)
+    test("organism determination managed attribute path test", () => {
+      const obj = {
+        id: "019ee020-fc5d-7661-8a70-2453796ca2ce",
+        type: "material-sample",
+        data: {
+          attributes: {
+            group: "cnc",
+            createdOn: "2026-06-19T13:45:18.718853Z",
+            createdBy: "dina-admin",
+            dwcOtherCatalogNumbers: null,
+            materialSampleName: null,
+            materialSampleType: null,
+            materialSampleState: null
+          },
+          relationships: {
+            projects: {
+              data: []
+            },
+            organism: {
+              data: [
+                {
+                  id: "019eefa8-789e-7716-8737-a79cf53151be",
+                  type: "organism"
+                }
+              ]
+            },
+            assemblages: {
+              data: []
+            }
+          }
+        },
+        included: {
+          organism: [
+            {
+              id: "019eefa8-789e-7716-8737-a79cf53151be",
+              type: "organism",
+              attributes: {
+                determination: [
+                  {
+                    managedAttributes: {
+                      test: "Test123"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      };
+
+      expect(
+        collectPathValues(
+          obj,
+          "included.organism.attributes.determination.managedAttributes.test"
+        )
+      ).toBe("Test123");
+    });
   });
 
   describe("getNestedColumn", () => {
@@ -666,6 +762,48 @@ describe("ColumnSelectorUtils", () => {
         CellComponent({ row: mockArrayRow } as any)
       );
       expect(arrayContainer.textContent).toBe("Holotype, Paratype");
+    });
+  });
+
+  describe("buildRelationshipAccessorPath", () => {
+    it("inserts a simple referencedBy at index 1", () => {
+      expect(
+        buildRelationshipAccessorPath(
+          "included.managedAttributes.myKey",
+          "organism"
+        )
+      ).toBe("included.organism.managedAttributes.myKey");
+    });
+
+    it("uses only the first segment when referencedBy contains a dot", () => {
+      expect(
+        buildRelationshipAccessorPath(
+          "included.attributes.determination.managedAttributes.test",
+          "organism.determination"
+        )
+      ).toBe(
+        "included.organism.attributes.determination.managedAttributes.test"
+      );
+    });
+
+    it("handles undefined referencedBy by inserting an empty string", () => {
+      expect(
+        buildRelationshipAccessorPath(
+          "included.managedAttributes.myKey",
+          undefined
+        )
+      ).toBe("included.managedAttributes.myKey");
+    });
+
+    it("handles a deeply nested accessorKey", () => {
+      expect(
+        buildRelationshipAccessorPath(
+          "included.attributes.extensionValues.ext1.fieldKey",
+          "collectingEvent"
+        )
+      ).toBe(
+        "included.collectingEvent.attributes.extensionValues.ext1.fieldKey"
+      );
     });
   });
 });

--- a/packages/common-ui/lib/list-page/types.ts
+++ b/packages/common-ui/lib/list-page/types.ts
@@ -203,7 +203,7 @@ export interface ESIndexMapping {
   /**
    * Only provided if it was added using a dynamic field config.
    */
-  dynamicField?: DynamicField;
+  dynamicField?: DynamicField | RelationshipDynamicField;
 
   /**
    * Only provided for relationshipAutocomplete type fields.


### PR DESCRIPTION
- Created a new function called buildRelationshipAccessorPath in the columnSelectorUtils, it's purpose is to remove code duplication and handle the referencedBy better for nested fields.
- Fixed typescript issue with dynamicField.
- Added more test coverage for new function and more complex situations.