### PR TITLE
38656 - Appending Other Identifiers fails

### DIFF
--- a/packages/dina-ui/components/workbook/column-mapping/WorkbookFieldSelectField.tsx
+++ b/packages/dina-ui/components/workbook/column-mapping/WorkbookFieldSelectField.tsx
@@ -378,11 +378,6 @@ export function WorkbookFieldSelectField({
                   MATERIAL_SAMPLE_OTHER_IDENTIFERS_ID
                 )
                 .where("dinaComponent", "EQ", "MATERIAL_SAMPLE")
-                .where(
-                  "controlledVocabulary.uuid" as any,
-                  "EQ",
-                  COLLECTION_MANAGED_ATTRIBUTE_ID
-                )
                 .searchFilter("name", input)
                 .build()
             }

--- a/packages/dina-ui/components/workbook/utils/__tests__/workbookMappingUtils.test.ts
+++ b/packages/dina-ui/components/workbook/utils/__tests__/workbookMappingUtils.test.ts
@@ -622,6 +622,68 @@ describe("workbookMappingUtils functions", () => {
     });
   });
 
+  describe("targetKey branching", () => {
+    test("identifier with null vocabularyElementType uses key branch, not managed attribute branch", () => {
+      const result = getDataFromWorkbook(
+        {
+          "0": {
+            sheetName: "Sheet1",
+            rows: [
+              { rowNumber: 0, content: ["CatNum"] },
+              { rowNumber: 1, content: ["CAT-123"] }
+            ]
+          }
+        } as WorkbookJSON,
+        0,
+        [
+          {
+            targetField: "identifiers",
+            skipped: false,
+            columnHeader: "CatNum",
+            targetKey: {
+              key: "catalog-number",
+              type: "controlled-vocabulary-item",
+              vocabularyElementType: null
+            } as any
+          }
+        ]
+      );
+      expect(result).toEqual([
+        { identifiers: { "catalog-number": "CAT-123" } }
+      ]);
+    });
+
+    test("managed attribute with vocabularyElementType=STRING still works", () => {
+      const result = getDataFromWorkbook(
+        {
+          "0": {
+            sheetName: "Sheet1",
+            rows: [
+              { rowNumber: 0, content: ["Attr"] },
+              { rowNumber: 1, content: ["attr-value"] }
+            ]
+          }
+        } as WorkbookJSON,
+        0,
+        [
+          {
+            targetField: "managedAttributes",
+            skipped: false,
+            columnHeader: "Attr",
+            targetKey: {
+              key: "some-attr",
+              type: "controlled-vocabulary-item",
+              vocabularyElementType: "STRING"
+            } as any
+          }
+        ]
+      );
+      expect(result).toEqual([
+        { managedAttributes: { "some-attr": "attr-value" } }
+      ]);
+    });
+  });
+
   it("isNumber", () => {
     expect(isNumber("111")).toBeTruthy();
     expect(isNumber("adf")).toBeFalsy();

--- a/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
+++ b/packages/dina-ui/components/workbook/utils/workbookMappingUtils.ts
@@ -618,7 +618,10 @@ export function getDataFromWorkbook(
       const fieldMap = fieldMaps[index];
       if (!fieldMap?.skipped) {
         if (fieldMap.targetKey) {
-          if ("vocabularyElementType" in fieldMap.targetKey) {
+          if (
+            "vocabularyElementType" in fieldMap.targetKey &&
+            !!fieldMap.targetKey.vocabularyElementType
+          ) {
             const managedAttributes: { [key: string]: any } =
               rowData[fieldMap.targetField!] ?? {};
             let value: any;


### PR DESCRIPTION
tightened check to avoid match on null/undefined item, which caused identifiers to be treated as empty