### PR TITLE
Support 38650 investigate warning for unsaved content

### DIFF
--- a/packages/common-ui/lib/formik-connected/DinaForm.tsx
+++ b/packages/common-ui/lib/formik-connected/DinaForm.tsx
@@ -15,6 +15,7 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo
 } from "react";
 import {
@@ -22,6 +23,7 @@ import {
   normalizeJsonApiPointer
 } from "../util/jsonApiErrorNormalization";
 import { useIntl } from "react-intl";
+import { useRouter } from "next/router";
 import { BulkEditTabContext, scrollToError } from "..";
 import { AccountContextI, useAccount } from "../account/AccountProvider";
 import { ApiClientI, useApiClient } from "../api-client/ApiClientContext";
@@ -190,7 +192,9 @@ export function DinaForm<Values extends FormikValues = FormikValues>(
    * e.g. Don't show the has-bulk-edit-value indicators in the Material Sample
    * form's nested Collecting Event form.
    */
-  const withBulkEditCtx = useCallback<(content: React.JSX.Element) => React.JSX.Element>(
+  const withBulkEditCtx = useCallback<
+    (content: React.JSX.Element) => React.JSX.Element
+  >(
     isNestedForm
       ? (content) => (
           <BulkEditTabContext.Provider value={null}>
@@ -229,9 +233,54 @@ interface FormWrapperProps {
   customErrorViewerMessage?: (field: string, error: any) => string;
 }
 
+/** Warns on browser close/refresh and internal SPA navigation if the form is dirty. */
+function PromptIfDirty({
+  formik,
+  readOnly
+}: {
+  formik: any;
+  readOnly?: boolean;
+}) {
+  const { formatMessage } = useIntl();
+  const router = useRouter();
+  const isDirty =
+    !readOnly && formik.dirty && formik.values.type && formik.submitCount === 0;
+
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const warningMessage = formatMessage({ id: "possibleDataLossWarning" });
+
+    // Browser close / refresh (F5)
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // returnValue must be set for older browsers (e.g. Chrome < 119)
+      e.returnValue = "";
+    };
+
+    // Internal SPA navigation (links, router.push, etc.)
+    const handleRouteChange = () => {
+      if (!window.confirm(warningMessage)) {
+        router.events.emit("routeChangeError");
+        throw "routeChange aborted.";
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    router.events.on("routeChangeStart", handleRouteChange);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      router.events.off("routeChangeStart", handleRouteChange);
+    };
+  }, [isDirty, formatMessage, router.events]);
+
+  return null;
+}
+
 /** Wraps the inner content with the Form + ErrorViewer components. */
 function FormWrapper({ children, customErrorViewerMessage }: FormWrapperProps) {
-  const { isNestedForm } = useDinaFormContext();
+  const { isNestedForm, readOnly } = useDinaFormContext();
 
   // Disable enter to submit form in nested forms.
   function disableEnterToSubmitOuterForm(e) {
@@ -241,16 +290,6 @@ function FormWrapper({ children, customErrorViewerMessage }: FormWrapperProps) {
     }
   }
 
-  const PromptIfDirty = ({ formik }) => {
-    const { formatMessage } = useIntl();
-    // only prompt if there is data change in edit or add pages
-    if (formik.dirty && formik.values.type && formik.submitCount === 0) {
-      window.onbeforeunload = () => {
-        return formatMessage({ id: "possibleDataLossWarning" });
-      };
-    } else window.onbeforeunload = null;
-    return null;
-  };
   const Wrapper = isNestedForm ? "div" : Form;
 
   return (
@@ -259,11 +298,7 @@ function FormWrapper({ children, customErrorViewerMessage }: FormWrapperProps) {
     >
       <ErrorViewer customErrorViewerMessage={customErrorViewerMessage} />
       <FormikConsumer>
-        {(formik) => (
-          <>
-            <PromptIfDirty formik={formik} />
-          </>
-        )}
+        {(formik) => <PromptIfDirty formik={formik} readOnly={readOnly} />}
       </FormikConsumer>
       {children}
     </Wrapper>

--- a/packages/common-ui/lib/formik-connected/DinaForm.tsx
+++ b/packages/common-ui/lib/formik-connected/DinaForm.tsx
@@ -258,20 +258,28 @@ function PromptIfDirty({
       e.returnValue = "";
     };
 
-    // Internal SPA navigation (links, router.push, etc.)
-    const handleRouteChange = () => {
-      if (!window.confirm(warningMessage)) {
-        router.events.emit("routeChangeError");
-        throw "routeChange aborted.";
-      }
-    };
-
     window.addEventListener("beforeunload", handleBeforeUnload);
-    router.events.on("routeChangeStart", handleRouteChange);
+
+    // Internal SPA navigation (links, router.push, etc.)
+    // router.events may be undefined in test environments.
+    if (router.events) {
+      const handleRouteChange = () => {
+        if (!window.confirm(warningMessage)) {
+          router.events.emit("routeChangeError");
+          throw "routeChange aborted.";
+        }
+      };
+
+      router.events.on("routeChangeStart", handleRouteChange);
+
+      return () => {
+        window.removeEventListener("beforeunload", handleBeforeUnload);
+        router.events.off("routeChangeStart", handleRouteChange);
+      };
+    }
 
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
-      router.events.off("routeChangeStart", handleRouteChange);
     };
   }, [isDirty, formatMessage, router.events]);
 

--- a/packages/common-ui/lib/formik-connected/__tests__/DinaForm.test.tsx
+++ b/packages/common-ui/lib/formik-connected/__tests__/DinaForm.test.tsx
@@ -6,7 +6,30 @@ import { SubmitButton } from "../SubmitButton";
 import { TextField } from "../TextField";
 import "@testing-library/jest-dom";
 
+// Mock next/router
+const mockRouterPush = jest.fn();
+const mockRouterEvents = {
+  on: jest.fn(),
+  off: jest.fn(),
+  emit: jest.fn()
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    events: mockRouterEvents
+  })
+}));
+
 describe("DinaForm component.", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear window event listeners
+    window.addEventListener = jest.fn();
+    window.removeEventListener = jest.fn();
+    window.confirm = jest.fn();
+  });
+
   it("Calls the onSubmit prop.", async () => {
     const mockOnSubmit = jest.fn();
     const wrapper = mountWithAppContext(
@@ -64,6 +87,321 @@ describe("DinaForm component.", () => {
     // Both errors should be shown:
     await waitFor(() => {
       expect(wrapper.queryByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  describe("PromptIfDirty - Window unload and SPA navigation listeners", () => {
+    it("Registers beforeunload listener when form is dirty", async () => {
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Initially, no listeners should be registered (form is not dirty)
+      expect(window.addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+
+      // Make the form dirty by changing a field
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        // Should register beforeunload listener when form becomes dirty
+        expect(window.addEventListener).toHaveBeenCalledWith(
+          "beforeunload",
+          expect.any(Function)
+        );
+      });
+    });
+
+    it("Registers routeChangeStart listener when form is dirty", async () => {
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Initially, no router listeners should be registered
+      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+
+      // Make the form dirty
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        // Should register routeChangeStart listener when form becomes dirty
+        expect(mockRouterEvents.on).toHaveBeenCalledWith(
+          "routeChangeStart",
+          expect.any(Function)
+        );
+      });
+    });
+
+    it("Does not register listeners when form is not dirty", () => {
+      mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "initial" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Should not register any listeners when form is clean
+      expect(window.addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+    });
+
+    it("Does not register listeners when form is in readOnly mode", async () => {
+      mountWithAppContext(
+        <DinaForm
+          initialValues={{ type: "test-type", name: "initial value" }}
+          readOnly={true}
+        >
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Wait a bit to ensure no listeners are registered
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Should not register listeners in readOnly mode even if form has values
+      expect(window.addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+    });
+
+    it("Does not register listeners when type is not set", async () => {
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Make the form dirty
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      // Wait a bit to ensure no listeners are registered
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Should not register listeners when type is not set
+      expect(window.addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+    });
+
+    it("Cleans up listeners when component unmounts", async () => {
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Make the form dirty
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        expect(window.addEventListener).toHaveBeenCalledWith(
+          "beforeunload",
+          expect.any(Function)
+        );
+      });
+
+      // Unmount the component
+      wrapper.unmount();
+
+      // Should clean up listeners
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.off).toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+    });
+
+    it("Cleans up and re-registers listeners when isDirty state changes", async () => {
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+          <SubmitButton />
+        </DinaForm>
+      );
+
+      // Make the form dirty
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        expect(window.addEventListener).toHaveBeenCalledWith(
+          "beforeunload",
+          expect.any(Function)
+        );
+      });
+
+      const addEventListenerCallCount = (
+        window.addEventListener as jest.Mock
+      ).mock.calls.length;
+
+      // Submit the form (this changes submitCount, making isDirty false)
+      fireEvent.click(wrapper.getByRole("button"));
+
+      await waitFor(() => {
+        // Should clean up listeners when form is no longer dirty
+        expect(window.removeEventListener).toHaveBeenCalledWith(
+          "beforeunload",
+          expect.any(Function)
+        );
+        expect(mockRouterEvents.off).toHaveBeenCalledWith(
+          "routeChangeStart",
+          expect.any(Function)
+        );
+      });
+    });
+
+    it("Prevents default on beforeunload event", async () => {
+      let beforeUnloadHandler: ((e: BeforeUnloadEvent) => void) | undefined;
+
+      // Capture the beforeunload handler
+      (window.addEventListener as jest.Mock).mockImplementation(
+        (event, handler) => {
+          if (event === "beforeunload") {
+            beforeUnloadHandler = handler;
+          }
+        }
+      );
+
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Make the form dirty
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        expect(beforeUnloadHandler).toBeDefined();
+      });
+
+      // Simulate beforeunload event
+      const mockEvent = {
+        preventDefault: jest.fn(),
+        returnValue: ""
+      } as unknown as BeforeUnloadEvent;
+
+      beforeUnloadHandler?.(mockEvent);
+
+      // Should prevent default and set returnValue
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockEvent.returnValue).toBe("");
+    });
+
+    it("Shows confirmation dialog on SPA navigation and aborts if user cancels", async () => {
+      let routeChangeHandler: (() => void) | undefined;
+
+      // Capture the routeChangeStart handler
+      mockRouterEvents.on.mockImplementation((event, handler) => {
+        if (event === "routeChangeStart") {
+          routeChangeHandler = handler;
+        }
+      });
+
+      // User cancels the navigation
+      (window.confirm as jest.Mock).mockReturnValue(false);
+
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Make the form dirty
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        expect(routeChangeHandler).toBeDefined();
+      });
+
+      // Simulate route change
+      expect(() => routeChangeHandler?.()).toThrow("routeChange aborted.");
+
+      // Should show confirmation dialog
+      expect(window.confirm).toHaveBeenCalled();
+
+      // Should emit routeChangeError
+      expect(mockRouterEvents.emit).toHaveBeenCalledWith("routeChangeError");
+    });
+
+    it("Allows SPA navigation if user confirms", async () => {
+      let routeChangeHandler: (() => void) | undefined;
+
+      // Capture the routeChangeStart handler
+      mockRouterEvents.on.mockImplementation((event, handler) => {
+        if (event === "routeChangeStart") {
+          routeChangeHandler = handler;
+        }
+      });
+
+      // User confirms the navigation
+      (window.confirm as jest.Mock).mockReturnValue(true);
+
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      // Make the form dirty
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        expect(routeChangeHandler).toBeDefined();
+      });
+
+      // Simulate route change - should not throw
+      expect(() => routeChangeHandler?.()).not.toThrow();
+
+      // Should show confirmation dialog
+      expect(window.confirm).toHaveBeenCalled();
+
+      // Should NOT emit routeChangeError
+      expect(mockRouterEvents.emit).not.toHaveBeenCalledWith(
+        "routeChangeError"
+      );
     });
   });
 });

--- a/packages/common-ui/lib/formik-connected/__tests__/DinaForm.test.tsx
+++ b/packages/common-ui/lib/formik-connected/__tests__/DinaForm.test.tsx
@@ -91,162 +91,7 @@ describe("DinaForm component.", () => {
   });
 
   describe("PromptIfDirty - Window unload and SPA navigation listeners", () => {
-    it("Registers beforeunload listener when form is dirty", async () => {
-      const wrapper = mountWithAppContext(
-        <DinaForm initialValues={{ type: "test-type", name: "" }}>
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Initially, no listeners should be registered (form is not dirty)
-      expect(window.addEventListener).not.toHaveBeenCalledWith(
-        "beforeunload",
-        expect.any(Function)
-      );
-
-      // Make the form dirty by changing a field
-      fireEvent.change(wrapper.getByRole("textbox"), {
-        target: { name: "name", value: "new value" }
-      });
-
-      await waitFor(() => {
-        // Should register beforeunload listener when form becomes dirty
-        expect(window.addEventListener).toHaveBeenCalledWith(
-          "beforeunload",
-          expect.any(Function)
-        );
-      });
-    });
-
-    it("Registers routeChangeStart listener when form is dirty", async () => {
-      const wrapper = mountWithAppContext(
-        <DinaForm initialValues={{ type: "test-type", name: "" }}>
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Initially, no router listeners should be registered
-      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
-        "routeChangeStart",
-        expect.any(Function)
-      );
-
-      // Make the form dirty
-      fireEvent.change(wrapper.getByRole("textbox"), {
-        target: { name: "name", value: "new value" }
-      });
-
-      await waitFor(() => {
-        // Should register routeChangeStart listener when form becomes dirty
-        expect(mockRouterEvents.on).toHaveBeenCalledWith(
-          "routeChangeStart",
-          expect.any(Function)
-        );
-      });
-    });
-
-    it("Does not register listeners when form is not dirty", () => {
-      mountWithAppContext(
-        <DinaForm initialValues={{ type: "test-type", name: "initial" }}>
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Should not register any listeners when form is clean
-      expect(window.addEventListener).not.toHaveBeenCalledWith(
-        "beforeunload",
-        expect.any(Function)
-      );
-      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
-        "routeChangeStart",
-        expect.any(Function)
-      );
-    });
-
-    it("Does not register listeners when form is in readOnly mode", async () => {
-      mountWithAppContext(
-        <DinaForm
-          initialValues={{ type: "test-type", name: "initial value" }}
-          readOnly={true}
-        >
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Wait a bit to ensure no listeners are registered
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // Should not register listeners in readOnly mode even if form has values
-      expect(window.addEventListener).not.toHaveBeenCalledWith(
-        "beforeunload",
-        expect.any(Function)
-      );
-      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
-        "routeChangeStart",
-        expect.any(Function)
-      );
-    });
-
-    it("Does not register listeners when type is not set", async () => {
-      const wrapper = mountWithAppContext(
-        <DinaForm initialValues={{ name: "" }}>
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Make the form dirty
-      fireEvent.change(wrapper.getByRole("textbox"), {
-        target: { name: "name", value: "new value" }
-      });
-
-      // Wait a bit to ensure no listeners are registered
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // Should not register listeners when type is not set
-      expect(window.addEventListener).not.toHaveBeenCalledWith(
-        "beforeunload",
-        expect.any(Function)
-      );
-      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
-        "routeChangeStart",
-        expect.any(Function)
-      );
-    });
-
-    it("Cleans up listeners when component unmounts", async () => {
-      const wrapper = mountWithAppContext(
-        <DinaForm initialValues={{ type: "test-type", name: "" }}>
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Make the form dirty
-      fireEvent.change(wrapper.getByRole("textbox"), {
-        target: { name: "name", value: "new value" }
-      });
-
-      await waitFor(() => {
-        expect(window.addEventListener).toHaveBeenCalledWith(
-          "beforeunload",
-          expect.any(Function)
-        );
-      });
-
-      // Unmount the component
-      wrapper.unmount();
-
-      // Should clean up listeners
-      expect(window.removeEventListener).toHaveBeenCalledWith(
-        "beforeunload",
-        expect.any(Function)
-      );
-      expect(mockRouterEvents.off).toHaveBeenCalledWith(
-        "routeChangeStart",
-        expect.any(Function)
-      );
-    });
-
-    it("Cleans up and re-registers listeners when isDirty state changes", async () => {
+    it("Registers both listeners when form is dirty, and cleans up when no longer dirty", async () => {
       const wrapper = mountWithAppContext(
         <DinaForm initialValues={{ type: "test-type", name: "" }}>
           <TextField name="name" />
@@ -254,6 +99,16 @@ describe("DinaForm component.", () => {
         </DinaForm>
       );
 
+      // Initially no listeners
+      expect(window.addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+
       // Make the form dirty
       fireEvent.change(wrapper.getByRole("textbox"), {
         target: { name: "name", value: "new value" }
@@ -264,17 +119,16 @@ describe("DinaForm component.", () => {
           "beforeunload",
           expect.any(Function)
         );
+        expect(mockRouterEvents.on).toHaveBeenCalledWith(
+          "routeChangeStart",
+          expect.any(Function)
+        );
       });
 
-      const addEventListenerCallCount = (
-        window.addEventListener as jest.Mock
-      ).mock.calls.length;
-
-      // Submit the form (this changes submitCount, making isDirty false)
+      // Submit the form (submitCount changes → isDirty becomes false)
       fireEvent.click(wrapper.getByRole("button"));
 
       await waitFor(() => {
-        // Should clean up listeners when form is no longer dirty
         expect(window.removeEventListener).toHaveBeenCalledWith(
           "beforeunload",
           expect.any(Function)
@@ -286,15 +140,88 @@ describe("DinaForm component.", () => {
       });
     });
 
-    it("Prevents default on beforeunload event", async () => {
+    it("Does not register listeners in readOnly mode", () => {
+      mountWithAppContext(
+        <DinaForm
+          initialValues={{ type: "test-type", name: "initial value" }}
+          readOnly={true}
+        >
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      expect(window.addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+    });
+
+    it("Does not register listeners when initialValues has no type", async () => {
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      // Let effects settle
+      await waitFor(() => {
+        expect(wrapper.getByRole("textbox")).toHaveDisplayValue("new value");
+      });
+
+      expect(window.addEventListener).not.toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.on).not.toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+    });
+
+    it("Cleans up listeners on unmount", async () => {
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        expect(window.addEventListener).toHaveBeenCalledWith(
+          "beforeunload",
+          expect.any(Function)
+        );
+      });
+
+      wrapper.unmount();
+
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        "beforeunload",
+        expect.any(Function)
+      );
+      expect(mockRouterEvents.off).toHaveBeenCalledWith(
+        "routeChangeStart",
+        expect.any(Function)
+      );
+    });
+
+    it("beforeunload handler calls preventDefault and sets returnValue", async () => {
       let beforeUnloadHandler: ((e: BeforeUnloadEvent) => void) | undefined;
 
-      // Capture the beforeunload handler
       (window.addEventListener as jest.Mock).mockImplementation(
         (event, handler) => {
-          if (event === "beforeunload") {
-            beforeUnloadHandler = handler;
-          }
+          if (event === "beforeunload") beforeUnloadHandler = handler;
         }
       );
 
@@ -304,7 +231,6 @@ describe("DinaForm component.", () => {
         </DinaForm>
       );
 
-      // Make the form dirty
       fireEvent.change(wrapper.getByRole("textbox"), {
         target: { name: "name", value: "new value" }
       });
@@ -313,7 +239,6 @@ describe("DinaForm component.", () => {
         expect(beforeUnloadHandler).toBeDefined();
       });
 
-      // Simulate beforeunload event
       const mockEvent = {
         preventDefault: jest.fn(),
         returnValue: ""
@@ -321,81 +246,40 @@ describe("DinaForm component.", () => {
 
       beforeUnloadHandler?.(mockEvent);
 
-      // Should prevent default and set returnValue
       expect(mockEvent.preventDefault).toHaveBeenCalled();
       expect(mockEvent.returnValue).toBe("");
     });
 
-    it("Shows confirmation dialog on SPA navigation and aborts if user cancels", async () => {
+    it("routeChangeStart handler confirms with user and aborts or allows navigation", async () => {
       let routeChangeHandler: (() => void) | undefined;
 
-      // Capture the routeChangeStart handler
       mockRouterEvents.on.mockImplementation((event, handler) => {
-        if (event === "routeChangeStart") {
-          routeChangeHandler = handler;
-        }
+        if (event === "routeChangeStart") routeChangeHandler = handler;
       });
 
-      // User cancels the navigation
+      const wrapper = mountWithAppContext(
+        <DinaForm initialValues={{ type: "test-type", name: "" }}>
+          <TextField name="name" />
+        </DinaForm>
+      );
+
+      fireEvent.change(wrapper.getByRole("textbox"), {
+        target: { name: "name", value: "new value" }
+      });
+
+      await waitFor(() => {
+        expect(routeChangeHandler).toBeDefined();
+      });
+
+      // User cancels → navigation aborted
       (window.confirm as jest.Mock).mockReturnValue(false);
-
-      const wrapper = mountWithAppContext(
-        <DinaForm initialValues={{ type: "test-type", name: "" }}>
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Make the form dirty
-      fireEvent.change(wrapper.getByRole("textbox"), {
-        target: { name: "name", value: "new value" }
-      });
-
-      await waitFor(() => {
-        expect(routeChangeHandler).toBeDefined();
-      });
-
-      // Simulate route change
       expect(() => routeChangeHandler?.()).toThrow("routeChange aborted.");
-
-      // Should show confirmation dialog
-      expect(window.confirm).toHaveBeenCalled();
-
-      // Should emit routeChangeError
       expect(mockRouterEvents.emit).toHaveBeenCalledWith("routeChangeError");
-    });
 
-    it("Allows SPA navigation if user confirms", async () => {
-      let routeChangeHandler: (() => void) | undefined;
-
-      // Capture the routeChangeStart handler
-      mockRouterEvents.on.mockImplementation((event, handler) => {
-        if (event === "routeChangeStart") {
-          routeChangeHandler = handler;
-        }
-      });
-
-      // User confirms the navigation
+      // User confirms → navigation allowed
+      jest.clearAllMocks();
       (window.confirm as jest.Mock).mockReturnValue(true);
-
-      const wrapper = mountWithAppContext(
-        <DinaForm initialValues={{ type: "test-type", name: "" }}>
-          <TextField name="name" />
-        </DinaForm>
-      );
-
-      // Make the form dirty
-      fireEvent.change(wrapper.getByRole("textbox"), {
-        target: { name: "name", value: "new value" }
-      });
-
-      await waitFor(() => {
-        expect(routeChangeHandler).toBeDefined();
-      });
-
-      // Simulate route change - should not throw
       expect(() => routeChangeHandler?.()).not.toThrow();
-
-      // Should show confirmation dialog
       expect(window.confirm).toHaveBeenCalled();
 
       // Should NOT emit routeChangeError


### PR DESCRIPTION
Test coverage added by Bob

Added listener for internal navigation when form is dirty.

Added guard for tests where router.events is undefined.
