### PR TITLE
Support #38627 - Add data fields in organism

### DIFF
--- a/packages/common-ui/lib/list-page/__tests__/__snapshots__/UseIndexMapping.test.tsx.snap
+++ b/packages/common-ui/lib/list-page/__tests__/__snapshots__/UseIndexMapping.test.tsx.snap
@@ -371,7 +371,7 @@ exports[`Use Index Mapping Hook Retrieve index and transform the structure. 1`] 
           "endsWithSupport": false,
           "hideField": false,
           "isReverseRelationship": false,
-          "keywordMultiFieldSupport": false,
+          "keywordMultiFieldSupport": true,
           "keywordNumericSupport": false,
           "label": "determination.typeStatus",
           "optimizedPrefix": false,

--- a/packages/common-ui/lib/list-page/useIndexMapping.tsx
+++ b/packages/common-ui/lib/list-page/useIndexMapping.tsx
@@ -83,6 +83,11 @@ export const overrideRelationshipConfig: OverrideRelationshipConfig = {
     "attributes.geographicThesaurus.source": {
       fields: ["keyword"]
     }
+  },
+  organism: {
+    "attributes.determination.typeStatus": {
+      fields: ["keyword"]
+    }
   }
 };
 

--- a/packages/dina-ui/pages/collection/material-sample/list.tsx
+++ b/packages/dina-ui/pages/collection/material-sample/list.tsx
@@ -35,7 +35,7 @@ export const MATERIAL_SAMPLE_NON_EXPORTABLE_COLUMNS: string[] = [
   "selectColumn",
   "assemblages.",
   "projects.",
-  "organism."
+  "organism.determination."
 ];
 
 export interface SampleListLayoutProps {


### PR DESCRIPTION
- Material Samples can export organism just not determination.
- Added override to organism.determination.typeStatus for displaying multiple in the list page.