### PR TITLE
Support #38623 - Dependency of fields Collectors and Collection Method in Collecting Event

### DIFF
--- a/packages/common-ui/lib/api-client/ApiClientContext.tsx
+++ b/packages/common-ui/lib/api-client/ApiClientContext.tsx
@@ -942,8 +942,17 @@ export class CustomDinaKitsu extends Kitsu {
 
       const deserialized = await deserialise(data);
 
-      // Get the list of requested includes
-      const requestedIncludes = (params.include as string)?.split(",") ?? [];
+      // Get the list of requested includes from both params and the path query string,
+      // since includes are sometimes embedded directly in the path as ?include=...
+      const includesFromParams = (params.include as string)?.split(",") ?? [];
+      const includesFromPath =
+        path.match(/[?&]include=([^&]+)/)?.[1]?.split(",") ?? [];
+      const requestedIncludes = _.uniq([
+        ...includesFromParams,
+        ...includesFromPath
+      ])
+        .map((s) => s.trim())
+        .filter(Boolean);
 
       // Handle both single object and array responses
       const items = Array.isArray(deserialized.data)
@@ -957,8 +966,13 @@ export class CustomDinaKitsu extends Kitsu {
         const rawRelationships = rawItems[i]?.relationships ?? {};
 
         for (const key of requestedIncludes) {
-          // Already resolved at top level, skip
-          if (item[key] !== undefined) continue;
+          // Already resolved at top level, skip.
+          // But don't skip empty arrays - they may be unresolved relationship stubs
+          // from a different API that couldn't be included (e.g. collectors from agent-api)
+          const currentValue = item[key];
+          const isEmptyArray =
+            Array.isArray(currentValue) && currentValue.length === 0;
+          if (currentValue !== undefined && !isEmptyArray) continue;
 
           const relData = rawRelationships[key]?.data;
           if (!relData) continue;

--- a/packages/common-ui/lib/api-client/__tests__/ApiClientContext.test.ts
+++ b/packages/common-ui/lib/api-client/__tests__/ApiClientContext.test.ts
@@ -1563,5 +1563,194 @@ describe("API client context", () => {
       expect(response.data[0].id).toBe("existing-id");
       expect(response.data[0].materialSample.id).toBe("sample-id");
     });
+
+    it("Parses includes from the path query string when not provided in params", async () => {
+      mockAxiosGet.mockResolvedValue({
+        data: {
+          data: {
+            type: "collecting-event",
+            id: "019ef07e-4674-7384-b117-7c78db679733",
+            attributes: {
+              dwcFieldNumber: "test"
+            },
+            relationships: {
+              collectors: {
+                data: [
+                  {
+                    id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+                    type: "person"
+                  }
+                ]
+              }
+            }
+          }
+          // No included - collectors are from agent-api, a different API
+        }
+      });
+
+      // Include is embedded in the path, not passed as a param
+      const response = await kitsu.get(
+        "collection-api/collecting-event/019ef07e-4674-7384-b117-7c78db679733?include=collectors,attachment",
+        {}
+      );
+
+      expect((response.data as any).collectors).toEqual([
+        {
+          id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+          type: "person"
+        }
+      ]);
+    });
+
+    it("Combines includes from both path query string and params without duplicates", async () => {
+      mockAxiosGet.mockResolvedValue({
+        data: {
+          data: {
+            type: "collecting-event",
+            id: "019ef07e-4674-7384-b117-7c78db679733",
+            attributes: {},
+            relationships: {
+              collectors: {
+                data: [
+                  {
+                    id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+                    type: "person"
+                  }
+                ]
+              },
+              attachment: {
+                data: [
+                  {
+                    id: "abc123",
+                    type: "metadata"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      });
+
+      // collectors in path, attachment in params, collectors duplicated in both
+      const response = await kitsu.get(
+        "collection-api/collecting-event/019ef07e-4674-7384-b117-7c78db679733?include=collectors",
+        { include: "collectors,attachment" }
+      );
+
+      expect((response.data as any).collectors).toEqual([
+        {
+          id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+          type: "person"
+        }
+      ]);
+      expect((response.data as any).attachment).toEqual([
+        {
+          id: "abc123",
+          type: "metadata"
+        }
+      ]);
+    });
+
+    it("Promotes a to-many relationship stub when kitsu resolves it to an empty array due to missing included section", async () => {
+      mockAxiosGet.mockResolvedValue({
+        data: {
+          data: {
+            type: "collecting-event",
+            id: "019ef07e-4674-7384-b117-7c78db679733",
+            attributes: {
+              dwcFieldNumber: "test"
+            },
+            relationships: {
+              collectors: {
+                data: [
+                  {
+                    id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+                    type: "person"
+                  }
+                ]
+              },
+              attachment: {
+                data: []
+              }
+            }
+          }
+          // No included section at all - collectors from agent-api cannot be included
+        }
+      });
+
+      const response = await kitsu.get(
+        "collection-api/collecting-event/019ef07e-4674-7384-b117-7c78db679733?include=collectors,attachment,collectionMethod"
+      );
+
+      // collectors should be promoted from relationship stubs, not left as []
+      expect((response.data as any).collectors).toEqual([
+        {
+          id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+          type: "person"
+        }
+      ]);
+
+      // attachment has an empty data array in relationships, should stay []
+      expect((response.data as any).attachment).toEqual([]);
+
+      // collectionMethod has no relationship data at all, should be undefined
+      expect((response.data as any).collectionMethod).toBeUndefined();
+    });
+
+    it("Does not overwrite a non-empty resolved relationship with stubs when included is present", async () => {
+      mockAxiosGet.mockResolvedValue({
+        data: {
+          data: {
+            type: "collecting-event",
+            id: "019ef07e-4674-7384-b117-7c78db679733",
+            attributes: {},
+            relationships: {
+              collectionMethod: {
+                data: {
+                  id: "col-method-1",
+                  type: "collection-method"
+                }
+              },
+              collectors: {
+                data: [
+                  {
+                    id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+                    type: "person"
+                  }
+                ]
+              }
+            }
+          },
+          included: [
+            {
+              type: "collection-method",
+              id: "col-method-1",
+              attributes: {
+                name: "Hand Collected"
+              }
+            }
+          ]
+        }
+      });
+
+      const response = await kitsu.get(
+        "collection-api/collecting-event/019ef07e-4674-7384-b117-7c78db679733?include=collectors,collectionMethod"
+      );
+
+      // collectionMethod was resolved via included, should have full attributes
+      expect((response.data as any).collectionMethod).toEqual({
+        id: "col-method-1",
+        type: "collection-method",
+        name: "Hand Collected"
+      });
+
+      // collectors were not in included (different API), should be promoted as stubs
+      expect((response.data as any).collectors).toEqual([
+        {
+          id: "21f87305-3cfa-4351-8a9c-16abedac776d",
+          type: "person"
+        }
+      ]);
+    });
   });
 });

--- a/packages/dina-ui/components/collection/collecting-event/useCollectingEvent.tsx
+++ b/packages/dina-ui/components/collection/collecting-event/useCollectingEvent.tsx
@@ -152,14 +152,20 @@ export function useCollectingEventSave({
     // Init relationships object for one-to-many relations:
     (collectingEventDiff as any).relationships = {};
 
-    // handle converting to relationship manually due to crnk bug
-    if (
-      collectingEventDiff &&
-      collectingEventDiff.collectors &&
-      collectingEventDiff.collectors.length > 0
-    ) {
+    // Only send collectors relationship if they were explicitly changed by the user.
+    // This prevents data loss if collectors fail to load (bulkGet error),
+    // and avoids sending unnecessary relationship data on every save.
+    const initialCollectors = collectingEventInitialValues.collectors as any[];
+    const submittedCollectors = submittedValues.collectors ?? [];
+
+    const collectorsChanged = !_.isEqual(
+      (initialCollectors ?? []).map((c) => c.id).sort(),
+      submittedCollectors.map((c) => c.id).sort()
+    );
+
+    if (collectorsChanged) {
       (collectingEventDiff as any).relationships.collectors = {
-        data: collectingEventDiff?.collectors.map((collector) => ({
+        data: submittedCollectors.map((collector) => ({
           id: collector.id,
           type: "person"
         }))

--- a/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
+++ b/packages/dina-ui/page-tests/collection/collecting-event/__test__/edit.test.tsx
@@ -536,6 +536,185 @@ describe("collecting-event edit page", () => {
       );
     });
   });
+
+  it("Displays collectors even when no collectionMethod is set", async () => {
+    mockGet.mockImplementation(async (model) => {
+      if (
+        model ===
+        "collection-api/collecting-event/1?include=collectors,attachment,collectionMethod,protocol,expedition,site"
+      ) {
+        return {
+          data: {
+            id: "1",
+            type: "collecting-event",
+            verbatimEventDateTime: "From 2019,12,21 4pm to 2019,12,22 4pm",
+            group: "test group",
+            geoReferenceAssertions: [{ isPrimary: true }],
+            otherRecordNumbers: ["12", "13", "14"],
+            attachment: [],
+            collectors: [
+              { id: "111", type: "person" },
+              { id: "222", type: "person" }
+            ],
+            collectionMethod: undefined
+          } as any
+        };
+      } else if (model === "agent-api/person") {
+        return { data: [testAgent()] };
+      } else if (model === "collection-api/vocabulary2/srs") {
+        return { data: [testSrs()] };
+      } else if (
+        model ===
+        "collection-api/controlled-vocabulary-item?filter[controlledVocabulary.key][EQ]=coordinate_format"
+      ) {
+        return { data: [testCoordinates()] };
+      } else if (model === "collection-api/collecting-event") {
+        return { data: [] };
+      } else if (
+        model === "collection-api/controlled-vocabulary-item" ||
+        model === "collection-api/collection-method"
+      ) {
+        return { data: [] };
+      } else if (model === "user-api/group") {
+        return { data: [] };
+      } else if (model === "objectstore-api/metadata") {
+        return { data: [] };
+      }
+    });
+
+    mockBulkGet.mockImplementation(async (paths: string[]) => {
+      if (!paths.length) return [];
+      if (
+        (paths[0] as string).startsWith("/person/") ||
+        (paths[0] as string).startsWith("person/")
+      ) {
+        return paths.map((path) => ({
+          id: path.replace(/\/?person\//, ""),
+          type: "person",
+          displayName: `Person ${path.replace(/\/?person\//, "")}`
+        }));
+      }
+      if (
+        (paths[0] as string).startsWith("/metadata/") ||
+        (paths[0] as string).startsWith("metadata/")
+      ) {
+        return paths.map((path) => ({
+          id: path.replace(/\/?metadata\//, ""),
+          type: "metadata",
+          originalFilename: "test-file"
+        }));
+      }
+    });
+
+    mockQuery = { id: 1 };
+
+    const wrapper = mountWithAppContext(<CollectingEventEditPage />, {
+      apiContext
+    });
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByRole("textbox", { name: /verbatim event datetime/i })
+      ).toHaveDisplayValue("From 2019,12,21 4pm to 2019,12,22 4pm");
+    });
+
+    // bulkGet should have been called to resolve the collector stubs from agent-api
+    await waitFor(() => {
+      expect(mockBulkGet).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.stringMatching(/\/?person\/111/),
+          expect.stringMatching(/\/?person\/222/)
+        ]),
+        expect.objectContaining({ apiBaseUrl: "/agent-api" })
+      );
+    });
+
+    // The resolved collectors should be visible as chips in the multi-select
+    await waitFor(() => {
+      expect(wrapper.getByText("Person 111")).toBeInTheDocument();
+      expect(wrapper.getByText("Person 222")).toBeInTheDocument();
+    });
+  });
+
+  it("Allows clearing collectors when a collectionMethod is set.", async () => {
+    // Override bulkGet to handle all path formats used in this test
+    mockBulkGet.mockImplementation(async (paths: string[]) => {
+      if (!paths.length) return [];
+      if ((paths[0] as string).match(/\/?person\//)) {
+        return paths.map((path) => ({
+          id: path.replace(/\/?person\//, ""),
+          type: "person",
+          displayName: `Person ${path.replace(/\/?person\//, "")}`
+        }));
+      }
+      if ((paths[0] as string).match(/\/?metadata\//)) {
+        return paths.map((path) => ({
+          id: path.replace(/\/?metadata\/.*/, "").replace(/\/?metadata\//, ""),
+          type: "metadata",
+          originalFilename: "test-file"
+        }));
+      }
+      return [];
+    });
+
+    mockPatch.mockReturnValueOnce({
+      data: [
+        {
+          data: testCollectingEvent(),
+          status: 201
+        }
+      ] as OperationsResponse
+    });
+
+    mockQuery = { id: 1 };
+
+    const wrapper = mountWithAppContext(<CollectingEventEditPage />, {
+      apiContext
+    });
+
+    await waitFor(() => {
+      expect(
+        wrapper.getByRole("textbox", { name: /verbatim event datetime/i })
+      ).toHaveDisplayValue("From 2019,12,21 4pm to 2019,12,22 4pm");
+    });
+
+    // Wait for collectors to be resolved and rendered.
+    await waitFor(() => {
+      expect(wrapper.getByText("Person 111")).toBeInTheDocument();
+      expect(wrapper.getByText("Person 222")).toBeInTheDocument();
+    });
+
+    const removeButtons = wrapper.getAllByRole("button", { name: /remove/i });
+    for (const button of removeButtons) {
+      fireEvent.click(button);
+    }
+
+    // Verify collectors are gone.
+    await waitFor(() => {
+      expect(wrapper.queryByText("Person 111")).not.toBeInTheDocument();
+      expect(wrapper.queryByText("Person 222")).not.toBeInTheDocument();
+    });
+
+    // Submit the form
+    userEvent.click(wrapper.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mockPatch).toBeCalledTimes(1);
+      expect(mockPatch).lastCalledWith(
+        "/collection-api/collecting-event/1",
+        expect.objectContaining({
+          data: expect.objectContaining({
+            relationships: expect.objectContaining({
+              collectors: {
+                data: []
+              }
+            })
+          })
+        }),
+        expect.anything()
+      );
+    });
+  });
 });
 
 /** Test collecting-event with all fields defined. */


### PR DESCRIPTION
- Updated the ApiClientContext to handle external relationships better. Fixed a bug where it only worked if included was in the request.
- Added test coverage for this updated logic.